### PR TITLE
`Jenkinsfile` simplifications

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,11 +1,10 @@
 properties([disableConcurrentBuilds(abortPrevious: true)])
 
 def mavenEnv(Map params = [:], Closure body) {
-    def agentContainerLabel = params['jdk'] == 8 ? 'maven' : 'maven-' + params['jdk']
-    node(agentContainerLabel) { // no Dockerized tests; https://github.com/jenkins-infra/documentation/blob/master/ci.adoc#container-agents
+    node("maven-$params.jdk") { // no Dockerized tests; https://github.com/jenkins-infra/documentation/blob/master/ci.adoc#container-agents
         timeout(90) {
             sh 'mvn -version'
-            def settingsXml = "${pwd tmp: true}/settings-azure.xml"
+            def settingsXml = "$WORKSPACE_TMP/settings.xml"
             def ok = infra.retrieveMavenSettingsFile(settingsXml)
             assert ok
             withEnv(["MAVEN_SETTINGS=$settingsXml"]) {


### PR DESCRIPTION
Mainly motivated by https://github.com/jenkinsci/bom/pull/1084#discussion_r869542040: since we can no longer build using JDK 8 (and do not try), no need to even have code to handle that case.

(Anyway https://ci.jenkins.io/label/maven-8/ exists.)