### PR TITLE
Add workflow-job tests jar to bom

### DIFF
--- a/bom-latest/pom.xml
+++ b/bom-latest/pom.xml
@@ -15,6 +15,7 @@
         <structs-plugin.version>1.20</structs-plugin.version>
         <workflow-api-plugin.version>2.40</workflow-api-plugin.version>
         <workflow-cps-plugin.version>2.81</workflow-cps-plugin.version>
+        <workflow-job-plugin.version>2.39</workflow-job-plugin.version>
         <workflow-step-api-plugin.version>2.22</workflow-step-api-plugin.version>
         <workflow-support-plugin.version>3.5</workflow-support-plugin.version>
     </properties>
@@ -76,7 +77,13 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins.workflow</groupId>
                 <artifactId>workflow-job</artifactId>
-                <version>2.39</version>
+                <version>${workflow-job-plugin.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins.workflow</groupId>
+                <artifactId>workflow-job</artifactId>
+                <classifier>tests</classifier>
+                <version>${workflow-job-plugin.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -105,6 +105,12 @@
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-job</artifactId>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
             <classifier>tests</classifier>
             <scope>test</scope>


### PR DESCRIPTION
`workflow-job` has a tests jar that is used by at least `workflow-multibranch`, so it would be nice for that to be in the BOM.

(I think there are currently only two source files in the tests jar that other plugins might use: [`MockTrigger`](https://github.com/jenkinsci/workflow-job-plugin/blob/f369d5bdfc39ac902f544a125e971414cb51a463/src/test/java/org/jenkinsci/plugins/workflow/job/properties/MockTrigger.java) and [`QueryingMockTrigger`](https://github.com/jenkinsci/workflow-job-plugin/blob/f369d5bdfc39ac902f544a125e971414cb51a463/src/test/java/org/jenkinsci/plugins/workflow/job/properties/QueryingMockTrigger.java). `workflow-multibranch` only uses `MockTrigger`, and I'm not aware of any other plugins that depend on the `workflow-job` tests jar, so I could also see an argument for just copying the source code of `MockTrigger` to `workflow-multibranch` and removing the `tests` jar from `workflow-job` completely, but I figured I'd file this first and see what people think)

