### PR TITLE
Dependabot/maven/bom weekly/io.jenkins.plugins popper2 api 2.11.5 2

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -31,7 +31,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check interesting categories
-        uses: jenkins-infra/interesting-category-action@v1.1.0
+        uses: jenkins-infra/interesting-category-action@v1.2.0
         id: interesting-categories
         if: steps.verify-ci-status.outputs.result == 'success'
         with:

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -8,52 +8,8 @@ on:
       - completed
 
 jobs:
-  validate:
-    runs-on: ubuntu-latest
-    outputs:
-      should_release: ${{ steps.verify-ci-status.outputs.result == 'success' && steps.interesting-categories.outputs.interesting == 'true' }}
-    steps:
-      - name: Verify CI status
-        uses: jenkins-infra/verify-ci-status-action@v1.2.0
-        id: verify-ci-status
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          output_result: true
-
-      - name: Release Drafter
-        uses: release-drafter/release-drafter@v5
-        if: steps.verify-ci-status.outputs.result == 'success'
-        with:
-          name: next
-          tag: next
-          version: next
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Check interesting categories
-        uses: jenkins-infra/interesting-category-action@v1.2.0
-        id: interesting-categories
-        if: steps.verify-ci-status.outputs.result == 'success'
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  release:
-    runs-on: ubuntu-latest
-    needs: [validate]
-    if: needs.validate.outputs.should_release == 'true'
-    steps:
-    - name: Check out
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-    - name: Set up JDK 8
-      uses: actions/setup-java@v3
-      with:
-        distribution: 'temurin'
-        java-version: 8
-    - name: Release
-      uses: jenkins-infra/jenkins-maven-cd-action@v1.3.0
-      with:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
-        MAVEN_TOKEN: ${{ secrets.MAVEN_TOKEN }}
+  maven-cd:
+    uses: jenkins-infra/github-reusable-workflows/.github/workflows/maven-cd.yml@v1
+    secrets:
+      MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+      MAVEN_TOKEN: ${{ secrets.MAVEN_TOKEN }}

--- a/bom-2.303.x/pom.xml
+++ b/bom-2.303.x/pom.xml
@@ -24,6 +24,11 @@
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>cloudbees-folder</artifactId>
+                <version>6.722.v8165b_a_cf25e9</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>credentials</artifactId>
                 <version>2.6.1.1</version>
             </dependency>

--- a/bom-2.319.x/pom.xml
+++ b/bom-2.319.x/pom.xml
@@ -116,6 +116,11 @@
                 <artifactId>pipeline-stage-tags-metadata</artifactId>
                 <version>1.9.3</version>
             </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>junit-attachments</artifactId>
+                <version>95.v69691d523620</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/bom-2.319.x/pom.xml
+++ b/bom-2.319.x/pom.xml
@@ -59,6 +59,17 @@
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins.workflow</groupId>
+                <artifactId>workflow-api</artifactId>
+                <version>1153.vb_912c0e47fb_a_</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins.workflow</groupId>
+                <artifactId>workflow-api</artifactId>
+                <version>1153.vb_912c0e47fb_a_</version>
+                <classifier>tests</classifier>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins.workflow</groupId>
                 <artifactId>workflow-cps</artifactId>
                 <version>2660.vb_c0412dc4e6d</version>
             </dependency>
@@ -67,6 +78,11 @@
                 <artifactId>workflow-cps</artifactId>
                 <version>2660.vb_c0412dc4e6d</version>
                 <classifier>tests</classifier>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins.workflow</groupId>
+                <artifactId>workflow-durable-task-step</artifactId>
+                <version>1139.v252a_e12e8463</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/bom-2.319.x/pom.xml
+++ b/bom-2.319.x/pom.xml
@@ -29,6 +29,11 @@
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>ldap</artifactId>
+                <version>2.9</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>metrics</artifactId>
                 <version>4.1.6.1</version>
             </dependency>

--- a/bom-2.319.x/pom.xml
+++ b/bom-2.319.x/pom.xml
@@ -19,6 +19,11 @@
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>command-launcher</artifactId>
+                <version>81.v9c2cb_cb_db_392</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>display-url-api</artifactId>
                 <version>2.3.5</version>
             </dependency>

--- a/bom-2.332.x/pom.xml
+++ b/bom-2.332.x/pom.xml
@@ -32,6 +32,11 @@
                 <artifactId>credentials</artifactId>
                 <version>1087.1089.v2f1b_9a_b_040e4</version>
             </dependency>
+            <dependency> <!-- TODO pending 2.332.3 in sample-plugin (once 2.346.1 released), or baseline reverted to 2.332.1 -->
+                <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>junit-attachments</artifactId>
+                <version>95.v69691d523620</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/bom-2.332.x/pom.xml
+++ b/bom-2.332.x/pom.xml
@@ -32,11 +32,6 @@
                 <artifactId>credentials</artifactId>
                 <version>1087.1089.v2f1b_9a_b_040e4</version>
             </dependency>
-            <dependency> <!-- TODO pending 2.332.3 in sample-plugin (once 2.346.1 released), or baseline reverted to 2.332.1 -->
-                <groupId>org.jenkins-ci.plugins</groupId>
-                <artifactId>junit-attachments</artifactId>
-                <version>95.v69691d523620</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -419,7 +419,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>script-security</artifactId>
-                <version>1172.v35f6a_0b_8207e</version>
+                <version>1175.v4b_d517d6db_f0</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -537,7 +537,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins.workflow</groupId>
                 <artifactId>workflow-cps-global-lib</artifactId>
-                <version>581.ve633085a_8a_87</version>
+                <version>583.vf3b_454e43966</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -18,7 +18,7 @@
         <subversion-plugin.version>2.15.5</subversion-plugin.version>
         <workflow-api-plugin.version>1153.vb_912c0e47fb_a_</workflow-api-plugin.version>
         <workflow-cps-plugin.version>2692.v76b_089ccd026</workflow-cps-plugin.version>
-        <workflow-job-plugin.version>1181.va_25d15548158</workflow-job-plugin.version>
+        <workflow-job-plugin.version>1182.v60a_e6279b_579</workflow-job-plugin.version>
         <workflow-multibranch-plugin.version>712.vc169a_1387405</workflow-multibranch-plugin.version>
         <workflow-step-api-plugin.version>625.vd896b_f445a_f8</workflow-step-api-plugin.version>
         <workflow-support-plugin.version>820.vd1a_6cc65ef33</workflow-support-plugin.version>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -126,7 +126,7 @@
             <dependency>
                 <groupId>io.jenkins.plugins</groupId>
                 <artifactId>jjwt-api</artifactId>
-                <version>0.11.2-71.v2722b_b_06a_2a_f</version>
+                <version>0.11.5-77.v646c772fddb_0</version>
             </dependency>
             <dependency>
                 <groupId>io.jenkins.plugins</groupId>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -232,7 +232,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>credentials</artifactId>
-                <version>1126.ve05618c41e62</version>
+                <version>1129.vef26f5df883c</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -12,14 +12,14 @@
         <checks-api.version>1.7.4</checks-api.version>
         <configuration-as-code-plugin.version>1429.v09b_044a_c93de</configuration-as-code-plugin.version>
         <git-plugin.version>4.11.3</git-plugin.version>
-        <pipeline-model-definition-plugin.version>2.2081.v3919681ffc1e</pipeline-model-definition-plugin.version>
+        <pipeline-model-definition-plugin.version>2.2086.v12b_420f036e5</pipeline-model-definition-plugin.version>
         <pipeline-stage-view-plugin.version>2.24</pipeline-stage-view-plugin.version>
         <scm-api-plugin.version>608.vfa_f971c5a_a_e9</scm-api-plugin.version>
         <subversion-plugin.version>2.15.5</subversion-plugin.version>
         <workflow-api-plugin.version>1153.vb_912c0e47fb_a_</workflow-api-plugin.version>
         <workflow-cps-plugin.version>2692.v76b_089ccd026</workflow-cps-plugin.version>
         <workflow-job-plugin.version>1182.v60a_e6279b_579</workflow-job-plugin.version>
-        <workflow-multibranch-plugin.version>712.vc169a_1387405</workflow-multibranch-plugin.version>
+        <workflow-multibranch-plugin.version>716.vc692a_e52371b_</workflow-multibranch-plugin.version>
         <workflow-step-api-plugin.version>625.vd896b_f445a_f8</workflow-step-api-plugin.version>
         <workflow-support-plugin.version>820.vd1a_6cc65ef33</workflow-support-plugin.version>
         <plugin-util-api.version>2.16.0</plugin-util-api.version>
@@ -137,6 +137,11 @@
                 <groupId>io.jenkins.plugins</groupId>
                 <artifactId>okhttp-api</artifactId>
                 <version>4.9.2-20211102</version>
+            </dependency>
+            <dependency>
+                <groupId>io.jenkins.plugins</groupId>
+                <artifactId>pipeline-groovy-lib</artifactId>
+                <version>591.v3a_7f422b_d058</version>
             </dependency>
             <dependency>
                 <groupId>io.jenkins.plugins</groupId>
@@ -537,7 +542,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins.workflow</groupId>
                 <artifactId>workflow-cps-global-lib</artifactId>
-                <version>583.vf3b_454e43966</version>
+                <version>588.v576c103a_ff86</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -293,7 +293,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>gitlab-plugin</artifactId>
-                <version>1.5.32</version>
+                <version>1.5.33</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -333,7 +333,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>ldap</artifactId>
-                <version>2.9</version>
+                <version>2.10</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -333,7 +333,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>junit-attachments</artifactId>
-                <version>95.v69691d523620</version>
+                <version>97.v93b_02b_575a_dd</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -16,9 +16,9 @@
         <pipeline-stage-view-plugin.version>2.24</pipeline-stage-view-plugin.version>
         <scm-api-plugin.version>608.vfa_f971c5a_a_e9</scm-api-plugin.version>
         <subversion-plugin.version>2.15.5</subversion-plugin.version>
-        <workflow-api-plugin.version>1153.vb_912c0e47fb_a_</workflow-api-plugin.version>
-        <workflow-cps-plugin.version>2706.v71dd22b_c5a_a_2</workflow-cps-plugin.version>
-        <workflow-job-plugin.version>1182.v60a_e6279b_579</workflow-job-plugin.version>
+        <workflow-api-plugin.version>1164.v760c223ddb_32</workflow-api-plugin.version>
+        <workflow-cps-plugin.version>2725.v7b_c717eb_12ce</workflow-cps-plugin.version>
+        <workflow-job-plugin.version>1186.v8def1a_5f3944</workflow-job-plugin.version>
         <workflow-multibranch-plugin.version>716.vc692a_e52371b_</workflow-multibranch-plugin.version>
         <workflow-step-api-plugin.version>625.vd896b_f445a_f8</workflow-step-api-plugin.version>
         <workflow-support-plugin.version>820.vd1a_6cc65ef33</workflow-support-plugin.version>
@@ -547,7 +547,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins.workflow</groupId>
                 <artifactId>workflow-durable-task-step</artifactId>
-                <version>1139.v252a_e12e8463</version>
+                <version>1144.vd77b_57189936</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -177,7 +177,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.modules</groupId>
                 <artifactId>sshd</artifactId>
-                <version>3.236.ved5e1b_cb_50b_2</version>
+                <version>3.237.v883d165a_c1d3</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -71,7 +71,7 @@
             <dependency>
                 <groupId>io.jenkins.plugins</groupId>
                 <artifactId>dark-theme</artifactId>
-                <version>180.vff872db_1b_de6</version>
+                <version>183.vcf51f72075b_8</version>
             </dependency>
             <dependency>
                 <groupId>io.jenkins.plugins</groupId>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -17,7 +17,7 @@
         <scm-api-plugin.version>608.vfa_f971c5a_a_e9</scm-api-plugin.version>
         <subversion-plugin.version>2.15.5</subversion-plugin.version>
         <workflow-api-plugin.version>1153.vb_912c0e47fb_a_</workflow-api-plugin.version>
-        <workflow-cps-plugin.version>2692.v76b_089ccd026</workflow-cps-plugin.version>
+        <workflow-cps-plugin.version>2706.v71dd22b_c5a_a_2</workflow-cps-plugin.version>
         <workflow-job-plugin.version>1182.v60a_e6279b_579</workflow-job-plugin.version>
         <workflow-multibranch-plugin.version>716.vc692a_e52371b_</workflow-multibranch-plugin.version>
         <workflow-step-api-plugin.version>625.vd896b_f445a_f8</workflow-step-api-plugin.version>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -333,7 +333,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>junit-attachments</artifactId>
-                <version>97.v93b_02b_575a_dd</version>
+                <version>101.v82f494a_00e9e</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -222,7 +222,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>command-launcher</artifactId>
-                <version>81.v9c2cb_cb_db_392</version>
+                <version>84.v4a_97f2027398</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -393,7 +393,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>pipeline-utility-steps</artifactId>
-                <version>2.12.1</version>
+                <version>2.12.2</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -172,7 +172,7 @@
             <dependency>
                 <groupId>io.jenkins.plugins</groupId>
                 <artifactId>theme-manager</artifactId>
-                <version>1.2</version>
+                <version>1.4</version>
             </dependency>
             <dependency>
                 <groupId>org.6wind.jenkins</groupId>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -162,7 +162,7 @@
             <dependency>
                 <groupId>io.jenkins.plugins</groupId>
                 <artifactId>popper2-api</artifactId>
-                <version>2.11.5-1</version>
+                <version>2.11.5-2</version>
             </dependency>
             <dependency>
                 <groupId>io.jenkins.plugins</groupId>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -547,7 +547,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins.workflow</groupId>
                 <artifactId>workflow-durable-task-step</artifactId>
-                <version>1144.vd77b_57189936</version>
+                <version>1146.v1a_d2e603f929</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -141,7 +141,7 @@
             <dependency>
                 <groupId>io.jenkins.plugins</groupId>
                 <artifactId>pipeline-groovy-lib</artifactId>
-                <version>591.v3a_7f422b_d058</version>
+                <version>593.va_a_fc25d520e9</version>
             </dependency>
             <dependency>
                 <groupId>io.jenkins.plugins</groupId>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -177,7 +177,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.modules</groupId>
                 <artifactId>sshd</artifactId>
-                <version>3.228.v4c9f9e652c86</version>
+                <version>3.236.ved5e1b_cb_50b_2</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -217,7 +217,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>cloudbees-folder</artifactId>
-                <version>6.722.v8165b_a_cf25e9</version>
+                <version>6.729.v2b_9d1a_74d673</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -328,7 +328,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>junit</artifactId>
-                <version>1.63</version>
+                <version>1119.va_a_5e9068da_d7</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -71,7 +71,7 @@
             <dependency>
                 <groupId>io.jenkins.plugins</groupId>
                 <artifactId>dark-theme</artifactId>
-                <version>183.vcf51f72075b_8</version>
+                <version>185.v276b_5a_8966a_e</version>
             </dependency>
             <dependency>
                 <groupId>io.jenkins.plugins</groupId>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -408,7 +408,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>saml</artifactId>
-                <version>2.297.v1a_dff8e51f90</version>
+                <version>2.298.vc7a_2b_3958628</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
         <bom>weekly</bom>
-        <jenkins.version>2.350</jenkins.version>
+        <jenkins.version>2.354</jenkins.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -131,6 +131,11 @@
         </dependency>
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
+            <artifactId>pipeline-groovy-lib</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
             <artifactId>plugin-util-api</artifactId>
             <scope>test</scope>
         </dependency>

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
         <bom>weekly</bom>
-        <jenkins.version>2.348</jenkins.version>
+        <jenkins.version>2.349</jenkins.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
         <bom>weekly</bom>
-        <jenkins.version>2.349</jenkins.version>
+        <jenkins.version>2.350</jenkins.version>
     </properties>
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
Followup to https://github.com/jenkinsci/bom/pull/1154 with frozen version of popper2 for 2.303.x (2.11.5-1).