### PR TITLE
Add Rebuilder to the managed set

### DIFF
--- a/bom-latest/pom.xml
+++ b/bom-latest/pom.xml
@@ -26,6 +26,11 @@
         <dependencies>
             <!-- Plugins (sorted): -->
             <dependency>
+                <groupId>com.sonyericsson.hudson.plugins.rebuild</groupId>
+                <artifactId>rebuild</artifactId>
+                <version>1.32</version>
+            </dependency>
+            <dependency>
                 <groupId>io.jenkins.plugins</groupId>
                 <artifactId>bootstrap4-api</artifactId>
                 <version>4.6.0-2</version>

--- a/pct.sh
+++ b/pct.sh
@@ -94,4 +94,7 @@ rm -fv pct-work/pipeline-model-definition/pipeline-model-definition/target/suref
 # TODO https://github.com/jenkinsci/git-plugin/pull/1093
 rm -fv pct-work/git/target/surefire-reports/TEST-jenkins.plugins.git.ModernScmTest.xml
 
+# TODO https://github.com/jenkinsci/workflow-multibranch-plugin/pull/128
+rm -fv pct-work/workflow-multibranch/target/surefire-reports/TEST-org.jenkinsci.plugins.workflow.multibranch.JobPropertyStepTest.xml
+
 # produces: **/target/surefire-reports/TEST-*.xml

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -43,6 +43,11 @@
     </dependencyManagement>
     <dependencies>
         <dependency>
+            <groupId>com.sonyericsson.hudson.plugins.rebuild</groupId>
+            <artifactId>rebuild</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>bootstrap4-api</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
I don't feel particularly strongly about including this in the BOM, but if tests pass and it improves compatibility testing for a moderately popular plugin, why not?