### PR TITLE
Restore `support-core` to plugin BOM

### DIFF
--- a/bom-2.319.x/pom.xml
+++ b/bom-2.319.x/pom.xml
@@ -29,6 +29,11 @@
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>metrics</artifactId>
+                <version>4.1.6.1</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>script-security</artifactId>
                 <version>1138.v8e727069a_025</version>
             </dependency>

--- a/bom-2.319.x/pom.xml
+++ b/bom-2.319.x/pom.xml
@@ -33,6 +33,11 @@
                 <version>1138.v8e727069a_025</version>
             </dependency>
             <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>support-core</artifactId>
+                <version>2.80</version>
+            </dependency>
+            <dependency>
                 <groupId>org.jenkins-ci.plugins.workflow</groupId>
                 <artifactId>workflow-basic-steps</artifactId>
                 <version>2.24</version>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -318,7 +318,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>metrics</artifactId>
-                <version>4.1.6.1</version>
+                <version>4.1.6.2-rc355.fa_fe367a_f14c</version> <!-- TODO https://github.com/jenkinsci/metrics-plugin/pull/153 -->
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
@@ -411,6 +411,11 @@
                 <artifactId>subversion</artifactId>
                 <version>${subversion-plugin.version}</version>
                 <classifier>tests</classifier>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>support-core</artifactId>
+                <version>1153.vf5dc75a_1a_42e</version> <!-- TODO https://github.com/jenkinsci/support-core-plugin/pull/360 -->
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -318,7 +318,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>metrics</artifactId>
-                <version>4.1.6.2-rc355.fa_fe367a_f14c</version> <!-- TODO https://github.com/jenkinsci/metrics-plugin/pull/153 -->
+                <version>4.1.6.2</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
@@ -415,7 +415,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>support-core</artifactId>
-                <version>1153.vf5dc75a_1a_42e</version> <!-- TODO https://github.com/jenkinsci/support-core-plugin/pull/360 -->
+                <version>1158.v9189f64fec8c</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -325,6 +325,11 @@
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>support-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>text-finder</artifactId>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
Downstream of https://github.com/jenkinsci/metrics-plugin/pull/153 and https://github.com/jenkinsci/support-core-plugin/pull/360. Restores the `support-core` plugin that was temporarily removed in #1013 to facilitate the Jackson/Jersey dependency reversal. CC @jetersen