### PR TITLE
Changing CasC in 2.204 to use a prop

### DIFF
--- a/bom-2.204.x/pom.xml
+++ b/bom-2.204.x/pom.xml
@@ -8,6 +8,9 @@
     </parent>
     <artifactId>bom-2.204.x</artifactId>
     <packaging>pom</packaging>
+    <properties>
+        <configuration-as-code-plugin.version>1.36</configuration-as-code-plugin.version>
+    </properties>
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -20,12 +23,12 @@
             <dependency>
                 <groupId>io.jenkins</groupId>
                 <artifactId>configuration-as-code</artifactId>
-                <version>1.36</version>
+                <version>${configuration-as-code-plugin.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.jenkins.configuration-as-code</groupId>
                 <artifactId>test-harness</artifactId>
-                <version>1.36</version>
+                <version>${configuration-as-code-plugin.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
When running PCT sometimes there is a mismatch between casc and casc:test-harness.
