### PR TITLE
Include hamcrest-core in BOM and sample plugin

### DIFF
--- a/bom-latest/pom.xml
+++ b/bom-latest/pom.xml
@@ -33,6 +33,11 @@
                 <classifier>tests</classifier>
             </dependency>
             <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest-core</artifactId>
+                <version>2.1</version>
+            </dependency>
+            <dependency>
                 <groupId>org.jenkins-ci.plugins.workflow</groupId>
                 <artifactId>workflow-api</artifactId>
                 <version>${workflow-api-plugin.version}</version>

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -162,6 +162,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>pipeline-build-step</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
## Include hamcrest-core in BOM and sample plugin

The hamcrest-core dependency is used directly in the sample-plugin ConfigurationAsCodeTest.  Many plugins also prefer to use hamcrest assertions for better error messages in failures.

Without this inclusion, the dependabot attempt to update the git plugin to use plugin pom 3.51 fails with the message:

```
  Failed while enforcing RequireUpperBoundDeps. The error(s) are [
  Require upper bound dependencies error for org.hamcrest:hamcrest-core:1.3 paths to dependency are:
  +-org.jenkins-ci.plugins:git:3.13.0-SNAPSHOT
    +-org.xmlunit:xmlunit-matchers:2.6.3
      +-org.hamcrest:hamcrest-core:1.3
  and
  +-org.jenkins-ci.plugins:git:3.13.0-SNAPSHOT
    +-org.jenkins-ci.main:jenkins-test-harness:2.56
      +-org.hamcrest:hamcrest-core:2.1
  and
  +-org.jenkins-ci.plugins:git:3.13.0-SNAPSHOT
    +-junit:junit:4.12
      +-org.hamcrest:hamcrest-core:1.3
  and
  +-org.jenkins-ci.plugins:git:3.13.0-SNAPSHOT
    +-org.jenkins-ci.main:jenkins-test-harness:2.56
      +-org.hamcrest:hamcrest-library:2.1
        +-org.hamcrest:hamcrest-core:2.1
  ]
```

Short term workaround for the git plugin is to declare the version of its hamcrest core dependency.  Same workaround will probably work for others.