### PR TITLE
Add jquery, junit, and junit-attachments to the managed set

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -148,7 +148,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>jquery</artifactId>
-                <version>1.12.4-0</version>
+                <version>1.12.4-1</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -147,6 +147,11 @@
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>jquery</artifactId>
+                <version>1.12.4-0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>jsch</artifactId>
                 <version>0.1.55.1</version>
             </dependency>
@@ -154,6 +159,11 @@
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>junit</artifactId>
                 <version>1.28</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>junit-attachments</artifactId>
+                <version>1.6</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -131,6 +131,21 @@
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>jquery</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>junit-attachments</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>timestamper</artifactId>
             <scope>test</scope>
         </dependency>

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -131,11 +131,6 @@
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>jquery</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
Depends on the release of jenkinsci/jquery-plugin#6.