### PR TITLE
Execute bash from path in she-bang

### DIFF
--- a/local-test.sh
+++ b/local-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euxo pipefail
 cd "$(dirname "$0")"
 

--- a/pct.sh
+++ b/pct.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euxo pipefail
 cd "$(dirname "$0")"
 

--- a/prep.sh
+++ b/prep.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euxo pipefail
 cd "$(dirname "${0}")"
 

--- a/updatecli/updatecli.d/update-plugins.sh
+++ b/updatecli/updatecli.d/update-plugins.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eux -o pipefail
 

--- a/updatecli/updatecli.d/weekly-apply.sh
+++ b/updatecli/updatecli.d/weekly-apply.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eux -o pipefail
 


### PR DESCRIPTION
macOS ships with bash 3.x and has no plans to update it.

At least prep.sh uses newer bash syntax.

It was hardcoded to use `bin/bash` in the she-bang which isn't recommended

I've updated it to look in the user's `PATH` instead

```
➜  bom git:(re-test-project-configure-page) ✗ /bin/bash --version
GNU bash, version 3.2.57(1)-release (arm64-apple-darwin21)
Copyright (C) 2007 Free Software Foundation, Inc.
➜  bom git:(re-test-project-configure-page) ✗ bash --version
GNU bash, version 5.1.0(1)-release (x86_64-apple-darwin20.1.0)
Copyright (C) 2020 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>

This is free software; you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
```