### PR TITLE
Add Config File Provider to the managed set

### DIFF
--- a/bom-2.289.x/pom.xml
+++ b/bom-2.289.x/pom.xml
@@ -24,6 +24,11 @@
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>config-file-provider</artifactId>
+                <version>3.8.1</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>email-ext</artifactId>
                 <version>2.87</version>
             </dependency>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -221,6 +221,11 @@
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>config-file-provider</artifactId>
+                <version>3.10.0-rc855.d773fd29143a_</version> <!-- TODO https://github.com/jenkinsci/config-file-provider-plugin/pull/200 -->
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>credentials</artifactId>
                 <version>1126.ve05618c41e62</version>
             </dependency>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -222,7 +222,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>config-file-provider</artifactId>
-                <version>3.10.0-rc855.d773fd29143a_</version> <!-- TODO https://github.com/jenkinsci/config-file-provider-plugin/pull/200 -->
+                <version>3.10.0</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -214,6 +214,11 @@
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>config-file-provider</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials-binding</artifactId>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
This is needed for running JENKINS-45047 with `useUpperBounds` on `email-ext`.