### PR TITLE
Re-enabling some previously excluded tests that should have been fixed and released by now

### DIFF
--- a/pct.sh
+++ b/pct.sh
@@ -59,15 +59,6 @@ fi
 # and anyway the tests in PluginAutomaticTestBuilder are generally uninteresting in a PCT context
 rm -fv pct-work/*/{,*/}target/surefire-reports/TEST-InjectedTest.xml
 
-# TODO pending https://github.com/jenkinsci/jdk-tool-plugin/pull/12
-rm -rf pct-work/jdk-tool/target/surefire-reports/TEST-hudson.tools.JDKInstallerTest.xml
-
-# TODO pending https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/96
-rm -rf pct-work/workflow-cps-global-lib/target/surefire-reports/TEST-org.jenkinsci.plugins.workflow.libs.GlobalLibrariesTest.xml
-
-# TODO Merged, but needs a release: https://github.com/jenkinsci/git-plugin/pull/857
-rm -fv pct-work/git/target/surefire-reports/TEST-hudson.plugins.git.GitStatusCrumbExclusionTest.xml
-
 # TODO flakey tests related to workflow-job saying it's finished but it still hasn't finished updating the log
 # ref: https://github.com/jenkinsci/workflow-job-plugin/pull/131/files#r291657569
 # https://github.com/jenkinsci/workflow-support-plugin/pull/105
@@ -82,30 +73,11 @@ rm -fv pct-work/junit/target/surefire-reports/TEST-hudson.tasks.junit.pipeline.J
 # https://github.com/jenkinsci/workflow-job-plugin/pull/158
 rm -fv pct-work/workflow-job/target/surefire-reports/TEST-org.jenkinsci.plugins.workflow.job.WorkflowRunRestartTest.xml
 
-# TODO pending https://github.com/jenkinsci/ansicolor-plugin/pull/164
-rm -fv pct-work/ansicolor/target/surefire-reports/TEST-hudson.plugins.ansicolor.AnsiColorBuildWrapperTest.xml
-# TODO https://github.com/jenkinsci/durable-task-plugin/pull/101
-rm -fv pct-work/durable-task/target/surefire-reports/TEST-org.jenkinsci.plugins.durabletask.BourneShellScriptTest.xml
-# TODO https://github.com/jenkinsci/git-client-plugin/pull/440
-rm -fv pct-work/git-client/target/surefire-reports/TEST-hudson.plugins.git.GitExceptionTest.xml
 # TODO fails for one reason in (non-PCT) official sources, run locally; and for another reason in PCT in Docker; passes in official sources in Docker, or locally in PCT
 rm -fv pct-work/git-client/target/surefire-reports/TEST-org.jenkinsci.plugins.gitclient.FilePermissionsTest.xml
-# TODO pending non-beta release of https://github.com/jenkinsci/git-client-plugin/pull/478 (or #479 backport)
-rm -fv pct-work/git-client/target/surefire-reports/TEST-org.jenkinsci.plugins.gitclient.{CliGitAPIImplTest,JGitAPIImplTest,JGitApacheAPIImplTest}.xml
-# TODO https://github.com/jenkinsci/configuration-as-code-plugin/pull/1243
-rm -fv pct-work/configuration-as-code-plugin/plugin/target/surefire-reports/TEST-io.jenkins.plugins.casc.ConfigurationAsCodeTest.xml
 
 # TODO cryptic PCT-only errors: https://github.com/jenkinsci/bom/pull/251#issuecomment-645012427
 rm -fv pct-work/matrix-project/target/surefire-reports/TEST-hudson.matrix.AxisTest.xml
-
-# TODO remove after timestamper upgrades to next bom https://github.com/jenkinsci/bom/pull/294#issuecomment-710770375
-rm -fv pct-work/timestamper/target/surefire-reports/TEST-hudson.plugins.timestamper.ConfigurationAsCodeTest.xml
-
-# TODO https://github.com/jenkinsci/workflow-multibranch-plugin/pull/102
-rm -fv pct-work/workflow-multibranch/target/surefire-reports/TEST-org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProjectTest.xml
-
-# TODO https://github.com/jenkinsci/matrix-auth-plugin/pull/93
-rm -fv pct-work/matrix-auth/target/surefire-reports/TEST-org.jenkinsci.plugins.matrixauth.PermissionAdderTest.xml
 
 # TODO https://github.com/jenkinsci/workflow-basic-steps-plugin/pull/137
 rm -fv pct-work/workflow-basic-steps/target/surefire-reports/TEST-org.jenkinsci.plugins.workflow.support.steps.stash.StashTest.xml


### PR DESCRIPTION
Based on my reading of the changelogs, these tests should be working now that the relevant fixes have been merged and released. I haven't tried running this locally, so let's see how the CI build looks.