### PR TITLE
Detect overall PCT failures

### DIFF
--- a/failFast
+++ b/failFast
@@ -1,1 +1,1 @@
-true
+false

--- a/failFast
+++ b/failFast
@@ -1,1 +1,1 @@
-false
+true

--- a/pct.sh
+++ b/pct.sh
@@ -39,9 +39,9 @@ then
     echo PCT marked failed, checking to see if that is due to a failure to run tests at all
     for t in pct-work/*/{,*/}target
     do
-        if [ -f $t/test-classes/the.hpl -a \! -d $t/surefire-reports ]
+        if [ -f $t/test-classes/InjectedTest.class -a \! -f $t/surefire-reports/TEST-InjectedTest.xml ]
         then
-            mkdir $t/surefire-reports
+            mkdir -p $t/surefire-reports
             cat > $t/surefire-reports/TEST-pct.xml <<'EOF'
 <testsuite name="pct">
   <testcase classname="pct" name="overall">

--- a/pct.sh
+++ b/pct.sh
@@ -34,6 +34,25 @@ then
     echo PCT failed
     cat pct-report.xml
     exit 1
+elif grep -q -F -e '<status>TEST_FAILURES</status>' pct-report.xml
+then
+    echo PCT test failures, making sure at least one is reported
+    candidates=
+    for t in pct-work/*/target
+    do
+        if [ \! -d $t/surefire-reports ]
+        then
+            candidates="$candidates $t"
+        fi
+    done
+    mkdir -p pct-work/target/surefire-reports
+    cat > pct-work/target/surefire-reports/TEST-pct.xml <<EOF
+<testsuite name="pct">
+  <testcase classname="pct" name="overall">
+    <error message="some sort of PCT failure; take a look at$candidates"/>
+  </testcase>
+</testsuite>
+EOF
 fi
 
 # TODO rather than removing all these, have a text file of known failures and just convert them to “skipped”

--- a/pct.sh
+++ b/pct.sh
@@ -36,23 +36,21 @@ then
     exit 1
 elif grep -q -F -e '<status>TEST_FAILURES</status>' pct-report.xml
 then
-    echo PCT test failures, making sure at least one is reported
-    candidates=
-    for t in pct-work/*/target
+    echo PCT marked failed, checking to see if that is due to a failure to run tests at all
+    for t in pct-work/*/{,*/}target
     do
-        if [ \! -d $t/surefire-reports ]
+        if [ -f $t/test-classes/the.hpl -a \! -d $t/surefire-reports ]
         then
-            candidates="$candidates $t"
-        fi
-    done
-    mkdir -p pct-work/target/surefire-reports
-    cat > pct-work/target/surefire-reports/TEST-pct.xml <<EOF
+            mkdir $t/surefire-reports
+            cat > $t/surefire-reports/TEST-pct.xml <<'EOF'
 <testsuite name="pct">
   <testcase classname="pct" name="overall">
-    <error message="some sort of PCT failure; take a look at$candidates"/>
+    <error message="some sort of PCT problem; look at logs"/>
   </testcase>
 </testsuite>
 EOF
+        fi
+    done
 fi
 
 # TODO rather than removing all these, have a text file of known failures and just convert them to “skipped”


### PR DESCRIPTION
When PCT _compilation_ succeeded but `surefire:test` or one of its preparatory goals crashed (i.e., not just some test failures), we were silently skipping that plugin, and it seems there were several of these. Noticed in #179. At root this seems like a flaw in PCT which I am just working around here.