### PR TITLE
Support Bash 3.2

### DIFF
--- a/local-test.sh
+++ b/local-test.sh
@@ -19,13 +19,13 @@ mkdir target/local-test
 cp -v target/pct.jar pct.sh excludes.txt target/local-test
 cp -v target/megawar-$LINE.war target/local-test/megawar.war
 
-if [[ -v TEST ]]; then
+if [[ -n ${TEST-} ]]; then
 	EXTRA_MAVEN_PROPERTIES="test=${TEST}"
 else
 	EXTRA_MAVEN_PROPERTIES=
 fi
 
-if [[ -v DOCKERIZED ]]; then
+if [[ -n ${DOCKERIZED-} ]]; then
 	docker volume inspect m2repo || docker volume create m2repo
 	docker run \
 		-v ~/.m2:/var/maven/.m2 \

--- a/pct.sh
+++ b/pct.sh
@@ -6,14 +6,14 @@ cd "$(dirname "$0")"
 
 rm -rf pct-work pct-report.xml
 
-if [[ -v MAVEN_SETTINGS ]]; then
+if [[ -n ${MAVEN_SETTINGS-} ]]; then
 	PCT_S_ARG="-m2SettingsFile ${MAVEN_SETTINGS}"
 else
 	PCT_S_ARG=
 fi
 
 MAVEN_PROPERTIES=jth.jenkins-war.path=$(pwd)/megawar.war:forkCount=.75C:surefire.excludesFile=$(pwd)/excludes.txt
-if [[ -v EXTRA_MAVEN_PROPERTIES ]]; then
+if [[ -n ${EXTRA_MAVEN_PROPERTIES-} ]]; then
 	MAVEN_PROPERTIES="${MAVEN_PROPERTIES}:${EXTRA_MAVEN_PROPERTIES}"
 fi
 

--- a/prep.sh
+++ b/prep.sh
@@ -3,7 +3,7 @@ set -euxo pipefail
 cd "$(dirname "${0}")"
 
 MVN='mvn -B -ntp'
-if [[ -v MAVEN_SETTINGS ]]; then
+if [[ -n ${MAVEN_SETTINGS-} ]]; then
 	MVN="${MVN} -s ${MAVEN_SETTINGS}"
 fi
 


### PR DESCRIPTION
The `-v` operator to check if a name has been set to a value requires Bash 4.2 or newer. Macs still ship with Bash 3.2. This PR makes these script usable on Macs by switching to an older syntax. The use of the dash is explained in the "Rewriting scripts to deal with it" section of [Bash FAQ #112](https://mywiki.wooledge.org/BashFAQ/112).