### PR TITLE
Bump Pipeline Graph Analysis from 1.12 to 188.v3a01e7973f2c

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -372,7 +372,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>pipeline-graph-analysis</artifactId>
-                <version>1.12</version>
+                <version>188.v3a01e7973f2c</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Not sure why Dependabot isn't updating this one.