### PR TITLE
Remove jackson2-api

### DIFF
--- a/bom-latest/pom.xml
+++ b/bom-latest/pom.xml
@@ -198,11 +198,6 @@
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
-                <artifactId>jackson2-api</artifactId>
-                <version>2.11.0</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>jdk-tool</artifactId>
                 <version>1.4</version>
             </dependency>

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -56,12 +56,6 @@
             <groupId>io.jenkins.configuration-as-code</groupId>
             <artifactId>test-harness</artifactId>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -140,11 +134,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>htmlpublisher</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>jackson2-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Test to see if it's possible to remove jackson2-api.

Longer version: during development of the 'add pipeline-model-definition' PR it certainly seemed like that plugin needed jackson2-api to be added to the BOM as well. However it is possible that later changes made that unnecessary (e.g. removal of Docker parts of pipeline-model-definition) and we didn't notice at the time.