### PR TITLE
Add tests of `plugin-util` to BOM

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -21,6 +21,7 @@
         <workflow-multibranch-plugin.version>696.v52535c46f4c9</workflow-multibranch-plugin.version>
         <workflow-step-api-plugin.version>622.vb_8e7c15b_c95a_</workflow-step-api-plugin.version>
         <workflow-support-plugin.version>804.vba10a18a1476</workflow-support-plugin.version>
+        <plugin-util-api.version>2.10.0</plugin-util-api.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -94,7 +95,13 @@
             <dependency>
                 <groupId>io.jenkins.plugins</groupId>
                 <artifactId>plugin-util-api</artifactId>
-                <version>2.10.0</version>
+                <version>${plugin-util-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.jenkins.plugins</groupId>
+                <artifactId>plugin-util-api</artifactId>
+                <version>${plugin-util-api.version}</version>
+                <classifier>tests</classifier>
             </dependency>
             <dependency>
                 <groupId>io.jenkins.plugins</groupId>


### PR DESCRIPTION
In order to use the assertions of `plugin-util` it makes sense to include the tests as well into the BOM.