### PR TITLE
Add Pipeline Graph Analysis to the managed set

### DIFF
--- a/bom-latest/pom.xml
+++ b/bom-latest/pom.xml
@@ -305,6 +305,11 @@
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>pipeline-graph-analysis</artifactId>
+                <version>1.11</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>pipeline-input-step</artifactId>
                 <version>2.12</version>
             </dependency>

--- a/failFast
+++ b/failFast
@@ -1,1 +1,1 @@
-true
+false

--- a/failFast
+++ b/failFast
@@ -1,1 +1,1 @@
-false
+true

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -233,6 +233,11 @@
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>pipeline-graph-analysis</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>pipeline-input-step</artifactId>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
I don't feel particularly strongly about including this in the BOM, but if tests pass and it improves compatibility testing for a moderately popular plugin, why not?