### PR TITLE
Update `workflow-cps` & `workflow-job` in 2.346.x+ for icon-related changes

### DIFF
--- a/bom-2.332.x/pom.xml
+++ b/bom-2.332.x/pom.xml
@@ -37,6 +37,17 @@
                 <artifactId>ssh-credentials</artifactId>
                 <version>277.v95c2fec1c047</version>
             </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins.workflow</groupId>
+                <artifactId>workflow-cps</artifactId>
+                <version>2729.vea_17b_79ed57a_</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins.workflow</groupId>
+                <artifactId>workflow-cps</artifactId>
+                <version>2729.vea_17b_79ed57a_</version>
+                <classifier>tests</classifier>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -21,7 +21,7 @@
         <scm-api-plugin.version>608.vfa_f971c5a_a_e9</scm-api-plugin.version>
         <subversion-plugin.version>2.15.5</subversion-plugin.version>
         <workflow-api-plugin.version>1182.v41475e53ea_43</workflow-api-plugin.version>
-        <workflow-cps-plugin.version>2729.vea_17b_79ed57a_</workflow-cps-plugin.version>
+        <workflow-cps-plugin.version>2746.v0da_83a_332669</workflow-cps-plugin.version>
         <workflow-job-plugin.version>1189.va_d37a_e9e4eda_</workflow-job-plugin.version>
         <workflow-multibranch-plugin.version>716.vc692a_e52371b_</workflow-multibranch-plugin.version>
         <workflow-step-api-plugin.version>625.vd896b_f445a_f8</workflow-step-api-plugin.version>


### PR DESCRIPTION
Subsumes #1253 & #1254 (which would otherwise conflict with one another).
