### PR TITLE
Add aws-java-sdk

### DIFF
--- a/bom-latest/pom.xml
+++ b/bom-latest/pom.xml
@@ -124,6 +124,11 @@
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>aws-java-sdk</artifactId>
+                <version>1.11.821</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>branch-api</artifactId>
                 <version>2.5.8</version>
             </dependency>

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -112,6 +112,11 @@
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>aws-java-sdk</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>branch-api</artifactId>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
Add the Jenkins packaged version of aws-java-sdk plugin, since it has opinions about Jackson, and there are quite a few AWS integration plugins that depend on it.

**Requires https://github.com/jenkinsci/bom/pull/282 to be merged first.**