### PR TITLE
Bump git-client from 2.8.0 to 2.8.1

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -138,7 +138,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>git-client</artifactId>
-                <version>2.8.0</version>
+                <version>2.8.1</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>

--- a/pct.sh
+++ b/pct.sh
@@ -47,6 +47,8 @@ rm -fv pct-work/plain-credentials/target/surefire-reports/TEST-InjectedTest.xml
 rm -fv pct-work/ansicolor/target/surefire-reports/TEST-hudson.plugins.ansicolor.AnsiColorBuildWrapperTest.xml
 # TODO https://github.com/jenkinsci/matrix-project-plugin/pull/59
 rm -fv pct-work/matrix-project/target/surefire-reports/TEST-InjectedTest.xml
+# TODO pending https://github.com/jenkinsci/git-client-plugin/pull/450
+rm -fv pct-work/git-client/target/surefire-reports/TEST-org.jenkinsci.plugins.gitclient.GitClientTest.xml
 # TODO pending https://github.com/jenkinsci/git-plugin/pull/738
 rm -fv pct-work/git/target/surefire-reports/TEST-hudson.plugins.git.CredentialsUserRemoteConfigTest.xml
 # TODO https://github.com/jenkinsci/jenkins/pull/4099 pending backport to 2.176.3


### PR DESCRIPTION
Implements the changes requested in jenkinsci/bom#71 which could not be implemented by the author of that PR because the author is a robot.