### PR TITLE
Bump `mailer` in weekly to reflect `instance-identity` dep

### DIFF
--- a/bom-2.346.x/pom.xml
+++ b/bom-2.346.x/pom.xml
@@ -19,6 +19,11 @@
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>mailer</artifactId>
+                <version>435.v79ef3972b_5c7</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>matrix-project</artifactId>
                 <version>772.v494f19991984</version>
             </dependency>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -393,7 +393,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>mailer</artifactId>
-                <version>435.v79ef3972b_5c7</version>
+                <version>438.v02c7f0a_12fa_4</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>

--- a/sample-plugin/check.groovy
+++ b/sample-plugin/check.groovy
@@ -45,6 +45,9 @@ project.artifacts.each { art ->
     if (plugin == null) {
         return
     }
+    if (plugin == 'instance-identity') {
+        return // JEP-230
+    }
     for (String intermediate : art.dependencyTrail.drop(1).dropRight(1).collect {stripAllButGA(it)}) {
         def intermediateArt = artifactMap[intermediate]
         if (intermediateArt == null) {


### PR DESCRIPTION
Supersedes #1282; picks up https://github.com/jenkinsci/mailer-plugin/pull/182.