### PR TITLE
Drop usage of jth.jenkins-war.path

### DIFF
--- a/pct.sh
+++ b/pct.sh
@@ -14,7 +14,7 @@ else
 fi
 
 # TODO use -ntp if there is a PCT option to pass Maven options
-MAVEN_PROPERTIES=org.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn:jth.jenkins-war.path=$(pwd)/megawar.war
+MAVEN_PROPERTIES=org.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 if [ -v EXTRA_MAVEN_PROPERTIES ]
 then
     MAVEN_PROPERTIES="$MAVEN_PROPERTIES:$EXTRA_MAVEN_PROPERTIES"


### PR DESCRIPTION
Fixes the errors in #338, I think. Probably also fixes the error in #308 by avoiding the need for https://github.com/jenkinsci/branch-api-plugin/pull/222, and probably the error in #301 avoiding the need for https://github.com/jenkinsci/plugin-compat-tester/pull/256.

Generally makes life easier, at the cost of weakening the test runs: we are no longer loading all the plugins in the BOM when running functional tests, only the ones mentioned in the test classpath for this particular plugin. Normally those other plugins would be irrelevant, but if they contribute `@Extension`s which break functionality of more basic plugins, we will no longer catch that.