### PR TITLE
Force rerunFailingTestsCount=4 in PCT

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,7 +58,7 @@ lines.each {line ->
                     unstash 'pct.sh'
                     unstash 'pct'
                     unstash "megawar-$line"
-                    withEnv(["PLUGINS=$plugin", "LINE=$line"]) {
+                    withEnv(["PLUGINS=$plugin", "LINE=$line", 'EXTRA_MAVEN_PROPERTIES=surefire.rerunFailingTestsCount=4']) {
                         sh 'mv megawar-$LINE.war megawar.war && bash pct.sh'
                     }
                 }


### PR DESCRIPTION
As of https://github.com/jenkinsci/plugin-pom/pull/269 this is no longer on by default for plugin tests. Looking at failures in e.g. #308, these are all in plugins using 4.x parents and are probably flakes. It would be great to fix the flakes at some point but that is not really the job of this project.
