### PR TITLE
Update `credentials`

### DIFF
--- a/bom-2.332.x/pom.xml
+++ b/bom-2.332.x/pom.xml
@@ -18,6 +18,11 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>credentials</artifactId>
+                <version>1087.v16065d268466</version>
+            </dependency>
+            <dependency>
                 <groupId>io.jenkins.plugins</groupId>
                 <artifactId>theme-manager</artifactId>
                 <version>0.6</version>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -192,7 +192,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>credentials</artifactId>
-                <version>1074.v60e6c29b_b_44b_</version>
+                <version>1111.v35a_307992395</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Supersedes #963. Picks up https://github.com/jenkinsci/credentials-plugin/pull/293 where available, without https://github.com/jenkinsci/credentials-plugin/pull/287 which requires weeklies.
