### PR TITLE
Skip marking build unstable if we are going to attempt again on a new node

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 def buildNumber = BUILD_NUMBER as int; if (buildNumber > 1) milestone(buildNumber - 1); milestone(buildNumber) // JENKINS-43353 / JENKINS-58625
 
-def mavenEnv(body) {
+def mavenEnv(Map params = [:], Closure body) {
     node('maven') { // no Dockerized tests; https://github.com/jenkins-infra/documentation/blob/master/ci.adoc#container-agents
         timeout(90) {
             sh 'mvn -version'
@@ -10,7 +10,7 @@ def mavenEnv(body) {
             withEnv(["MAVEN_SETTINGS=$settingsXml"]) {
                 body()
             }
-            if (junit(testResults: '**/target/surefire-reports/TEST-*.xml', allowEmptyResults: true).failCount > 0) {
+            if (junit(testResults: '**/target/surefire-reports/TEST-*.xml', allowEmptyResults: true, skipMarkingBuildUnstable: !!params['skipMarkingBuildUnstable']).failCount > 0) {
                 // TODO JENKINS-27092 throw up UNSTABLE status in this case
                 error 'Some test failures, not going to continue'
             }
@@ -48,8 +48,8 @@ lines.each {line ->
           def attempt = 0
           def attempts = 2
           retry(attempts) { // in case of transient node outages
-            echo 'Attempt ' + attempt++ + ' of ' + attempts
-            mavenEnv {
+            echo 'Attempt ' + ++attempt + ' of ' + attempts
+            mavenEnv(skipMarkingBuildUnstable: attempt < attempts) {
                 deleteDir()
                 unstash 'pct.sh'
                 unstash 'pct'


### PR DESCRIPTION
Observed [here](https://ci.jenkins.io/job/Tools/job/bom/job/PR-594/2/): the first time `pct-workflow-cps-2.235.x` was attempted, it got to the end and marked the build unstable, then threw an error. Then the second attempt was made, which passed. No error was thrown, but the unstable status from the first attempt remained. I think we should only be marking the build as unstable if we failed on the last attempt.