### PR TITLE
Exclude git client plugin test_list_branches failures

### DIFF
--- a/excludes.txt
+++ b/excludes.txt
@@ -4,6 +4,11 @@ hudson.matrix.AxisTest
 # TODO until we drop support for 2.249.x, work around https://github.com/jenkinsci/git-plugin/pull/1093
 jenkins.plugins.git.ModernScmTest
 
+# TODO until we drop support for 2.249.x, work around https://github.com/jenkinsci/git-client-plugin/pull/675 not available in git client plugin 3.6.0
+org.jenkinsci.plugins.gitclient.CliGitAPIImplTest.test_list_branches
+org.jenkinsci.plugins.gitclient.JGitAPIImplTest.test_list_branches
+org.jenkinsci.plugins.gitclient.JGitApacheAPIImplTest.test_list_branches
+
 # TODO fails for one reason in (non-PCT) official sources, run locally; and for another reason in PCT in Docker; passes in official sources in Docker, or locally in PCT
 org.jenkinsci.plugins.gitclient.FilePermissionsTest
 

--- a/excludes.txt
+++ b/excludes.txt
@@ -5,9 +5,9 @@ hudson.matrix.AxisTest
 jenkins.plugins.git.ModernScmTest
 
 # TODO until we drop support for 2.249.x, work around https://github.com/jenkinsci/git-client-plugin/pull/675 not available in git client plugin 3.6.0
-org.jenkinsci.plugins.gitclient.CliGitAPIImplTest.test_list_branches
-org.jenkinsci.plugins.gitclient.JGitAPIImplTest.test_list_branches
-org.jenkinsci.plugins.gitclient.JGitApacheAPIImplTest.test_list_branches
+org.jenkinsci.plugins.gitclient.CliGitAPIImplTest
+org.jenkinsci.plugins.gitclient.JGitAPIImplTest
+org.jenkinsci.plugins.gitclient.JGitApacheAPIImplTest
 
 # TODO fails for one reason in (non-PCT) official sources, run locally; and for another reason in PCT in Docker; passes in official sources in Docker, or locally in PCT
 org.jenkinsci.plugins.gitclient.FilePermissionsTest


### PR DESCRIPTION
## Exclude bom 2.249.x test failures from git client plugin

Git client plugin 3.6.0 does not include jenkinsci/git-client-plugin#675 that resolves a test failure with command line git 2.33 and later.  Git client plugin 3.7.0 and later include that fix.

Git client plugin 3.6.0 also does not include the change for git LFS execution on ci.jenkins.io.

This exclusion will no longer be needed when the bom drops support for 2.249.x.

Fixes #638.