### PR TITLE
Remove unneeded exclusions

### DIFF
--- a/excludes.txt
+++ b/excludes.txt
@@ -6,12 +6,6 @@ org.jenkinsci.plugins.gitclient.FilePermissionsTest
 
 # TODO flakes on CI for inscrutable reasons
 org.jenkinsci.plugins.durabletask.BourneShellScriptTest
-org.jenkinsci.plugins.pipeline.modeldefinition.BasicModelDefTest
-org.jenkinsci.plugins.pipeline.modeldefinition.MatrixTest
-org.jenkinsci.plugins.pipeline.modeldefinition.WhenStageTest
-org.jenkinsci.plugins.pipeline.modeldefinition.WhenStageMultibranchTest
-org.jenkinsci.plugins.pipeline.modeldefinition.PostStageTest
-org.jenkinsci.plugins.pipeline.modeldefinition.ToolsTest
 
 # TODO https://github.com/jenkinsci/ansicolor-plugin/pull/236
 hudson.plugins.ansicolor.action.ShortlogActionCreatorIntegrationTest


### PR DESCRIPTION
As of jenkinsci/pipeline-model-definition-plugin#480 I think these exclusions are no longer necessary. Let's try a CI build, and if it passes we can remove the unneeded exclusions.

Fixes #613.