### PR TITLE
Indent here-documents in a natural fashion

### DIFF
--- a/pct.sh
+++ b/pct.sh
@@ -35,13 +35,13 @@ elif grep -q -F -e '<status>TEST_FAILURES</status>' pct-report.xml; then
 	for t in pct-work/*/{,*/}target; do
 		if [ -f "${t}/test-classes/InjectedTest.class" ] && [ ! -f "${t}/surefire-reports/TEST-InjectedTest.xml" ]; then
 			mkdir -p "${t}/surefire-reports"
-			cat >"${t}/surefire-reports/TEST-pct.xml" <<'EOF'
-<testsuite name="pct">
-  <testcase classname="pct" name="overall">
-    <error message="some sort of PCT problem; look at logs"/>
-  </testcase>
-</testsuite>
-EOF
+			cat >"${t}/surefire-reports/TEST-pct.xml" <<-'EOF'
+				<testsuite name="pct">
+				  <testcase classname="pct" name="overall">
+				    <error message="some sort of PCT problem; look at logs"/>
+				  </testcase>
+				</testsuite>
+			EOF
 		fi
 	done
 fi


### PR DESCRIPTION
See [Here Documents](https://www.gnu.org/software/bash/manual/bash.html#Here-Documents) from the `bash(1)` documentation:

> If the redirection operator is `<<-`, then all leading tab characters are stripped from input lines and the line containing _delimiter._ This allows here-documents within shell scripts to be indented in a natural fashion.

As of #950 we are consistently using tab-based indentation, making it possible for us to avail ourselves of this feature.