### PR TITLE
Bump Pipeline: Shared Groovy Libraries from 2.21 to 552.vd9cc05b8a2e1

### DIFF
--- a/bom-2.289.x/pom.xml
+++ b/bom-2.289.x/pom.xml
@@ -24,6 +24,11 @@
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins.workflow</groupId>
+                <artifactId>workflow-cps-global-lib</artifactId>
+                <version>2.21</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins.workflow</groupId>
                 <artifactId>workflow-durable-task-step</artifactId>
                 <version>2.40</version>
             </dependency>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -152,7 +152,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins.workflow</groupId>
                 <artifactId>workflow-cps-global-lib</artifactId>
-                <version>2.21</version>
+                <version>552.vd9cc05b8a2e1</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins.workflow</groupId>


### PR DESCRIPTION
Not sure why Dependabot isn't updating this one.