### PR TITLE
Test on Java 17

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,7 +52,7 @@ lines.each {line ->
           retry(attempts) { // in case of transient node outages
             echo 'Attempt ' + ++attempt + ' of ' + attempts
             def jdk = line == 'weekly' ? 17 : 11
-            if (plugin == 'cloudbees-folder' || plugin == 'rebuild' || plugin == 'pipeline-utility-steps') {
+            if (plugin == 'ansicolor' || plugin == 'cloudbees-folder' || plugin == 'rebuild' || plugin == 'pipeline-utility-steps') {
                 // TODO plugin-pom 4.40+
                 jdk = 11
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,8 @@
 properties([disableConcurrentBuilds(abortPrevious: true)])
 
 def mavenEnv(Map params = [:], Closure body) {
-    node('maven-11') { // no Dockerized tests; https://github.com/jenkins-infra/documentation/blob/master/ci.adoc#container-agents
+    def agentContainerLabel = params['jdk'] == 8 ? 'maven' : 'maven-' + params['jdk']
+    node(agentContainerLabel) { // no Dockerized tests; https://github.com/jenkins-infra/documentation/blob/master/ci.adoc#container-agents
         timeout(90) {
             sh 'mvn -version'
             def settingsXml = "${pwd tmp: true}/settings-azure.xml"
@@ -23,7 +24,7 @@ def lines
 def failFast
 
 stage('prep') {
-    mavenEnv {
+    mavenEnv(jdk: 11) {
         checkout scm
         failFast = Boolean.parseBoolean(readFile('failFast').trim())
         withEnv(['SAMPLE_PLUGIN_OPTS=-Dset.changelist']) {
@@ -50,7 +51,12 @@ lines.each {line ->
           def attempts = 2
           retry(attempts) { // in case of transient node outages
             echo 'Attempt ' + ++attempt + ' of ' + attempts
-            mavenEnv(skipMarkingBuildUnstable: attempt < attempts) {
+            def jdk = line == 'weekly' ? 17 : 11
+            if (plugin == 'cloudbees-folder' || plugin == 'rebuild' || plugin == 'pipeline-utility-steps') {
+                // TODO plugin-pom 4.40+
+                jdk = 11
+            }
+            mavenEnv(jdk: jdk, skipMarkingBuildUnstable: attempt < attempts) {
                 deleteDir()
                 unstash 'pct.sh'
                 unstash 'excludes.txt'

--- a/pct.sh
+++ b/pct.sh
@@ -17,7 +17,18 @@ if [[ -v EXTRA_MAVEN_PROPERTIES ]]; then
 	MAVEN_PROPERTIES="${MAVEN_PROPERTIES}:${EXTRA_MAVEN_PROPERTIES}"
 fi
 
-java -jar pct.jar \
+#
+# Plugin Compatibility Tester (PCT) requires custom --add-opens directives when running on Java 17.
+# As a temporary workaround, we pass in these directives when invoking PCT. When
+# jenkinsci/plugin-compat-tester#352 is merged and released, and when this repository has upgraded
+# to that release, this workaround can be deleted.
+#
+java \
+	--add-opens java.base/java.lang.reflect=ALL-UNNAMED \
+	--add-opens java.base/java.text=ALL-UNNAMED \
+	--add-opens java.base/java.util=ALL-UNNAMED \
+	--add-opens java.desktop/java.awt.font=ALL-UNNAMED \
+	-jar pct.jar \
 	-war "$(pwd)/megawar.war" \
 	-includePlugins "${PLUGINS}" \
 	-workDirectory "$(pwd)/pct-work" \


### PR DESCRIPTION
### Problem

While we have announced [preview support for Java 17](https://www.jenkins.io/blog/2022/03/21/java17-preview-availability/), we do not yet regularly test plugins on Java 17. Not only does this mean that we lack confidence that these plugins work on Java 17, but also it means that any potential regressions in Java 17 support would not be detected by test automation.

### Solution

Run PCT for the BOM plugin set (which is nearly identical to the set of top 100 Jenkins plugins) on Java 17 for the weekly core line. Currently, we run PCT/BOM testing for two core lines: the oldest supported LTS line (at the time of current writing, 2.289.3) and newest weekly line (at the time of current writing, 2.345). Running the former with Java 11 and the latter with Java 17 gives us a nice matrix of test coverage without raising existing compute costs. Also note that no existing LTS lines support Java 17, so we could not run those tests on Java 17 even if we wanted to.

### Implementation

This PR contains two short-term workarounds; the comments in the PR explain why the workarounds are necessary. These comments also explain the conditions necessary for the workarounds to be removed: in both cases, these conditions require cooperation from maintainers of other repositories.