### PR TITLE
Update workflow-cps-global-lib to 2.17 and remove commons-lang3 exclusion

### DIFF
--- a/bom-latest/pom.xml
+++ b/bom-latest/pom.xml
@@ -67,7 +67,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins.workflow</groupId>
                 <artifactId>workflow-cps-global-lib</artifactId>
-                <version>2.16</version>
+                <version>2.17</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -81,17 +81,6 @@
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps-global-lib</artifactId>
             <scope>test</scope>
-            <exclusions>
-                <!--
-                TODO clashes with jenkins-test-harness » jenkins-test-harness-htmlunit; one or the other should be shaded
-                 also any of https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/95, https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/94,
-                 https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/93 would solve it.
-                -->
-                <exclusion>
-                    <groupId>org.apache.commons</groupId>
-                    <artifactId>commons-lang3</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>


### PR DESCRIPTION
I just released workflow-cps-global-lib 2.17. Only filing a manual PR to remove an exclusion in `sample-plugin` at the same time to show that the enforcer issue is fixed in the new release.