### PR TITLE
Add token-macro to the managed set

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,11 +89,17 @@ Make sure it is used (perhaps transitively) in `sample-plugin/pom.xml`.
 Ideally also update the sample plugin’s tests to actually exercise it,
 as a sanity check.
 
+Avoid adding transitive dependencies to `sample-plugin/pom.xml`. It is supposed
+to look as much as possible like a real plugin, and a real plugin should only
+declare its direct dependencies and not its transitive dependencies.
+
 You can also add a `<classifier>tests</classifier>` entry,
 for a plugin which specifies `<no-test-jar>false</no-test-jar>`.
 You should introduce a POM property so that the version is not repeated.
 
 The build will enforce that all transitive plugin dependencies are also managed.
+If the build fails due to an unmanaged transitive plugin dependency, add it to
+`bom/pom.xml`.
 
 ## PCT
 

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -208,6 +208,11 @@
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>token-macro</artifactId>
+                <version>2.8</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>variant</artifactId>
                 <version>1.3</version>
             </dependency>

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -131,11 +131,6 @@
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>mailer</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>timestamper</artifactId>
             <scope>test</scope>
         </dependency>

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -131,7 +131,17 @@
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>mailer</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>timestamper</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>token-macro</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Adds `token-macro` to the managed set. I also noticed that `mailer` was present in `bom/pom.xml` but not `sample-plugin/pom.xml`, so I added it to `sample-plugin/pom.xml` for consistency.