### PR TITLE
Use `surefire.excludesFile` to skip failing tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,6 +37,7 @@ stage('prep') {
             lines.each {stash name: "megawar-$it", includes: "megawar-${it}.war"}
         }
         stash name: 'pct.sh', includes: 'pct.sh'
+        stash name: 'excludes.txt', includes: 'excludes.txt'
         infra.prepareToPublishIncrementals()
     }
 }
@@ -52,6 +53,7 @@ lines.each {line ->
             mavenEnv(skipMarkingBuildUnstable: attempt < attempts) {
                 deleteDir()
                 unstash 'pct.sh'
+                unstash 'excludes.txt'
                 unstash 'pct'
                 unstash "megawar-$line"
                 withEnv(["PLUGINS=$plugin", "LINE=$line", 'EXTRA_MAVEN_PROPERTIES=surefire.rerunFailingTestsCount=4']) {

--- a/excludes.txt
+++ b/excludes.txt
@@ -9,6 +9,9 @@ org.jenkinsci.plugins.durabletask.BourneShellScriptTest
 org.jenkinsci.plugins.pipeline.modeldefinition.BasicModelDefTest
 org.jenkinsci.plugins.pipeline.modeldefinition.MatrixTest
 
+# TODO seemingly legitimate but undiagnosed PCT failures in interruptedWhileStartingMaxSurvivability and interruptedWhileStartingPerformanceOptimized
+org.jenkinsci.plugins.workflow.job.WorkflowRunRestartTest
+
 # TODO https://github.com/jenkinsci/workflow-multibranch-plugin/pull/128
 org.jenkinsci.plugins.workflow.multibranch.JobPropertyStepTest
 

--- a/excludes.txt
+++ b/excludes.txt
@@ -1,0 +1,19 @@
+# TODO cryptic PCT-only errors: https://github.com/jenkinsci/bom/pull/251#issuecomment-645012427
+hudson.matrix.AxisTest
+
+# TODO fails for one reason in (non-PCT) official sources, run locally; and for another reason in PCT in Docker; passes in official sources in Docker, or locally in PCT
+org.jenkinsci.plugins.gitclient.FilePermissionsTest
+
+# TODO flakes on CI for inscrutable reasons
+org.jenkinsci.plugins.durabletask.BourneShellScriptTest
+org.jenkinsci.plugins.pipeline.modeldefinition.BasicModelDefTest
+org.jenkinsci.plugins.pipeline.modeldefinition.MatrixTest
+
+# TODO https://github.com/jenkinsci/workflow-multibranch-plugin/pull/128
+org.jenkinsci.plugins.workflow.multibranch.JobPropertyStepTest
+
+# TODO until dropping 2.235.x so can rely on https://github.com/jenkinsci/workflow-basic-steps-plugin/pull/120
+org.jenkinsci.plugins.workflow.steps.TimeoutStepTest
+
+# TODO https://github.com/jenkinsci/workflow-basic-steps-plugin/pull/137
+org.jenkinsci.plugins.workflow.support.steps.stash.StashTest

--- a/excludes.txt
+++ b/excludes.txt
@@ -1,6 +1,9 @@
 # TODO cryptic PCT-only errors: https://github.com/jenkinsci/bom/pull/251#issuecomment-645012427
 hudson.matrix.AxisTest
 
+# TODO until we drop support for 2.249.x, work around https://github.com/jenkinsci/git-plugin/pull/1093
+jenkins.plugins.git.ModernScmTest
+
 # TODO fails for one reason in (non-PCT) official sources, run locally; and for another reason in PCT in Docker; passes in official sources in Docker, or locally in PCT
 org.jenkinsci.plugins.gitclient.FilePermissionsTest
 

--- a/local-test.sh
+++ b/local-test.sh
@@ -16,7 +16,7 @@ LINEZ=$LINE bash prep.sh
 
 rm -rf target/local-test
 mkdir target/local-test
-cp -v target/pct.jar pct.sh target/local-test
+cp -v target/pct.jar pct.sh excludes.txt target/local-test
 cp -v target/megawar-$LINE.war target/local-test/megawar.war
 
 if [ -v TEST ]

--- a/pct.sh
+++ b/pct.sh
@@ -2,7 +2,7 @@
 set -euxo pipefail
 cd "$(dirname "$0")"
 
-# expects: megawar.war, pct.war, $PLUGINS, $LINE
+# expects: megawar.war, pct.war, excludes.txt, $PLUGINS, $LINE
 
 rm -rf pct-work pct-report.xml
 
@@ -13,7 +13,7 @@ else
     PCT_S_ARG=
 fi
 
-MAVEN_PROPERTIES=jth.jenkins-war.path=$(pwd)/megawar.war:forkCount=.75C
+MAVEN_PROPERTIES=jth.jenkins-war.path=$(pwd)/megawar.war:forkCount=.75C:surefire.excludesFile=$(pwd)/excludes.txt
 if [ -v EXTRA_MAVEN_PROPERTIES ]
 then
     MAVEN_PROPERTIES="$MAVEN_PROPERTIES:$EXTRA_MAVEN_PROPERTIES"
@@ -52,62 +52,10 @@ EOF
     done
 fi
 
-# TODO rather than removing all these, have a text file of known failures and just convert them to “skipped”
-# or add surefire.excludesFile to MAVEN_PROPERTIES so we do not waste time even running these
-
 # TODO various problems with PCT itself (e.g. https://github.com/jenkinsci/bom/pull/338#issuecomment-715256727)
 # and anyway the tests in PluginAutomaticTestBuilder are generally uninteresting in a PCT context
+# We always try to run this test rather than adding it to excludes.txt in order
+# to be able to detect if PCT failed to run tests at all a few lines above.
 rm -fv pct-work/*/{,*/}target/surefire-reports/TEST-InjectedTest.xml
-
-# TODO flakey tests related to workflow-job saying it's finished but it still hasn't finished updating the log
-# ref: https://github.com/jenkinsci/workflow-job-plugin/pull/131/files#r291657569
-# https://github.com/jenkinsci/workflow-support-plugin/pull/105
-# https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/130
-# https://github.com/jenkinsci/workflow-basic-steps-plugin/pull/110 analogue for CatchErrorStepTest
-rm -fv pct-work/workflow-basic-steps/target/surefire-reports/TEST-org.jenkinsci.plugins.workflow.steps.CatchErrorStepTest.xml
-rm -fv pct-work/workflow-support/target/surefire-reports/TEST-org.jenkinsci.plugins.workflow.support.pickles.serialization.SerializationSecurityTest.xml
-rm -fv pct-work/workflow-durable-task-step/target/surefire-reports/TEST-org.jenkinsci.plugins.workflow.steps.durable_task.ShellStepTest.xml
-rm -fv pct-work/workflow-durable-task-step/target/surefire-reports/TEST-org.jenkinsci.plugins.workflow.support.steps.ExecutorStepTest.xml
-rm -fv pct-work/workflow-cps/target/surefire-reports/TEST-org.jenkinsci.plugins.workflow.cps.FlowDurabilityTest.xml
-rm -fv pct-work/junit/target/surefire-reports/TEST-hudson.tasks.junit.pipeline.JUnitResultsStepTest.xml
-# https://github.com/jenkinsci/workflow-job-plugin/pull/158
-rm -fv pct-work/workflow-job/target/surefire-reports/TEST-org.jenkinsci.plugins.workflow.job.WorkflowRunRestartTest.xml
-
-# TODO fails for one reason in (non-PCT) official sources, run locally; and for another reason in PCT in Docker; passes in official sources in Docker, or locally in PCT
-rm -fv pct-work/git-client/target/surefire-reports/TEST-org.jenkinsci.plugins.gitclient.FilePermissionsTest.xml
-
-# TODO cryptic PCT-only errors: https://github.com/jenkinsci/bom/pull/251#issuecomment-645012427
-rm -fv pct-work/matrix-project/target/surefire-reports/TEST-hudson.matrix.AxisTest.xml
-
-# TODO https://github.com/jenkinsci/workflow-basic-steps-plugin/pull/137
-rm -fv pct-work/workflow-basic-steps/target/surefire-reports/TEST-org.jenkinsci.plugins.workflow.support.steps.stash.StashTest.xml
-
-# TODO until dropping 2.235.x so can rely on https://github.com/jenkinsci/workflow-basic-steps-plugin/pull/120
-rm -fv pct-work/workflow-basic-steps/target/surefire-reports/TEST-org.jenkinsci.plugins.workflow.steps.TimeoutStepTest.xml
-
-# TODO https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/417
-rm -fv pct-work/pipeline-model-definition/pipeline-model-definition/target/surefire-reports/TEST-org.jenkinsci.plugins.pipeline.modeldefinition.parser.ASTParserUtilsTest.xml
-
-# TODO https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/421
-rm -fv pct-work/pipeline-model-definition/pipeline-model-definition/target/surefire-reports/TEST-org.jenkinsci.plugins.pipeline.modeldefinition.steps.CredentialWrapperStepTest.xml
-
-# TODO https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/429
-rm -fv pct-work/pipeline-model-definition/pipeline-model-definition/target/surefire-reports/TEST-org.jenkinsci.plugins.pipeline.modeldefinition.ToolsTest.xml
-
-# TODO https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/441
-rm -fv pct-work/pipeline-model-definition/pipeline-model-definition/target/surefire-reports/TEST-org.jenkinsci.plugins.pipeline.modeldefinition.AgentTest.xml
-
-# TODO flakey on CI, not tracked down yet but blocking all other PRs
-rm -fv pct-work/pipeline-model-definition/pipeline-model-definition/target/surefire-reports/TEST-org.jenkinsci.plugins.pipeline.modeldefinition.BasicModelDefTest.xml
-rm -fv pct-work/pipeline-model-definition/pipeline-model-definition/target/surefire-reports/TEST-org.jenkinsci.plugins.pipeline.modeldefinition.MatrixTest.xml
-
-# TODO https://github.com/jenkinsci/git-plugin/pull/1093
-rm -fv pct-work/git/target/surefire-reports/TEST-jenkins.plugins.git.ModernScmTest.xml
-
-# TODO https://github.com/jenkinsci/workflow-multibranch-plugin/pull/128
-rm -fv pct-work/workflow-multibranch/target/surefire-reports/TEST-org.jenkinsci.plugins.workflow.multibranch.JobPropertyStepTest.xml
-
-# TODO flakes on CI for inscrutable reasons
-rm -fv pct-work/durable-task/target/surefire-reports/TEST-org.jenkinsci.plugins.durabletask.BourneShellScriptTest.xml
 
 # produces: **/target/surefire-reports/TEST-*.xml


### PR DESCRIPTION
Test runs would be faster if we did not waste time even running tests whose results we do not care about.