### PR TITLE
Update UI libraries for Jenkins 2.303.x and 2.319.x.

### DIFF
--- a/bom-2.303.x/pom.xml
+++ b/bom-2.303.x/pom.xml
@@ -39,6 +39,11 @@
             </dependency>
             <dependency>
                 <groupId>io.jenkins.plugins</groupId>
+                <artifactId>echarts-api</artifactId>
+                <version>5.3.2-1</version>
+            </dependency>
+            <dependency>
+                <groupId>io.jenkins.plugins</groupId>
                 <artifactId>font-awesome-api</artifactId>
                 <version>6.0.0-1</version>
             </dependency>

--- a/bom-2.303.x/pom.xml
+++ b/bom-2.303.x/pom.xml
@@ -64,6 +64,17 @@
             </dependency>
             <dependency>
                 <groupId>io.jenkins.plugins</groupId>
+                <artifactId>plugin-util-api</artifactId>
+                <version>2.16.0</version>
+            </dependency>
+            <dependency>
+                <groupId>io.jenkins.plugins</groupId>
+                <artifactId>plugin-util-api</artifactId>
+                <version>2.16.0</version>
+                <classifier>tests</classifier>
+            </dependency>
+            <dependency>
+                <groupId>io.jenkins.plugins</groupId>
                 <artifactId>popper2-api</artifactId>
                 <version>2.11.5-1</version>
             </dependency>

--- a/bom-2.303.x/pom.xml
+++ b/bom-2.303.x/pom.xml
@@ -38,6 +38,11 @@
                 <version>1.27.1</version>
             </dependency>
             <dependency>
+                <groupId>io.jenkins.plugins</groupId>
+                <artifactId>jquery3-api</artifactId>
+                <version>3.6.0-3</version>
+            </dependency>
+            <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>metrics</artifactId>
                 <version>4.0.2.8.1</version>

--- a/bom-2.303.x/pom.xml
+++ b/bom-2.303.x/pom.xml
@@ -18,6 +18,11 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
+                <groupId>io.jenkins.plugins</groupId>
+                <artifactId>bootstrap5-api</artifactId>
+                <version>5.1.3-6</version>
+            </dependency>
+            <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>bouncycastle-api</artifactId>
                 <version>2.25</version>

--- a/bom-2.303.x/pom.xml
+++ b/bom-2.303.x/pom.xml
@@ -39,6 +39,11 @@
             </dependency>
             <dependency>
                 <groupId>io.jenkins.plugins</groupId>
+                <artifactId>font-awesome-api</artifactId>
+                <version>6.0.0-1</version>
+            </dependency>
+            <dependency>
+                <groupId>io.jenkins.plugins</groupId>
                 <artifactId>jquery3-api</artifactId>
                 <version>3.6.0-3</version>
             </dependency>

--- a/bom-2.303.x/pom.xml
+++ b/bom-2.303.x/pom.xml
@@ -43,6 +43,11 @@
                 <version>4.0.2.8.1</version>
             </dependency>
             <dependency>
+                <groupId>io.jenkins.plugins</groupId>
+                <artifactId>popper2-api</artifactId>
+                <version>2.11.5-1</version>
+            </dependency>
+            <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>ssh-slaves</artifactId>
                 <version>1.806.v2253cedd3295</version>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -162,7 +162,7 @@
             <dependency>
                 <groupId>io.jenkins.plugins</groupId>
                 <artifactId>popper2-api</artifactId>
-                <version>2.11.5-1</version>
+                <version>2.11.5-2</version>
             </dependency>
             <dependency>
                 <groupId>io.jenkins.plugins</groupId>


### PR DESCRIPTION
Followup for dependabot updates:
- https://github.com/jenkinsci/bom/pull/1152
- https://github.com/jenkinsci/bom/pull/1154
- https://github.com/jenkinsci/bom/pull/1155
- https://github.com/jenkinsci/bom/pull/1156
- https://github.com/jenkinsci/bom/pull/1157 
- https://github.com/jenkinsci/bom/pull/1195 

Adds the missing frozen version for 2.303.x