### PR TITLE
Set forkCount to speed up builds

### DIFF
--- a/bom-latest/pom.xml
+++ b/bom-latest/pom.xml
@@ -12,7 +12,7 @@
         <checks-api.version>1.5.0</checks-api.version>
         <configuration-as-code-plugin.version>1.47</configuration-as-code-plugin.version>
         <git-plugin.version>4.6.0</git-plugin.version>
-        <pipeline-model-definition-plugin.version>1.8.3</pipeline-model-definition-plugin.version>
+        <pipeline-model-definition-plugin.version>1.8.4</pipeline-model-definition-plugin.version>
         <scm-api-plugin.version>2.6.4</scm-api-plugin.version>
         <structs-plugin.version>1.22</structs-plugin.version>
         <workflow-api-plugin.version>2.41</workflow-api-plugin.version>

--- a/bom-latest/pom.xml
+++ b/bom-latest/pom.xml
@@ -12,7 +12,7 @@
         <checks-api.version>1.5.0</checks-api.version>
         <configuration-as-code-plugin.version>1.47</configuration-as-code-plugin.version>
         <git-plugin.version>4.6.0</git-plugin.version>
-        <pipeline-model-definition-plugin.version>1.8.4</pipeline-model-definition-plugin.version>
+        <pipeline-model-definition-plugin.version>1.8.3</pipeline-model-definition-plugin.version>
         <scm-api-plugin.version>2.6.4</scm-api-plugin.version>
         <structs-plugin.version>1.22</structs-plugin.version>
         <workflow-api-plugin.version>2.41</workflow-api-plugin.version>

--- a/pct.sh
+++ b/pct.sh
@@ -13,8 +13,7 @@ else
     PCT_S_ARG=
 fi
 
-# TODO use -ntp if there is a PCT option to pass Maven options
-MAVEN_PROPERTIES=org.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn:jth.jenkins-war.path=$(pwd)/megawar.war:forkCount=.5C:reuseForks=false
+MAVEN_PROPERTIES=jth.jenkins-war.path=$(pwd)/megawar.war:forkCount=.5C:reuseForks=false
 if [ -v EXTRA_MAVEN_PROPERTIES ]
 then
     MAVEN_PROPERTIES="$MAVEN_PROPERTIES:$EXTRA_MAVEN_PROPERTIES"

--- a/pct.sh
+++ b/pct.sh
@@ -13,7 +13,7 @@ else
     PCT_S_ARG=
 fi
 
-MAVEN_PROPERTIES=jth.jenkins-war.path=$(pwd)/megawar.war:forkCount=.5C
+MAVEN_PROPERTIES=jth.jenkins-war.path=$(pwd)/megawar.war:forkCount=1C
 if [ -v EXTRA_MAVEN_PROPERTIES ]
 then
     MAVEN_PROPERTIES="$MAVEN_PROPERTIES:$EXTRA_MAVEN_PROPERTIES"

--- a/pct.sh
+++ b/pct.sh
@@ -14,7 +14,7 @@ else
 fi
 
 # TODO use -ntp if there is a PCT option to pass Maven options
-MAVEN_PROPERTIES=org.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn:jth.jenkins-war.path=$(pwd)/megawar.war:forkCount=.5C
+MAVEN_PROPERTIES=org.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn:jth.jenkins-war.path=$(pwd)/megawar.war:forkCount=.5C:reuseForks=false
 if [ -v EXTRA_MAVEN_PROPERTIES ]
 then
     MAVEN_PROPERTIES="$MAVEN_PROPERTIES:$EXTRA_MAVEN_PROPERTIES"

--- a/pct.sh
+++ b/pct.sh
@@ -113,4 +113,7 @@ rm -fv pct-work/workflow-basic-steps/target/surefire-reports/TEST-org.jenkinsci.
 # TODO until dropping 2.235.x so can rely on https://github.com/jenkinsci/workflow-basic-steps-plugin/pull/120
 rm -fv pct-work/workflow-basic-steps/target/surefire-reports/TEST-org.jenkinsci.plugins.workflow.steps.TimeoutStepTest.xml
 
+# TODO https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/417
+rm -fv pct-work/pipeline-model-definition/pipeline-model-definition/target/surefire-reports/TEST-org.jenkinsci.plugins.pipeline.modeldefinition.parser.ASTParserUtilsTest.xml
+
 # produces: **/target/surefire-reports/TEST-*.xml

--- a/pct.sh
+++ b/pct.sh
@@ -14,7 +14,7 @@ else
 fi
 
 # TODO use -ntp if there is a PCT option to pass Maven options
-MAVEN_PROPERTIES=org.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn:jth.jenkins-war.path=$(pwd)/megawar.war
+MAVEN_PROPERTIES=org.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn:jth.jenkins-war.path=$(pwd)/megawar.war:forkCount=.5C
 if [ -v EXTRA_MAVEN_PROPERTIES ]
 then
     MAVEN_PROPERTIES="$MAVEN_PROPERTIES:$EXTRA_MAVEN_PROPERTIES"

--- a/pct.sh
+++ b/pct.sh
@@ -13,7 +13,7 @@ else
     PCT_S_ARG=
 fi
 
-MAVEN_PROPERTIES=jth.jenkins-war.path=$(pwd)/megawar.war:forkCount=1C
+MAVEN_PROPERTIES=jth.jenkins-war.path=$(pwd)/megawar.war:forkCount=.75C
 if [ -v EXTRA_MAVEN_PROPERTIES ]
 then
     MAVEN_PROPERTIES="$MAVEN_PROPERTIES:$EXTRA_MAVEN_PROPERTIES"

--- a/pct.sh
+++ b/pct.sh
@@ -13,7 +13,7 @@ else
     PCT_S_ARG=
 fi
 
-MAVEN_PROPERTIES=jth.jenkins-war.path=$(pwd)/megawar.war:forkCount=.5C:reuseForks=false
+MAVEN_PROPERTIES=jth.jenkins-war.path=$(pwd)/megawar.war:forkCount=.5C
 if [ -v EXTRA_MAVEN_PROPERTIES ]
 then
     MAVEN_PROPERTIES="$MAVEN_PROPERTIES:$EXTRA_MAVEN_PROPERTIES"

--- a/prep.sh
+++ b/prep.sh
@@ -41,9 +41,8 @@ do
 done
 
 # TODO find a way to encode this in some POM so that it can be managed by Dependabot
-SNAPSHOT_VERSION=0.5.1-SNAPSHOT # TODO incrementals broken till https://github.com/jenkinsci/plugin-compat-tester/pull/260 is merged
-version=0.5.1-20201017.070523-3 # TODO https://github.com/jenkinsci/plugin-compat-tester/pull/261
-pct=$HOME/.m2/repository/org/jenkins-ci/tests/plugins-compat-tester-cli/${SNAPSHOT_VERSION}/plugins-compat-tester-cli-${version}.jar
+version=0.5.1-rc1068.959674bdeffd # TODO https://github.com/jenkinsci/plugin-compat-tester/pull/275
+pct=$HOME/.m2/repository/org/jenkins-ci/tests/plugins-compat-tester-cli/${version}/plugins-compat-tester-cli-${version}.jar
 [ -f $pct ] || $MVN dependency:get -Dartifact=org.jenkins-ci.tests:plugins-compat-tester-cli:${version}:jar -DremoteRepositories=https://repo.jenkins-ci.org/public/,https://repo.jenkins-ci.org/incrementals/ -Dtransitive=false
 cp $pct target/pct.jar
 


### PR DESCRIPTION
https://github.com/jenkinsci/plugin-compat-tester/pull/273 speeds up builds of bottleneck plugins like `pipeline-model-definition` and makes the overall build completely significantly faster: ~61m → ~42m.
