### PR TITLE
Bump Pipeline: Groovy from 2.94 to 2648.va9433432b33c

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -17,7 +17,7 @@
         <structs-plugin.version>1.23</structs-plugin.version>
         <subversion-plugin.version>2.15.1</subversion-plugin.version>
         <workflow-api-plugin.version>1108.v57edf648f5d4</workflow-api-plugin.version>
-        <workflow-cps-plugin.version>2.94</workflow-cps-plugin.version>
+        <workflow-cps-plugin.version>2648.va9433432b33c</workflow-cps-plugin.version>
         <workflow-job-plugin.version>1145.v7f2433caa07f</workflow-job-plugin.version>
         <workflow-multibranch-plugin.version>2.26</workflow-multibranch-plugin.version>
         <workflow-step-api-plugin.version>615.vb09dac339255</workflow-step-api-plugin.version>


### PR DESCRIPTION
Not sure why Dependabot isn't updating this one.