### PR TITLE
[JENKINS-45047] Migrate from PCT `org.jenkins.tools.test.hook.TransformPom` to HPI plugin `overrideWar`

### DIFF
--- a/pct.sh
+++ b/pct.sh
@@ -54,12 +54,6 @@ if [[ $LINE == '2.319.x' ]]; then
 	# imports (which is not a realistic test scenario) just because the Jakarta Mail API plugin
 	# happens to be on the class path and triggers an upper bounds violation.
 	#
-	# javax.servlet:servlet-api comes from core at version 0, which is an intentional trick to
-	# prevent this library from being used, and we do not want it to be upgraded to a nonzero
-	# version (which is not a realistic test scenario) just because it happens to be on the
-	# class path of some plugin and triggers an upper bounds violation. JENKINS-68696 tracks the
-	# removal of this trick.
-	#
 	echo upperBoundsExcludes=com.sun.mail:jakarta.mail,javax.servlet:servlet-api >maven.properties
 else
 	#

--- a/pct.sh
+++ b/pct.sh
@@ -18,16 +18,90 @@ if [[ -n ${EXTRA_MAVEN_PROPERTIES-} ]]; then
 fi
 
 #
-# Plugin Compatibility Tester (PCT) requires custom --add-opens directives when running on Java 17.
-# As a temporary workaround, we pass in these directives when invoking PCT. When
-# jenkinsci/plugin-compat-tester#352 is merged and released, and when this repository has upgraded
-# to that release, this workaround can be deleted.
+# Grab the Jenkins version from the WAR file so that we can pass it in via jenkins.version. This is
+# needed because HPI Plugin requires the version of the WAR passed in via overrideWar to be
+# identical to jenkins.version. If we do not explicitly pass in jenkins.version, then the
+# jenkins.version defined in the plugin's pom.xml file will be used, which may not match the version
+# of the WAR under test.
 #
+mkdir pct-work
+pushd pct-work
+jar xf ../megawar.war META-INF/MANIFEST.MF
+JENKINS_VERSION=$(grep Jenkins-Version META-INF/MANIFEST.MF | awk '{print $2}')
+popd
+rm -rf pct-work
+MAVEN_PROPERTIES+=":jenkins.version=${JENKINS_VERSION}:overrideWar=$(pwd)/megawar.war:useUpperBounds=true"
+
+#
+# The overrideWar option is available in HPI Plugin 3.29 or later, but many plugins under test
+# still use an older plugin parent POM and therefore an older HPI plugin version. As a temporary
+# workaround, we override the HPI plugin version to the latest version.
+#
+# TODO When all plugins in the managed set are using a plugin parent POM with HPI Plugin 3.29 or
+# later (i.e., plugin parent POM 4.44 or later), this can be deleted.
+#
+MAVEN_PROPERTIES+=:hpi-plugin.version=3.30
+
+#
+# Define the excludes for upper bounds checking. We define these excludes in a separate file and
+# pass it in via -mavenPropertiesFile rather than using -mavenProperties because -mavenProperties
+# uses a colon as the separator and these values contain colons.
+#
+if [[ $LINE == '2.319.x' ]]; then
+	#
+	# com.sun.mail needs to be excluded because it is still provided by core on this line (using
+	# pre-Jakarta imports) and we do not want it to be upgraded to a version that uses Jakarta
+	# imports (which is not a realistic test scenario) just because the Jakarta Mail API plugin
+	# happens to be on the class path and triggers an upper bounds violation.
+	#
+	# javax.servlet:servlet-api comes from core at version 0, which is an intentional trick to
+	# prevent this library from being used, and we do not want it to be upgraded to a nonzero
+	# version (which is not a realistic test scenario) just because it happens to be on the
+	# class path of some plugin and triggers an upper bounds violation. JENKINS-68696 tracks the
+	# removal of this trick.
+	#
+	echo upperBoundsExcludes=com.sun.mail:jakarta.mail,javax.servlet:servlet-api >"$(pwd)/maven.properties"
+else
+	#
+	# javax.servlet:servlet-api comes from core at version 0, which is an intentional trick to
+	# prevent this library from being used, and we do not want it to be upgraded to a nonzero
+	# version (which is not a realistic test scenario) just because it happens to be on the
+	# class path of some plugin and triggers an upper bounds violation. JENKINS-68696 tracks the
+	# removal of this trick.
+	#
+	echo upperBoundsExcludes=javax.servlet:servlet-api >"$(pwd)/maven.properties"
+fi
+
+#
+# Apache HttpComponents Client 4.x API, Oracle Java SE Development Kit Installer, JSch, OkHttp, and
+# Plain Credentials use an older plugin parent POM and therefore an older test harness that predates
+# compatibility with the removal of JNR in recent cores in jenkinsci/jenkins-test-harness#350. As a
+# temporary workaround, we override the test harness to a recent version. Note that we cannot use a
+# test harness newer than 1812.v6d4e97d91fd8, because later releases of the test harness require
+# changes to the plugin parent POM for JUnit 5 support.
+#
+# TODO When these plugins are using a plugin parent POM with test harness 1657.vf8a824e79147 or
+# later (i.e., plugin parent POM 4.32 or later), this can be deleted.
+#
+if [[ $PLUGINS =~ apache-httpcomponents-client-4-api ]] ||
+	[[ $PLUGINS =~ jdk-tool ]] ||
+	[[ $PLUGINS =~ jsch ]] ||
+	[[ $PLUGINS =~ okhttp-api ]] ||
+	[[ $PLUGINS =~ plain-credentials ]]; then
+	MAVEN_PROPERTIES+=:jenkins-test-harness.version=1812.v6d4e97d91fd8
+fi
+
+#
+# Testing plugins against a version of Jenkins that requires Java 11 exposes
+# jenkinsci/plugin-pom#563. This was fixed in plugin parent POM 4.42, but many plugins under test
+# still use an older plugin parent POM. As a temporary workaround, we skip Enforcer.
+#
+# TODO When all plugins in the managed set are using plugin parent POM 4.42 or later, this can be
+# deleted.
+#
+MAVEN_PROPERTIES+=:enforcer.skip=true
+
 java \
-	--add-opens java.base/java.lang.reflect=ALL-UNNAMED \
-	--add-opens java.base/java.text=ALL-UNNAMED \
-	--add-opens java.base/java.util=ALL-UNNAMED \
-	--add-opens java.desktop/java.awt.font=ALL-UNNAMED \
 	-jar pct.jar \
 	-war "$(pwd)/megawar.war" \
 	-includePlugins "${PLUGINS}" \
@@ -35,6 +109,8 @@ java \
 	-reportFile "$(pwd)/pct-report.xml" \
 	$PCT_S_ARG \
 	-mavenProperties "${MAVEN_PROPERTIES}" \
+	-excludeHooks org.jenkins.tools.test.hook.TransformPom \
+	-mavenPropertiesFile "$(pwd)/maven.properties" \
 	-skipTestCache true
 
 if grep -q -F -e '<status>INTERNAL_ERROR</status>' pct-report.xml; then
@@ -69,11 +145,5 @@ elif grep -q -F -e '<status>TEST_FAILURES</status>' pct-report.xml; then
 		fi
 	done
 fi
-
-# TODO various problems with PCT itself (e.g. https://github.com/jenkinsci/bom/pull/338#issuecomment-715256727)
-# and anyway the tests in PluginAutomaticTestBuilder are generally uninteresting in a PCT context
-# We always try to run this test rather than adding it to excludes.txt in order
-# to be able to detect if PCT failed to run tests at all a few lines above.
-rm -fv pct-work/*/{,*/}target/surefire-reports/TEST-InjectedTest.xml
 
 # produces: **/target/surefire-reports/TEST-*.xml

--- a/pct.sh
+++ b/pct.sh
@@ -27,7 +27,7 @@ fi
 mkdir pct-work
 pushd pct-work
 jar xf ../megawar.war META-INF/MANIFEST.MF
-JENKINS_VERSION=$(grep Jenkins-Version META-INF/MANIFEST.MF | awk '{print $2}')
+JENKINS_VERSION=$(perl -w -p -0777 -e 's/\r?\n //g' META-INF/MANIFEST.MF | grep Jenkins-Version | awk '{print $2}')
 popd
 rm -rf pct-work
 MAVEN_PROPERTIES+=":jenkins.version=${JENKINS_VERSION}:overrideWar=$(pwd)/megawar.war:useUpperBounds=true"

--- a/pct.sh
+++ b/pct.sh
@@ -63,7 +63,7 @@ else
 	# class path of some plugin and triggers an upper bounds violation. JENKINS-68696 tracks the
 	# removal of this trick.
 	#
-	echo upperBoundsExcludes=javax.servlet:servlet-api >"$(pwd)/maven.properties"
+	echo upperBoundsExcludes=javax.servlet:servlet-api >maven.properties
 fi
 
 #

--- a/pct.sh
+++ b/pct.sh
@@ -60,7 +60,7 @@ if [[ $LINE == '2.319.x' ]]; then
 	# class path of some plugin and triggers an upper bounds violation. JENKINS-68696 tracks the
 	# removal of this trick.
 	#
-	echo upperBoundsExcludes=com.sun.mail:jakarta.mail,javax.servlet:servlet-api >"$(pwd)/maven.properties"
+	echo upperBoundsExcludes=com.sun.mail:jakarta.mail,javax.servlet:servlet-api >maven.properties
 else
 	#
 	# javax.servlet:servlet-api comes from core at version 0, which is an intentional trick to

--- a/prep.sh
+++ b/prep.sh
@@ -32,7 +32,7 @@ for LINE in $LINEZ; do
 	echo '# nothing' >jenkins/split-plugins.txt
 	cp -r jenkins-for-test "megawar-${LINE}"
 	jar uvf megawar-$LINE/WEB-INF/lib/jenkins-core-*.jar jenkins/split-plugins.txt
-	rm -rfv megawar-$LINE/META-INF/*.{RSA,SF}
+	rm -rfv megawar-$LINE/WEB-INF/detached-plugins megawar-$LINE/META-INF/*.{RSA,SF}
 	mkdir "megawar-${LINE}/WEB-INF/plugins"
 	cp -rv test-classes/test-dependencies/*.hpi "megawar-${LINE}/WEB-INF/plugins"
 	cd "megawar-${LINE}"

--- a/prep.sh
+++ b/prep.sh
@@ -32,7 +32,7 @@ for LINE in $LINEZ; do
 	echo '# nothing' >jenkins/split-plugins.txt
 	cp -r jenkins-for-test "megawar-${LINE}"
 	jar uvf megawar-$LINE/WEB-INF/lib/jenkins-core-*.jar jenkins/split-plugins.txt
-	rm -rfv `# TODO delete all but instance-identity? megawar-$LINE/WEB-INF/detached-plugins` megawar-$LINE/META-INF/*.{RSA,SF}
+	rm -rfv megawar-$LINE/META-INF/*.{RSA,SF}
 	mkdir "megawar-${LINE}/WEB-INF/plugins"
 	cp -rv test-classes/test-dependencies/*.hpi "megawar-${LINE}/WEB-INF/plugins"
 	cd "megawar-${LINE}"
@@ -41,7 +41,7 @@ for LINE in $LINEZ; do
 done
 
 # TODO find a way to encode this in some POM so that it can be managed by Dependabot
-version=1152.vafc19b26d5aa # TODO https://github.com/jenkinsci/plugin-compat-tester/pull/345
+version=1178.vbef3c43d0e69
 pct=$HOME/.m2/repository/org/jenkins-ci/tests/plugins-compat-tester-cli/${version}/plugins-compat-tester-cli-${version}.jar
 [ -f "${pct}" ] || $MVN dependency:get -Dartifact=org.jenkins-ci.tests:plugins-compat-tester-cli:${version}:jar -DremoteRepositories=https://repo.jenkins-ci.org/public/,https://repo.jenkins-ci.org/incrementals/ -Dtransitive=false
 cp "${pct}" target/pct.jar


### PR DESCRIPTION
Fixes #657 by moving us from an incremental build of PCT, which should never have been accepted, to a release build of PCT.

Fixes #821, a regression introduced by [JENKINS-47498](https://issues.jenkins.io/browse/JENKINS-47498), by suppressing the `org.jenkins.tools.test.hook.TransformPom` hook from PCT in favor of the `overrideWar` option from https://github.com/jenkinsci/maven-hpi-plugin/pull/336 to pin each plugin to the version in the fat WAR; i.e., the version of the plugin specified in the version of the BOM under test, as opposed to current behavior of the version of the plugin specified in the version of the BOM specified by the plugin under test. This should eliminate the need to run around the Jenkins ecosystem bumping BOM versions and doing plugin releases every time an incompatible change is made. It should also help us catch regressions sooner. Actually, it already has, as while preparing this PR I found several such regressions (both the first time around in March, and recently while preparing the present PR).

Does not fix #895, but brings us closer to a solution. Not only is the release build of PCT is more strict than the incremental build we were using before, but also using a release build of PCT should make it easier to test the likes of https://github.com/jenkinsci/plugin-compat-tester/pull/348. Pending the completion of the latter it should be easier to reëvaluate [/pct.sh#L40-L71](https://github.com/jenkinsci/bom/blob/cbb7687af202c07953830b490adbefab05a2989f/pct.sh#L40-L71) in favor of a more robust alternative.

See the self-review for more explanation.

Last but not least, some well-deserved acknowledgements:

- @dohbedoh for releasing recent backports to the Mina SSHD API plugins that were blocking the present effort.
- @imonteroperez for merging and releasing https://github.com/jenkinsci/plugin-compat-tester/pull/353 and https://github.com/jenkinsci/plugin-compat-tester/pull/372, which were critical for the present effort.
- @jetersen for his recent heroic effort to update the Mina SSHD API plugins, including releasing recent fixes to the Variant plugin and kindly incorporating a properties fix that was blocking the present effort.
- @jglick for the design of [JENKINS-47498](https://issues.jenkins.io/browse/JENKINS-47498), starting the implementation in https://github.com/jenkinsci/maven-hpi-plugin/pull/66, a recent bug fix to `workflow-job` that was blocking this effort, merging and releasing https://github.com/jenkinsci/plugin-compat-tester/pull/352 and https://github.com/jenkinsci/plugin-compat-tester/pull/375, and much other help that currently escapes my memory.
- @jtnord for the helpful feedback in https://github.com/jenkinsci/maven-hpi-plugin/pull/336.
- @timja for releasing recent backports to the JUnit plugin that were blocking the present effort. I am truly grateful for your helpful involvement in nearly every project I work on.

I am sure I have forgotten others. I will edit this post if I remember. Thank you to all!