### PR TITLE
Bump `ldap` to 2.8

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -283,7 +283,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>ldap</artifactId>
-                <version>2.7</version>
+                <version>2.8</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Picks up https://github.com/jenkinsci/ldap-plugin/pull/133, which I hope will prevent every build from failing.
