### PR TITLE
Make shell scripts `shfmt(1)` and `shellcheck(1)` clean

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,8 +30,8 @@ stage('prep') {
             sh 'bash prep.sh'
         }
         dir('target') {
-            plugins = readFile('plugins.txt').split(' ')
-            lines = readFile('lines.txt').split(' ')
+            plugins = readFile('plugins.txt').split('\n')
+            lines = readFile('lines.txt').split('\n')
             lines = [lines[0], lines[-1]] // run PCT only on newest and oldest lines, to save resources
             stash name: 'pct', includes: 'pct.jar'
             lines.each {stash name: "megawar-$it", includes: "megawar-${it}.war"}

--- a/local-test.sh
+++ b/local-test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -euxo pipefail
-cd "$(dirname $0)"
+cd "$(dirname "$0")"
 
 # expects: $PLUGINS, optionally $TEST, $LINE
 
@@ -8,9 +8,8 @@ LATEST_LINE=weekly
 : "${LINE:=$LATEST_LINE}"
 
 export SAMPLE_PLUGIN_OPTS=-Dtest=InjectedTest
-if [ $LINE \!= $LATEST_LINE ]
-then
-    export SAMPLE_PLUGIN_OPTS="$SAMPLE_PLUGIN_OPTS -P$LINE"
+if [ $LINE \!= $LATEST_LINE ]; then
+	export SAMPLE_PLUGIN_OPTS="${SAMPLE_PLUGIN_OPTS} -P${LINE}"
 fi
 LINEZ=$LINE bash prep.sh
 
@@ -19,30 +18,28 @@ mkdir target/local-test
 cp -v target/pct.jar pct.sh excludes.txt target/local-test
 cp -v target/megawar-$LINE.war target/local-test/megawar.war
 
-if [ -v TEST ]
-then
-    EXTRA_MAVEN_PROPERTIES="test=$TEST"
+if [ -v TEST ]; then
+	EXTRA_MAVEN_PROPERTIES="test=${TEST}"
 else
-    EXTRA_MAVEN_PROPERTIES=
+	EXTRA_MAVEN_PROPERTIES=
 fi
 
-if [ -v DOCKERIZED ]
-then
-    docker volume inspect m2repo || docker volume create m2repo
-    docker run \
-           -v ~/.m2:/var/maven/.m2 \
-           --rm \
-           --name bom-pct \
-           -v "$(pwd)"/target/local-test:/pct \
-           -e MAVEN_OPTS=-Duser.home=/var/maven \
-           -e MAVEN_CONFIG=/var/maven/.m2 \
-           -e PLUGINS="$PLUGINS" \
-           -e LINE=$LINE \
-           -e EXTRA_MAVEN_PROPERTIES=$EXTRA_MAVEN_PROPERTIES \
-           --entrypoint bash \
-           jenkins/jnlp-agent-maven \
-           -c "trap 'chown -R $(id -u):$(id -g) /pct /var/maven/.m2/repository' EXIT; bash /pct/pct.sh"
+if [ -v DOCKERIZED ]; then
+	docker volume inspect m2repo || docker volume create m2repo
+	docker run \
+		-v ~/.m2:/var/maven/.m2 \
+		--rm \
+		--name bom-pct \
+		-v "$(pwd)/target/local-test:/pct" \
+		-e MAVEN_OPTS=-Duser.home=/var/maven \
+		-e MAVEN_CONFIG=/var/maven/.m2 \
+		-e "PLUGINS=${PLUGINS}" \
+		-e "LINE=${LINE}" \
+		-e "EXTRA_MAVEN_PROPERTIES=${EXTRA_MAVEN_PROPERTIES}" \
+		--entrypoint bash \
+		jenkins/jnlp-agent-maven \
+		-c "trap 'chown -R $(id -u):$(id -g) /pct /var/maven/.m2/repository' EXIT; bash /pct/pct.sh"
 else
-    export EXTRA_MAVEN_PROPERTIES
-    LINE=$LINE bash target/local-test/pct.sh
+	export EXTRA_MAVEN_PROPERTIES
+	LINE=$LINE bash target/local-test/pct.sh
 fi

--- a/pct.sh
+++ b/pct.sh
@@ -6,50 +6,44 @@ cd "$(dirname "$0")"
 
 rm -rf pct-work pct-report.xml
 
-if [ -v MAVEN_SETTINGS ]
-then
-    PCT_S_ARG="-m2SettingsFile $MAVEN_SETTINGS"
+if [ -v MAVEN_SETTINGS ]; then
+	PCT_S_ARG="-m2SettingsFile ${MAVEN_SETTINGS}"
 else
-    PCT_S_ARG=
+	PCT_S_ARG=
 fi
 
 MAVEN_PROPERTIES=jth.jenkins-war.path=$(pwd)/megawar.war:forkCount=.75C:surefire.excludesFile=$(pwd)/excludes.txt
-if [ -v EXTRA_MAVEN_PROPERTIES ]
-then
-    MAVEN_PROPERTIES="$MAVEN_PROPERTIES:$EXTRA_MAVEN_PROPERTIES"
+if [ -v EXTRA_MAVEN_PROPERTIES ]; then
+	MAVEN_PROPERTIES="${MAVEN_PROPERTIES}:${EXTRA_MAVEN_PROPERTIES}"
 fi
 
 java -jar pct.jar \
-     -war "$(pwd)/megawar.war" \
-     -includePlugins "${PLUGINS}" \
-     -workDirectory "$(pwd)/pct-work" \
-     -reportFile "$(pwd)/pct-report.xml" \
-     $PCT_S_ARG \
-     -mavenProperties "${MAVEN_PROPERTIES}" \
-     -skipTestCache true
+	-war "$(pwd)/megawar.war" \
+	-includePlugins "${PLUGINS}" \
+	-workDirectory "$(pwd)/pct-work" \
+	-reportFile "$(pwd)/pct-report.xml" \
+	$PCT_S_ARG \
+	-mavenProperties "${MAVEN_PROPERTIES}" \
+	-skipTestCache true
 
-if grep -q -F -e '<status>INTERNAL_ERROR</status>' pct-report.xml
-then
-    echo PCT failed
-    cat pct-report.xml
-    exit 1
-elif grep -q -F -e '<status>TEST_FAILURES</status>' pct-report.xml
-then
-    echo PCT marked failed, checking to see if that is due to a failure to run tests at all
-    for t in pct-work/*/{,*/}target
-    do
-        if [ -f $t/test-classes/InjectedTest.class -a \! -f $t/surefire-reports/TEST-InjectedTest.xml ]
-        then
-            mkdir -p $t/surefire-reports
-            cat > $t/surefire-reports/TEST-pct.xml <<'EOF'
+if grep -q -F -e '<status>INTERNAL_ERROR</status>' pct-report.xml; then
+	echo PCT failed
+	cat pct-report.xml
+	exit 1
+elif grep -q -F -e '<status>TEST_FAILURES</status>' pct-report.xml; then
+	echo PCT marked failed, checking to see if that is due to a failure to run tests at all
+	for t in pct-work/*/{,*/}target; do
+		if [ -f "${t}/test-classes/InjectedTest.class" ] && [ ! -f "${t}/surefire-reports/TEST-InjectedTest.xml" ]; then
+			mkdir -p "${t}/surefire-reports"
+			cat >"${t}/surefire-reports/TEST-pct.xml" <<'EOF'
 <testsuite name="pct">
   <testcase classname="pct" name="overall">
     <error message="some sort of PCT problem; look at logs"/>
   </testcase>
 </testsuite>
 EOF
-        fi
-    done
+		fi
+	done
 fi
 
 # TODO various problems with PCT itself (e.g. https://github.com/jenkinsci/bom/pull/338#issuecomment-715256727)

--- a/prep.sh
+++ b/prep.sh
@@ -1,49 +1,49 @@
-#!/usr/bin/env bash
+#!/bin/bash
 set -euxo pipefail
 cd "$(dirname "${0}")"
 
 MVN='mvn -B -ntp'
-if [ -v MAVEN_SETTINGS ]
-then
-    MVN="$MVN -s $MAVEN_SETTINGS"
+if [ -v MAVEN_SETTINGS ]; then
+	MVN="${MVN} -s ${MAVEN_SETTINGS}"
 fi
 
 $MVN clean install ${SAMPLE_PLUGIN_OPTS:-}
 
-ALL_LINEZ=$(echo weekly; fgrep '.x</bom>' sample-plugin/pom.xml | sed -E 's, *<bom>(.+)</bom>,\1,g' | sort -rn)
+ALL_LINEZ=$(
+	echo weekly
+	grep -F '.x</bom>' sample-plugin/pom.xml | sed -E 's, *<bom>(.+)</bom>,\1,g' | sort -rn
+)
 : "${LINEZ:=$ALL_LINEZ}"
-echo -n $LINEZ > target/lines.txt
+echo -n "${LINEZ}" >target/lines.txt
 
 rebuild=no
-for LINE in $LINEZ
-do
-    if [ $rebuild = yes ]
-    then
-        $MVN -f sample-plugin clean package ${SAMPLE_PLUGIN_OPTS:-} -P$LINE
-    else
-        rebuild=yes
-        pushd sample-plugin/target/test-classes/test-dependencies
-        echo -n *.hpi | sed s/.hpi//g > ../../../../target/plugins.txt
-        popd
-    fi
-    pushd sample-plugin/target
-    mkdir jenkins
-    # TODO keep managed splits, overriding version with the managed one
-    echo '# nothing' > jenkins/split-plugins.txt
-    cp -r jenkins-for-test megawar-$LINE
-    jar uvf megawar-$LINE/WEB-INF/lib/jenkins-core-*.jar jenkins/split-plugins.txt
-    rm -rfv megawar-$LINE/WEB-INF/detached-plugins megawar-$LINE/META-INF/*.{RSA,SF}
-    mkdir megawar-$LINE/WEB-INF/plugins
-    cp -rv test-classes/test-dependencies/*.hpi megawar-$LINE/WEB-INF/plugins
-    cd megawar-$LINE
-    jar c0Mf ../../../target/megawar-$LINE.war *
-    popd
+for LINE in $LINEZ; do
+	if [ $rebuild = yes ]; then
+		$MVN -f sample-plugin clean package ${SAMPLE_PLUGIN_OPTS:-} "-P${LINE}"
+	else
+		rebuild=yes
+		pushd sample-plugin/target/test-classes/test-dependencies
+		echo -n *.hpi | sed s/.hpi//g >../../../../target/plugins.txt
+		popd
+	fi
+	pushd sample-plugin/target
+	mkdir jenkins
+	# TODO keep managed splits, overriding version with the managed one
+	echo '# nothing' >jenkins/split-plugins.txt
+	cp -r jenkins-for-test "megawar-${LINE}"
+	jar uvf megawar-$LINE/WEB-INF/lib/jenkins-core-*.jar jenkins/split-plugins.txt
+	rm -rfv megawar-$LINE/WEB-INF/detached-plugins megawar-$LINE/META-INF/*.{RSA,SF}
+	mkdir "megawar-${LINE}/WEB-INF/plugins"
+	cp -rv test-classes/test-dependencies/*.hpi "megawar-${LINE}/WEB-INF/plugins"
+	cd "megawar-${LINE}"
+	jar c0Mf "../../../target/megawar-${LINE}.war" *
+	popd
 done
 
 # TODO find a way to encode this in some POM so that it can be managed by Dependabot
 version=1152.vafc19b26d5aa # TODO https://github.com/jenkinsci/plugin-compat-tester/pull/345
 pct=$HOME/.m2/repository/org/jenkins-ci/tests/plugins-compat-tester-cli/${version}/plugins-compat-tester-cli-${version}.jar
-[ -f $pct ] || $MVN dependency:get -Dartifact=org.jenkins-ci.tests:plugins-compat-tester-cli:${version}:jar -DremoteRepositories=https://repo.jenkins-ci.org/public/,https://repo.jenkins-ci.org/incrementals/ -Dtransitive=false
-cp $pct target/pct.jar
+[ -f "${pct}" ] || $MVN dependency:get -Dartifact=org.jenkins-ci.tests:plugins-compat-tester-cli:${version}:jar -DremoteRepositories=https://repo.jenkins-ci.org/public/,https://repo.jenkins-ci.org/incrementals/ -Dtransitive=false
+cp "${pct}" target/pct.jar
 
 # produces: target/{megawar-*.war,pct.jar,plugins.txt,lines.txt}

--- a/prep.sh
+++ b/prep.sh
@@ -14,7 +14,7 @@ ALL_LINEZ=$(
 	grep -F '.x</bom>' sample-plugin/pom.xml | sed -E 's, *<bom>(.+)</bom>,\1,g' | sort -rn
 )
 : "${LINEZ:=$ALL_LINEZ}"
-echo -n "${LINEZ}" >target/lines.txt
+echo "${LINEZ}" >target/lines.txt
 
 rebuild=no
 for LINE in $LINEZ; do
@@ -23,7 +23,7 @@ for LINE in $LINEZ; do
 	else
 		rebuild=yes
 		pushd sample-plugin/target/test-classes/test-dependencies
-		echo -n *.hpi | sed s/.hpi//g >../../../../target/plugins.txt
+		ls -1 *.hpi | sed s/.hpi//g >../../../../target/plugins.txt
 		popd
 	fi
 	pushd sample-plugin/target

--- a/updatecli/updatecli.d/weekly-apply.sh
+++ b/updatecli/updatecli.d/weekly-apply.sh
@@ -12,18 +12,16 @@ set -eux -o pipefail
 # if the parent pom is already built no need to rebuild the whole project (faster build time)
 existing_version=$(awk -F "[><]" 'NR == 17 && /jenkins.version/{print $3}' ./sample-plugin/pom.xml)
 
-if test "$1" == "${existing_version}"
-then
-  ## No change
-  # early return with no output
-  exit 0
+if test "$1" == "${existing_version}"; then
+	## No change
+	# early return with no output
+	exit 0
 else
-  if test "$DRY_RUN" == "false"
-  then
-    ## Value changed to $1" - NO dry run
-    sed -i -e "17s#<jenkins.version>[0-9.]\+</jenkins.version>#<jenkins.version>$1</jenkins.version>#" ./sample-plugin/pom.xml
-  fi
-  # Report on stdout
-  echo "$1"
-  exit 0
+	if test "${DRY_RUN}" == "false"; then
+		## Value changed to $1" - NO dry run
+		sed -i -e "17s#<jenkins.version>[0-9.]\+</jenkins.version>#<jenkins.version>$1</jenkins.version>#" ./sample-plugin/pom.xml
+	fi
+	# Report on stdout
+	echo "$1"
+	exit 0
 fi


### PR DESCRIPTION
While editing these shell scripts, I have noticed some inconsistent formatting and some minor `shellcheck(1)` violations in string quoting. This PR fixes both to make the scripts easier to edit and to make it easier to create new `shellcheck(1)`-clean PRs in the future. Best reviewed with the "ignore whitespace changes" option enabled.