### PR TITLE
Add/update GitLab plugins

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -85,6 +85,16 @@
             </dependency>
             <dependency>
                 <groupId>io.jenkins.plugins</groupId>
+                <artifactId>gitlab-api</artifactId>
+                <version>5.0.1-69.vcdc19e779072</version>
+            </dependency>
+            <dependency>
+                <groupId>io.jenkins.plugins</groupId>
+                <artifactId>gitlab-branch-source</artifactId>
+                <version>623.vcc98dc4b_0ce4</version>
+            </dependency>
+            <dependency>
+                <groupId>io.jenkins.plugins</groupId>
                 <artifactId>javax-activation-api</artifactId>
                 <version>1.2.0-2</version>
             </dependency>
@@ -253,7 +263,17 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>gitlab-oauth</artifactId>
-                <version>1.15</version>
+                <version>1.16</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>gitlab-plugin</artifactId>
+                <version>1.5.30</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>handy-uri-templates-2-api</artifactId>
+                <version>2.1.8-1.0</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -111,7 +111,7 @@
             <dependency>
                 <groupId>io.jenkins.plugins</groupId>
                 <artifactId>jersey2-api</artifactId>
-                <version>2.35-6</version>
+                <version>2.35-7</version>
             </dependency>
             <dependency>
                 <groupId>io.jenkins.plugins</groupId>
@@ -268,7 +268,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>gitlab-plugin</artifactId>
-                <version>1.5.31-rc1394.2dc6e25da_537</version> <!-- TODO https://github.com/jenkinsci/gitlab-plugin/pull/1279 -->
+                <version>1.5.31</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -273,7 +273,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>handy-uri-templates-2-api</artifactId>
-                <version>2.1.8-2.0-rc21.df08d16e72dd</version> <!-- TODO https://github.com/jenkinsci/handy-uri-templates-2-api-plugin/pull/3 -->
+                <version>2.1.8-22.v77d5b_75e6953</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -268,12 +268,12 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>gitlab-plugin</artifactId>
-                <version>1.5.30</version>
+                <version>1.5.31-rc1394.2dc6e25da_537</version> <!-- TODO https://github.com/jenkinsci/gitlab-plugin/pull/1279 -->
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>handy-uri-templates-2-api</artifactId>
-                <version>2.1.8-1.0</version>
+                <version>2.1.8-2.0-rc21.df08d16e72dd</version> <!-- TODO https://github.com/jenkinsci/handy-uri-templates-2-api-plugin/pull/3 -->
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>

--- a/failFast
+++ b/failFast
@@ -1,1 +1,1 @@
-true
+false

--- a/failFast
+++ b/failFast
@@ -1,1 +1,1 @@
-false
+true

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -97,6 +97,11 @@
         </dependency>
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
+            <artifactId>gitlab-branch-source</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
             <artifactId>jaxb</artifactId>
             <scope>test</scope>
             <exclusions>
@@ -226,6 +231,11 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>gitlab-oauth</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>gitlab-plugin</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Now that the GitLab plugins have been refreshed, I get the sense that we're close to being able to add them to the BOM. Let's see how this test run goes.