### PR TITLE
Use Jenkins Artifactory server

### DIFF
--- a/prep.sh
+++ b/prep.sh
@@ -25,7 +25,7 @@ cp -rv test-classes/test-dependencies/*.hpi megawar/WEB-INF/plugins
 # TODO find a way to encode this in some POM so that it can be managed by Dependabot
 version=0.1.0
 pct=$HOME/.m2/repository/org/jenkins-ci/tests/plugins-compat-tester-cli/$version/plugins-compat-tester-cli-$version.jar
-[ -f $pct ] || $MVN dependency:get -Dartifact=org.jenkins-ci.tests:plugins-compat-tester-cli:$version:jar -Dtransitive=false
+[ -f $pct ] || $MVN dependency:get -Dartifact=org.jenkins-ci.tests:plugins-compat-tester-cli:$version:jar -DremoteRepositories=https://repo.jenkins-ci.org/public/ -Dtransitive=false
 
 cp $pct pct.jar
 cd megawar/WEB-INF/plugins

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -17,6 +17,18 @@
         <jenkins.version>2.176.2</jenkins.version>
         <java.level>8</java.level>
     </properties>
+    <repositories>
+        <repository>
+            <id>repo.jenkins-ci.org</id>
+            <url>https://repo.jenkins-ci.org/public/</url>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>repo.jenkins-ci.org</id>
+            <url>https://repo.jenkins-ci.org/public/</url>
+        </pluginRepository>
+    </pluginRepositories>
     <dependencyManagement>
         <dependencies>
             <dependency>


### PR DESCRIPTION
### Problem

While trying to run the local tests for this repository, I got the following errors:

> [ERROR]     Non-resolvable parent POM for io.jenkins.tools.bom:sample:${revision}${changelist}: Failure to find org.jenkins-ci.plugins:plugin:pom:3.47 in https://repo.maven.apache.org/maven2 was cached in the local repository, resolution will not be reattempted until the update interval of central has elapsed or updates are forced and 'parent.relativePath' points at no local POM @ line 4, column 13 -> [Help 2]

> [ERROR] Failed to execute goal org.apache.maven.plugins:maven-dependency-plugin:2.8:get (default-cli) on project standalone-pom: Couldn't download artifact: Could not find artifact org.jenkins-ci.tests:plugins-compat-tester-cli:jar:0.1.0 in central (https://repo.maven.apache.org/maven2)

### Evaluation

The build seems to assume that one has a ` ~/.m2/settings.xml` configured as described [here](https://wiki.jenkins.io/display/JENKINS/Plugin+tutorial) with `<activeByDefault>true</activeByDefault>` and the Jenkins Artifactory server set up. My ` ~/.m2/settings.xml` is more minimal and doesn't have this configuration, so the build can't find the artifacts it needs.

### Solution

Configure the build to explicitly fetch artifacts from the Jenkins Artifactory server.

### Testing Done

Running the PCT tests for this repository on my local system failed before this change and succeeded after this change.