### PR TITLE
Specify url in POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
     <artifactId>parent</artifactId>
     <version>${revision}${changelist}</version>
     <packaging>pom</packaging>
+    <url>https://github.com/jenkinsci/bom</url>
     <properties>
         <revision>26</revision>
         <changelist>-SNAPSHOT</changelist>


### PR DESCRIPTION
Acc. to https://support.github.com/ticket/personal/0/1032182 (only visible to me) this was preventing Dependabot from properly displaying release notes for PRs updating the BOM. https://github.com/jenkinsci/artifact-manager-s3-plugin/pull/186 for example.