### PR TITLE
Bump configuration-as-code from 1.34 to 1.35

### DIFF
--- a/bom-latest/pom.xml
+++ b/bom-latest/pom.xml
@@ -9,7 +9,7 @@
     <artifactId>bom-2.176.x</artifactId>
     <packaging>pom</packaging>
     <properties>
-        <configuration-as-code-plugin.version>1.34</configuration-as-code-plugin.version>
+        <configuration-as-code-plugin.version>1.35</configuration-as-code-plugin.version>
         <git-plugin.version>4.0.0</git-plugin.version>
         <scm-api-plugin.version>2.6.3</scm-api-plugin.version>
         <structs-plugin.version>1.20</structs-plugin.version>
@@ -27,10 +27,9 @@
                 <version>${configuration-as-code-plugin.version}</version>
             </dependency>
             <dependency>
-                <groupId>io.jenkins</groupId>
-                <artifactId>configuration-as-code</artifactId>
+                <groupId>io.jenkins.configuration-as-code</groupId>
+                <artifactId>test-harness</artifactId>
                 <version>${configuration-as-code-plugin.version}</version>
-                <classifier>tests</classifier>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -48,9 +48,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.jenkins</groupId>
-            <artifactId>configuration-as-code</artifactId>
-            <classifier>tests</classifier>
+            <groupId>io.jenkins.configuration-as-code</groupId>
+            <artifactId>test-harness</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
This will be breaking for anyone using the previous tests package