### PR TITLE
Bump jackson2-api

### DIFF
--- a/bom-latest/pom.xml
+++ b/bom-latest/pom.xml
@@ -262,7 +262,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>jackson2-api</artifactId>
-                <version>2.12.4-1</version>
+                <version>2.13.0-226.v0c5dd2d2fd2a</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Hopefully dependabot will work again after this, unless it can't handle this version format =/

dependabot log seems to think the previous version is the latest