### PR TITLE
Bump version of data-tables-api to 1.12.1-1

### DIFF
--- a/bom-2.303.x/pom.xml
+++ b/bom-2.303.x/pom.xml
@@ -75,6 +75,11 @@
             </dependency>
             <dependency>
                 <groupId>io.jenkins.plugins</groupId>
+                <artifactId>data-tables-api</artifactId>
+                <version>1.11.4-4</version>
+            </dependency>
+            <dependency>
+                <groupId>io.jenkins.plugins</groupId>
                 <artifactId>forensics-api</artifactId>
                 <version>1.13.0</version>
             </dependency>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -11,6 +11,7 @@
     <properties>
         <checks-api.version>1.7.4</checks-api.version>
         <configuration-as-code-plugin.version>1429.v09b_044a_c93de</configuration-as-code-plugin.version>
+        <data-tables-api.version>1.12.1-1</data-tables-api.version>
         <forensics-api.version>1.15.1</forensics-api.version>
         <git-plugin.version>4.11.3</git-plugin.version>
         <pipeline-model-definition-plugin.version>2.2097.v33db_b_de764b_e</pipeline-model-definition-plugin.version>
@@ -77,7 +78,13 @@
             <dependency>
                 <groupId>io.jenkins.plugins</groupId>
                 <artifactId>data-tables-api</artifactId>
-                <version>1.11.4-4</version>
+                <version>${data-tables-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.jenkins.plugins</groupId>
+                <artifactId>data-tables-api</artifactId>
+                <version>${data-tables-api.version}</version>
+                <classifier>tests</classifier>
             </dependency>
             <dependency>
                 <groupId>io.jenkins.plugins</groupId>


### PR DESCRIPTION
Since this release requires Jenkins 2.319.x the version for 2.303.x has been frozen to 1.11.4-4. Additionally, the tests classifier has been added as additional artefact, since a couple of plugins use the test assertions as well.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
