### PR TITLE
build: Unpin junit-attachment plugin

### DIFF
--- a/bom-2.332.x/pom.xml
+++ b/bom-2.332.x/pom.xml
@@ -32,11 +32,6 @@
                 <artifactId>credentials</artifactId>
                 <version>1087.1089.v2f1b_9a_b_040e4</version>
             </dependency>
-            <dependency> <!-- TODO pending 2.332.3 in sample-plugin (once 2.346.1 released), or baseline reverted to 2.332.1 -->
-                <groupId>org.jenkins-ci.plugins</groupId>
-                <artifactId>junit-attachments</artifactId>
-                <version>95.v69691d523620</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -333,7 +333,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>junit-attachments</artifactId>
-                <version>97.v93b_02b_575a_dd</version>
+                <version>101.v82f494a_00e9e</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
The plugin baseline has been reverted to 2.332.1, should be good to lift the restriction here again.