### PR TITLE
chore: Bump 2.346 profile to .1 and bump 2.332 to .4

### DIFF
--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -515,14 +515,14 @@
             <id>2.346.x</id>
             <properties>
                 <bom>2.346.x</bom>
-                <jenkins.version>2.346</jenkins.version>
+                <jenkins.version>2.346.1</jenkins.version>
             </properties>
         </profile>
         <profile>
             <id>2.332.x</id>
             <properties>
                 <bom>2.332.x</bom>
-                <jenkins.version>2.332.1</jenkins.version>
+                <jenkins.version>2.332.4</jenkins.version>
             </properties>
         </profile>
         <profile>


### PR DESCRIPTION
The PR bumps the latest LTS release to the first point release and bumps the second last LTS release to the final security release.