### PR TITLE
Add Workspace Cleanup and Resource Disposer to the managed set

### DIFF
--- a/bom-latest/pom.xml
+++ b/bom-latest/pom.xml
@@ -310,6 +310,11 @@
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>resource-disposer</artifactId>
+                <version>0.15</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>scm-api</artifactId>
                 <version>${scm-api-plugin.version}</version>
             </dependency>
@@ -358,6 +363,11 @@
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>variant</artifactId>
                 <version>1.4</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>ws-cleanup</artifactId>
+                <version>0.39</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.ui</groupId>

--- a/bom-latest/pom.xml
+++ b/bom-latest/pom.xml
@@ -321,7 +321,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>resource-disposer</artifactId>
-                <version>0.15</version>
+                <version>0.16</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>

--- a/failFast
+++ b/failFast
@@ -1,1 +1,1 @@
-true
+false

--- a/failFast
+++ b/failFast
@@ -1,1 +1,1 @@
-false
+true

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -267,6 +267,11 @@
             <artifactId>variant</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>ws-cleanup</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>


### PR DESCRIPTION
As with my other recent PRs, the goal of this change is just to increase compatibility testing for these plugins. Note that Resource Disposer is a dependency of Workspace Cleanup, so I have not included a dependency on it in the sample plugin.