### PR TITLE
Revert "Bump configuration-as-code from 1.34 to 1.35 (test harness renamed)"

### DIFF
--- a/bom-latest/pom.xml
+++ b/bom-latest/pom.xml
@@ -9,7 +9,7 @@
     <artifactId>bom-2.176.x</artifactId>
     <packaging>pom</packaging>
     <properties>
-        <configuration-as-code-plugin.version>1.35</configuration-as-code-plugin.version>
+        <configuration-as-code-plugin.version>1.34</configuration-as-code-plugin.version>
         <git-plugin.version>4.0.0</git-plugin.version>
         <scm-api-plugin.version>2.6.3</scm-api-plugin.version>
         <structs-plugin.version>1.20</structs-plugin.version>
@@ -27,9 +27,10 @@
                 <version>${configuration-as-code-plugin.version}</version>
             </dependency>
             <dependency>
-                <groupId>io.jenkins.configuration-as-code</groupId>
-                <artifactId>test-harness</artifactId>
+                <groupId>io.jenkins</groupId>
+                <artifactId>configuration-as-code</artifactId>
                 <version>${configuration-as-code-plugin.version}</version>
+                <classifier>tests</classifier>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -48,8 +48,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.jenkins.configuration-as-code</groupId>
-            <artifactId>test-harness</artifactId>
+            <groupId>io.jenkins</groupId>
+            <artifactId>configuration-as-code</artifactId>
+            <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Reverts jenkinsci/bom#161. While this did not produce any test _failures_, it also caused the majority of plugins to be skipped. Between [this](https://ci.jenkins.io/job/Tools/job/bom/job/master/126/testReport/) and [this](https://ci.jenkins.io/job/Tools/job/bom/job/master/127/testReport/) we see

> 5,953 tests (-13656)

Easily seen locally, e.g.

```bash
PLUGINS=mailer TEST=InjectedTest bash local-test.sh
```

⇒

```
Failed to execute goal on project mailer: Could not resolve dependencies for project org.jenkins-ci.plugins:mailer:hpi:1.29: Could not find artifact io.jenkins:configuration-as-code:jar:tests:1.35 in repo.jenkins-ci.org
```

Seems that https://github.com/jenkinsci/configuration-as-code-plugin/issues/917 is incompatible with `plugin-compat-tester` usage, as https://github.com/jenkinsci/configuration-as-code-plugin/pull/1215#issuecomment-562880039 warned. You should choose from

* revert the rename
* restore the original artifact (I suppose just wrapping the new artifact somehow) for compatibility
* introduce a custom extension into PCT to handle the rename