### PR TITLE
Add Throttle Concurrent Builds to the managed set

### DIFF
--- a/bom-latest/pom.xml
+++ b/bom-latest/pom.xml
@@ -341,6 +341,11 @@
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>throttle-concurrents</artifactId>
+                <version>2.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>timestamper</artifactId>
                 <version>1.12</version>
             </dependency>

--- a/pct.sh
+++ b/pct.sh
@@ -94,4 +94,7 @@ rm -fv pct-work/pipeline-model-definition/pipeline-model-definition/target/suref
 # TODO https://github.com/jenkinsci/git-plugin/pull/1093
 rm -fv pct-work/git/target/surefire-reports/TEST-jenkins.plugins.git.ModernScmTest.xml
 
+# TODO https://github.com/jenkinsci/workflow-multibranch-plugin/pull/128
+rm -fv pct-work/workflow-multibranch/target/surefire-reports/TEST-org.jenkinsci.plugins.workflow.multibranch.JobPropertyStepTest.xml
+
 # produces: **/target/surefire-reports/TEST-*.xml

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -249,6 +249,11 @@
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>throttle-concurrents</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>timestamper</artifactId>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
Although this plugin is not used as a dependency very often, I think it would be desirable to have it included in the BOM inasmuch as this results in increased compatibility testing.