### PR TITLE
Support multi-module projects

### DIFF
--- a/pct.sh
+++ b/pct.sh
@@ -44,7 +44,8 @@ if grep -q -F -e '<status>INTERNAL_ERROR</status>' pct-report.xml; then
 elif grep -q -F -e '<status>TEST_FAILURES</status>' pct-report.xml; then
 	echo PCT marked failed, checking to see if that is due to a failure to run tests at all
 	for t in pct-work/*/{,*/}target; do
-		if [[ -f "${t}/test-classes/InjectedTest.class" ]] && [[ ! -f "${t}/surefire-reports/TEST-InjectedTest.xml" ]] && [[ ! -f "${t}/failsafe-reports/TEST-InjectedTest.xml" ]]; then
+		SHORT_NAME=$(echo "$t" | tr / '\n' | grep -v ^target$ | tail -1)
+		if [[ $PLUGINS =~ $SHORT_NAME ]] && [[ -f "${t}/test-classes/InjectedTest.class" ]] && [[ ! -f "${t}/surefire-reports/TEST-InjectedTest.xml" ]] && [[ ! -f "${t}/failsafe-reports/TEST-InjectedTest.xml" ]]; then
 			mkdir -p "${t}/surefire-reports"
 			cat >"${t}/surefire-reports/TEST-pct.xml" <<-'EOF'
 				<testsuite name="pct">


### PR DESCRIPTION
The logic in question failed to handle `pipeline-model-extensions`, a plugin that lives in a repository named `pipeline-model-definition` that also contains a different plugin named `pipeline-model-api`. When running the tests for `pipeline-model-extensions`, we'd compile `pipeline-model-api` but not run `pipeline-model-api`'s tests. This logic then erroneously marked the build as a failure. Instead we only mark the build as a failure if the test that failed was one of the tests we were trying to run in the first place.