### PR TITLE
Embrace bashisms

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ PLUGINS=structs,mailer TEST=InjectedTest bash local-test.sh
 optionally also passing
 
 ```
-DOCKERIZED=yes
+DOCKERIZED=true
 ```
 
 to reproduce image-specific failures.

--- a/local-test.sh
+++ b/local-test.sh
@@ -7,10 +7,11 @@ cd "$(dirname "$0")"
 LATEST_LINE=weekly
 : "${LINE:=$LATEST_LINE}"
 
-export SAMPLE_PLUGIN_OPTS=-Dtest=InjectedTest
-if [ $LINE \!= $LATEST_LINE ]; then
-	export SAMPLE_PLUGIN_OPTS="${SAMPLE_PLUGIN_OPTS} -P${LINE}"
+SAMPLE_PLUGIN_OPTS=-Dtest=InjectedTest
+if [[ $LINE != "${LATEST_LINE}" ]]; then
+	SAMPLE_PLUGIN_OPTS+=" -P${LINE}"
 fi
+export SAMPLE_PLUGIN_OPTS
 LINEZ=$LINE bash prep.sh
 
 rm -rf target/local-test
@@ -18,13 +19,13 @@ mkdir target/local-test
 cp -v target/pct.jar pct.sh excludes.txt target/local-test
 cp -v target/megawar-$LINE.war target/local-test/megawar.war
 
-if [ -v TEST ]; then
+if [[ -v TEST ]]; then
 	EXTRA_MAVEN_PROPERTIES="test=${TEST}"
 else
 	EXTRA_MAVEN_PROPERTIES=
 fi
 
-if [ -v DOCKERIZED ]; then
+if [[ -v DOCKERIZED ]]; then
 	docker volume inspect m2repo || docker volume create m2repo
 	docker run \
 		-v ~/.m2:/var/maven/.m2 \

--- a/pct.sh
+++ b/pct.sh
@@ -6,14 +6,14 @@ cd "$(dirname "$0")"
 
 rm -rf pct-work pct-report.xml
 
-if [ -v MAVEN_SETTINGS ]; then
+if [[ -v MAVEN_SETTINGS ]]; then
 	PCT_S_ARG="-m2SettingsFile ${MAVEN_SETTINGS}"
 else
 	PCT_S_ARG=
 fi
 
 MAVEN_PROPERTIES=jth.jenkins-war.path=$(pwd)/megawar.war:forkCount=.75C:surefire.excludesFile=$(pwd)/excludes.txt
-if [ -v EXTRA_MAVEN_PROPERTIES ]; then
+if [[ -v EXTRA_MAVEN_PROPERTIES ]]; then
 	MAVEN_PROPERTIES="${MAVEN_PROPERTIES}:${EXTRA_MAVEN_PROPERTIES}"
 fi
 
@@ -33,7 +33,7 @@ if grep -q -F -e '<status>INTERNAL_ERROR</status>' pct-report.xml; then
 elif grep -q -F -e '<status>TEST_FAILURES</status>' pct-report.xml; then
 	echo PCT marked failed, checking to see if that is due to a failure to run tests at all
 	for t in pct-work/*/{,*/}target; do
-		if [ -f "${t}/test-classes/InjectedTest.class" ] && [ ! -f "${t}/surefire-reports/TEST-InjectedTest.xml" ]; then
+		if [[ -f "${t}/test-classes/InjectedTest.class" ]] && [[ ! -f "${t}/surefire-reports/TEST-InjectedTest.xml" ]]; then
 			mkdir -p "${t}/surefire-reports"
 			cat >"${t}/surefire-reports/TEST-pct.xml" <<-'EOF'
 				<testsuite name="pct">

--- a/prep.sh
+++ b/prep.sh
@@ -3,7 +3,7 @@ set -euxo pipefail
 cd "$(dirname "${0}")"
 
 MVN='mvn -B -ntp'
-if [ -v MAVEN_SETTINGS ]; then
+if [[ -v MAVEN_SETTINGS ]]; then
 	MVN="${MVN} -s ${MAVEN_SETTINGS}"
 fi
 
@@ -16,12 +16,12 @@ ALL_LINEZ=$(
 : "${LINEZ:=$ALL_LINEZ}"
 echo "${LINEZ}" >target/lines.txt
 
-rebuild=no
+rebuild=false
 for LINE in $LINEZ; do
-	if [ $rebuild = yes ]; then
+	if $rebuild; then
 		$MVN -f sample-plugin clean package ${SAMPLE_PLUGIN_OPTS:-} "-P${LINE}"
 	else
-		rebuild=yes
+		rebuild=true
 		pushd sample-plugin/target/test-classes/test-dependencies
 		ls -1 *.hpi | sed s/.hpi//g >../../../../target/plugins.txt
 		popd

--- a/updatecli/updatecli.d/weekly-apply.sh
+++ b/updatecli/updatecli.d/weekly-apply.sh
@@ -12,12 +12,12 @@ set -eux -o pipefail
 # if the parent pom is already built no need to rebuild the whole project (faster build time)
 existing_version=$(awk -F "[><]" 'NR == 17 && /jenkins.version/{print $3}' ./sample-plugin/pom.xml)
 
-if test "$1" == "${existing_version}"; then
+if [[ $1 == "${existing_version}" ]]; then
 	## No change
 	# early return with no output
 	exit 0
 else
-	if test "${DRY_RUN}" == "false"; then
+	if ! $DRY_RUN; then
 		## Value changed to $1" - NO dry run
 		sed -i -e "17s#<jenkins.version>[0-9.]\+</jenkins.version>#<jenkins.version>$1</jenkins.version>#" ./sample-plugin/pom.xml
 	fi


### PR DESCRIPTION
The scripts in this repository use `/bin/bash` as their interpreter, and they use bashisms in some places but not in others. I think embracing bashisms consistently throughout a script makes the script easier to read. [Articles like this](https://stackoverflow.com/questions/669452/are-double-square-brackets-preferable-over-single-square-brackets-in-b) point out that if you're going to be using `bash(1)` anyway, using its constructs like `[[` over `[` are generally safer and have fewer surprises.