### PR TITLE
Ignore failures in InjectedTest

### DIFF
--- a/pct.sh
+++ b/pct.sh
@@ -58,10 +58,10 @@ fi
 
 # TODO various problems with PCT itself (e.g. https://github.com/jenkinsci/bom/pull/338#issuecomment-715256727)
 # and anyway the tests in PluginAutomaticTestBuilder are generally uninteresting in a PCT context
-rm -fv pct-work/*/target/surefire-reports/TEST-InjectedTest.xml
+rm -fv pct-work/*/{,*/}target/surefire-reports/TEST-InjectedTest.xml
 
 # TODO https://github.com/jenkinsci/jenkins/pull/4099 in 2.176.x
-# TODO strange NPE from net.sourceforge.htmlunit.corejs.javascript.ScriptRuntime.hasTopCall in 2.263.x; recheck after https://github.com/jenkinsci/command-launcher-plugin/pull/14
+# TODO unrelated failure in 2.263.x until 1.5 update
 rm -fv pct-work/command-launcher/target/surefire-reports/TEST-hudson.slaves.CommandLauncher2Test.xml
 
 # TODO pending https://github.com/jenkinsci/jdk-tool-plugin/pull/12

--- a/pct.sh
+++ b/pct.sh
@@ -55,21 +55,15 @@ fi
 
 # TODO rather than removing all these, have a text file of known failures and just convert them to “skipped”
 # or add surefire.excludesFile to MAVEN_PROPERTIES so we do not waste time even running these
-# TODO this should probably now read `= 2.176.x`, though CommandLauncher2Test now fails with a new error
-if [ "$LINE" != 2.190.x ]
+
+# TODO various problems with PCT itself (e.g. https://github.com/jenkinsci/bom/pull/338#issuecomment-715256727)
+# and anyway the tests in PluginAutomaticTestBuilder are generally uninteresting in a PCT context
+rm -fv pct-work/*/target/surefire-reports/TEST-InjectedTest.xml
+
+if [ "$LINE" = 2.176.x ]
 then
-    # TODO https://github.com/jenkinsci/jenkins/pull/4120 problems with workflow-cps → jquery-detached:
-    rm -fv pct-work/structs-plugin/plugin/target/surefire-reports/TEST-InjectedTest.xml
-    rm -fv pct-work/apache-httpcomponents-client-4-api/target/surefire-reports/TEST-InjectedTest.xml
-    rm -fv pct-work/ssh-slaves/target/surefire-reports/TEST-InjectedTest.xml
-    rm -fv pct-work/plain-credentials/target/surefire-reports/TEST-InjectedTest.xml
     # TODO https://github.com/jenkinsci/jenkins/pull/4099
     rm -fv pct-work/command-launcher/target/surefire-reports/TEST-hudson.slaves.CommandLauncher2Test.xml
-
-    # TODO wrong detached plugin is being picked up
-    # JavaScript GUI Lib: jQuery bundles (jQuery and jQuery UI) plugin v1.2 is older than required. To fix, install v1.2.1 or later.
-    # we have 1.12.4-1 managed currently
-    rm -fv pct-work/trilead-api/target/surefire-reports/TEST-InjectedTest.xml
 fi
 
 # TODO pending https://github.com/jenkinsci/jdk-tool-plugin/pull/12
@@ -80,12 +74,6 @@ rm -rf pct-work/workflow-cps-global-lib/target/surefire-reports/TEST-org.jenkins
 
 # TODO Merged, but needs a release: https://github.com/jenkinsci/git-plugin/pull/857
 rm -fv pct-work/git/target/surefire-reports/TEST-hudson.plugins.git.GitStatusCrumbExclusionTest.xml
-
-# TODO wrong detached plugin is being picked up
-# Structs Plugin version 1.7 is older than required. To fix, install version 1.20 or later.
-# we have 1.20 managed currently
-rm -fv pct-work/cloudbees-folder/target/surefire-reports/TEST-InjectedTest.xml
-
 
 # TODO flakey tests related to workflow-job saying it's finished but it still hasn't finished updating the log
 # ref: https://github.com/jenkinsci/workflow-job-plugin/pull/131/files#r291657569
@@ -105,8 +93,6 @@ rm -fv pct-work/workflow-job/target/surefire-reports/TEST-org.jenkinsci.plugins.
 
 # TODO pending https://github.com/jenkinsci/ansicolor-plugin/pull/164
 rm -fv pct-work/ansicolor/target/surefire-reports/TEST-hudson.plugins.ansicolor.AnsiColorBuildWrapperTest.xml
-# TODO https://github.com/jenkinsci/matrix-project-plugin/pull/59
-rm -fv pct-work/matrix-project/target/surefire-reports/TEST-InjectedTest.xml
 # TODO https://github.com/jenkinsci/durable-task-plugin/pull/101
 rm -fv pct-work/durable-task/target/surefire-reports/TEST-org.jenkinsci.plugins.durabletask.BourneShellScriptTest.xml
 # TODO https://github.com/jenkinsci/git-client-plugin/pull/440

--- a/pct.sh
+++ b/pct.sh
@@ -60,11 +60,9 @@ fi
 # and anyway the tests in PluginAutomaticTestBuilder are generally uninteresting in a PCT context
 rm -fv pct-work/*/target/surefire-reports/TEST-InjectedTest.xml
 
-if [ "$LINE" = 2.176.x ]
-then
-    # TODO https://github.com/jenkinsci/jenkins/pull/4099
-    rm -fv pct-work/command-launcher/target/surefire-reports/TEST-hudson.slaves.CommandLauncher2Test.xml
-fi
+# TODO https://github.com/jenkinsci/jenkins/pull/4099 in 2.176.x
+# TODO strange NPE from net.sourceforge.htmlunit.corejs.javascript.ScriptRuntime.hasTopCall in 2.263.x; recheck after https://github.com/jenkinsci/command-launcher-plugin/pull/14
+rm -fv pct-work/command-launcher/target/surefire-reports/TEST-hudson.slaves.CommandLauncher2Test.xml
 
 # TODO pending https://github.com/jenkinsci/jdk-tool-plugin/pull/12
 rm -rf pct-work/jdk-tool/target/surefire-reports/TEST-hudson.tools.JDKInstallerTest.xml


### PR DESCRIPTION
Causes problems in #338 and elsewhere, yet is rarely useful in diagnosing cross-compatibility issues in PCT. (The test _is_ useful in the plugin’s own CI. And it serves a useful purpose in the `sample-plugin`, which is not affected by this.)

A better alternative to PCT, like https://github.com/jenkinsci/maven-hpi-plugin/pull/66, might obviate the need for this.