### PR TITLE
Remove exclusions of RateLimitBranchPropertyTest & OrganizationFolderTest

### DIFF
--- a/pct.sh
+++ b/pct.sh
@@ -104,17 +104,11 @@ rm -fv pct-work/workflow-basic-steps/target/surefire-reports/TEST-org.jenkinsci.
 # TODO cryptic PCT-only errors: https://github.com/jenkinsci/bom/pull/251#issuecomment-645012427
 rm -fv pct-work/matrix-project/target/surefire-reports/TEST-hudson.matrix.AxisTest.xml
 
-# TODO https://github.com/jenkinsci/branch-api-plugin/pull/211
-rm -fv pct-work/branch-api/target/surefire-reports/TEST-jenkins.branch.RateLimitBranchPropertyTest.xml
-
 # TODO remove after timestamper upgrades to next bom https://github.com/jenkinsci/bom/pull/294#issuecomment-710770375
 rm -fv pct-work/timestamper/target/surefire-reports/TEST-hudson.plugins.timestamper.ConfigurationAsCodeTest.xml
 
 # TODO https://github.com/jenkinsci/workflow-basic-steps-plugin/pull/134
 rm -fv pct-work/workflow-basic-steps/target/surefire-reports/TEST-org.jenkinsci.plugins.workflow.steps.CoreWrapperStepTest.xml
-
-# TODO https://github.com/jenkinsci/branch-api-plugin/pull/222
-rm -fv pct-work/branch-api/target/surefire-reports/TEST-jenkins.branch.OrganizationFolderTest.xml
 
 # TODO https://github.com/jenkinsci/workflow-multibranch-plugin/pull/102
 rm -fv pct-work/workflow-multibranch/target/surefire-reports/TEST-org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProjectTest.xml


### PR DESCRIPTION
After #349 we should be be able to remove exclusions pending https://github.com/jenkinsci/branch-api-plugin/pull/211 & https://github.com/jenkinsci/branch-api-plugin/pull/222.
