### PR TITLE
Add Subversion to the managed set

### DIFF
--- a/bom-latest/pom.xml
+++ b/bom-latest/pom.xml
@@ -285,6 +285,11 @@
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>mapdb-api</artifactId>
+                <version>1.0.9.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>matrix-auth</artifactId>
                 <version>2.6.7</version>
             </dependency>
@@ -343,6 +348,11 @@
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>structs</artifactId>
                 <version>${structs-plugin.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>subversion</artifactId>
+                <version>2.14.2</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>

--- a/bom-latest/pom.xml
+++ b/bom-latest/pom.xml
@@ -352,7 +352,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>subversion</artifactId>
-                <version>2.14.2</version>
+                <version>2.14.3</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>

--- a/pct.sh
+++ b/pct.sh
@@ -91,4 +91,7 @@ rm -fv pct-work/pipeline-model-definition/pipeline-model-definition/target/suref
 # TODO https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/421
 rm -fv pct-work/pipeline-model-definition/pipeline-model-definition/target/surefire-reports/TEST-org.jenkinsci.plugins.pipeline.modeldefinition.steps.CredentialWrapperStepTest.xml
 
+# TODO https://github.com/jenkinsci/git-plugin/pull/1093
+rm -fv pct-work/git/target/surefire-reports/TEST-jenkins.plugins.git.ModernScmTest.xml
+
 # produces: **/target/surefire-reports/TEST-*.xml

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -248,6 +248,11 @@
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>subversion</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>timestamper</artifactId>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
Adding Subversion (and its direct dependency MapDB API) to the managed set. It is used in the tests for `workflow-multibranch`, `workflow-cps-global-lib`, and `workflow-scm-step`, all of which need to bump their dependency and do a release whenever Subversion is updated, which is a bit annoying. That could be solved by including Subversion in the BOM. And yes, Subversion does need to be updated for recent versions of core because of the Digester removal.