### PR TITLE
[JENKINS-49707] Retry `node` block after infrastructure outages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ properties([disableConcurrentBuilds(abortPrevious: true)])
 def mavenEnv(Map params = [:], Closure body) {
   def attempt = 0
   def attempts = 2
-  retry(attempts, conditions: [kubernetesAgent(), nonresumable()]) {
+  retry(count: attempts, conditions: [kubernetesAgent(), nonresumable()]) {
     echo 'Attempt ' + ++attempt + ' of ' + attempts
     node("maven-$params.jdk") { // no Dockerized tests; https://github.com/jenkins-infra/documentation/blob/master/ci.adoc#container-agents
         timeout(90) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,10 @@
 properties([disableConcurrentBuilds(abortPrevious: true)])
 
 def mavenEnv(Map params = [:], Closure body) {
+  def attempt = 0
+  def attempts = 2
+  retry(attempts, conditions: [kubernetesAgent(), nonresumable()]) {
+    echo 'Attempt ' + ++attempt + ' of ' + attempts
     node("maven-$params.jdk") { // no Dockerized tests; https://github.com/jenkins-infra/documentation/blob/master/ci.adoc#container-agents
         timeout(90) {
             sh 'mvn -version'
@@ -10,12 +14,13 @@ def mavenEnv(Map params = [:], Closure body) {
             withEnv(["MAVEN_SETTINGS=$settingsXml"]) {
                 body()
             }
-            if (junit(testResults: '**/target/surefire-reports/TEST-*.xml', allowEmptyResults: true, skipMarkingBuildUnstable: !!params['skipMarkingBuildUnstable']).failCount > 0) {
+            if (junit(testResults: '**/target/surefire-reports/TEST-*.xml', allowEmptyResults: true).failCount > 0) {
                 // TODO JENKINS-27092 throw up UNSTABLE status in this case
                 error 'Some test failures, not going to continue'
             }
         }
     }
+  }
 }
 
 def plugins
@@ -46,16 +51,12 @@ branches = [failFast: failFast]
 lines.each {line ->
     plugins.each { plugin ->
         branches["pct-$plugin-$line"] = {
-          def attempt = 0
-          def attempts = 2
-          retry(attempts) { // in case of transient node outages
-            echo 'Attempt ' + ++attempt + ' of ' + attempts
             def jdk = line == 'weekly' ? 17 : 11
             if (plugin == 'ansicolor') {
                 // TODO plugin-pom 4.40+
                 jdk = 11
             }
-            mavenEnv(jdk: jdk, skipMarkingBuildUnstable: attempt < attempts) {
+            mavenEnv(jdk: jdk) {
                 deleteDir()
                 unstash 'pct.sh'
                 unstash 'excludes.txt'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -66,7 +66,6 @@ lines.each {line ->
                     sh 'mv megawar-$LINE.war megawar.war && bash pct.sh'
                 }
             }
-          }
         }
     }
 }


### PR DESCRIPTION
Analogous to https://github.com/jenkins-infra/pipeline-library/pull/405. Should be possible as of https://github.com/jenkins-infra/helpdesk/issues/2984#issuecomment-1176418097.

Probably also solves https://github.com/jenkins-infra/helpdesk/issues/3031#issuecomment-1175343746.

Amends a `retry` added initially in #339, retaining extra logging from #592.

Deliberately removes fix from #597 since what we are handling here is _infrastructure_ problems, not flaky tests. If we want to _also_ handle flaky tests, https://maven.apache.org/surefire/maven-surefire-plugin/examples/rerun-failing-tests.html would be more appropriate. See #614.
