### PR TITLE
Filter dependabot to only latest line and sample plugin

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,7 +1,0 @@
-version: 1
-update_configs:
-  - package_manager: java:maven
-    directory: /
-    update_schedule: daily
-    default_reviewers:
-      - jglick

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "maven" # See documentation for possible values
+    directory: "/sample-plugin" # Location of package manifests
+    reviewers:
+      - "jglick"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "maven" # See documentation for possible values
+    directory: "/bom-latest" # Location of package manifests
+    reviewers:
+      - "jglick"
+    schedule:
+      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,18 +1,15 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
 # https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
 version: 2
 updates:
-  - package-ecosystem: "maven" # See documentation for possible values
-    directory: "/sample-plugin" # Location of package manifests
+  - package-ecosystem: "maven"
+    directory: "/sample-plugin"
     reviewers:
       - "jglick"
     schedule:
       interval: "daily"
-  - package-ecosystem: "maven" # See documentation for possible values
-    directory: "/bom-latest" # Location of package manifests
+  - package-ecosystem: "maven"
+    directory: "/bom-latest"
     reviewers:
       - "jglick"
     schedule:


### PR DESCRIPTION
https://github.com/jenkinsci/bom/pull/265#issuecomment-654870763

Doesn't seem possible to include the root pom and not all submodules
So the root pom will be excluded with this, there's only one version in there which is the parent pom

Thoughts?

