### PR TITLE
Ignore failing git plugin Assembla test

### DIFF
--- a/excludes.txt
+++ b/excludes.txt
@@ -4,6 +4,9 @@ hudson.matrix.AxisTest
 # TODO until we drop support for 2.249.x, work around https://github.com/jenkinsci/git-plugin/pull/1093
 jenkins.plugins.git.ModernScmTest
 
+# TODO until we update to a git plugin version after 4.8.2, work around https://github.com/jenkinsci/git-plugin/pull/1144
+hudson.plugins.git.browser.AssemblaWebDoCheckURLTest
+
 # TODO until we drop support for 2.249.x, work around https://github.com/jenkinsci/git-client-plugin/pull/675 not available in git client plugin 3.6.0
 org.jenkinsci.plugins.gitclient.CliGitAPIImplTest
 org.jenkinsci.plugins.gitclient.JGitAPIImplTest


### PR DESCRIPTION
## Ignore git plugin failing test of Assembla browser check

Test depends on the https://www.assembla.com web site.  Web site layout has changed enough that the test now fails.

Test is removed from the plugin in https://github.com/jenkinsci/git-plugin/pull/1144
