### PR TITLE
Bump Structs from 1.23 to 308.v852b473a2b8c

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -14,7 +14,6 @@
         <git-plugin.version>4.10.1</git-plugin.version>
         <pipeline-model-definition-plugin.version>1.9.3</pipeline-model-definition-plugin.version>
         <scm-api-plugin.version>2.6.5</scm-api-plugin.version>
-        <structs-plugin.version>1.23</structs-plugin.version>
         <subversion-plugin.version>2.15.1</subversion-plugin.version>
         <workflow-api-plugin.version>1108.v57edf648f5d4</workflow-api-plugin.version>
         <workflow-cps-plugin.version>2648.va9433432b33c</workflow-cps-plugin.version>
@@ -428,7 +427,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>structs</artifactId>
-                <version>${structs-plugin.version}</version>
+                <version>308.v852b473a2b8c</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
@@ -506,12 +505,6 @@
                 <groupId>org.jenkinsci.plugins</groupId>
                 <artifactId>pipeline-stage-tags-metadata</artifactId>
                 <version>${pipeline-model-definition-plugin.version}</version>
-            </dependency>
-            <!-- Non-plugins: -->
-            <dependency>
-                <groupId>org.jenkins-ci</groupId>
-                <artifactId>symbol-annotation</artifactId>
-                <version>${structs-plugin.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Not sure why Dependabot isn't updating this one.