### PR TITLE
Bump Throttle Concurrent Builds from 2.2 to 2.3

### DIFF
--- a/bom-latest/pom.xml
+++ b/bom-latest/pom.xml
@@ -369,7 +369,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>throttle-concurrents</artifactId>
-                <version>2.2</version>
+                <version>2.3</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Fixes the flaky test encountered in the aftermath of jenkinsci/bom#471 by pulling in Throttle Concurrent Builds 2.3 thus jenkinsci/throttle-concurrent-builds-plugin#130.