### PR TITLE
Sort `weekly` at top of reverse-chrono `lines.txt`

### DIFF
--- a/prep.sh
+++ b/prep.sh
@@ -10,7 +10,7 @@ fi
 
 $MVN clean install ${SAMPLE_PLUGIN_OPTS:-}
 
-ALL_LINEZ=$(fgrep '<bom>' sample-plugin/pom.xml | sed -E 's, *<bom>(.+)</bom>,\1,g' | sort -rn)
+ALL_LINEZ=$(echo weekly; fgrep '.x</bom>' sample-plugin/pom.xml | sed -E 's, *<bom>(.+)</bom>,\1,g' | sort -rn)
 : "${LINEZ:=$ALL_LINEZ}"
 echo -n $LINEZ > target/lines.txt
 


### PR DESCRIPTION
https://github.com/jenkinsci/bom/pull/671#issuecomment-1071089261: seems we were testing against `2.332.x` & `weekly` (but not `2.319.x` or older!) when we meant to test against `weekly` and `2.289.x` (skipping intermediate lines under the assumption that they most likely pass if the endpoints of the range do).