### PR TITLE
updatecli: Handle updating jenkins property version without guesswork

### DIFF
--- a/.github/workflows/action-updatecli.yaml
+++ b/.github/workflows/action-updatecli.yaml
@@ -31,7 +31,7 @@ jobs:
           curl -sSL "$url" -o "$path"
           echo "PLUGIN_MANAGER_JAR_PATH=$path" >> $GITHUB_ENV
 
-      - name: Generate updatecli manifests for plugins
+      - name: Generate updatecli manifests
         shell: pwsh
         run: |
           Set-PSRepository -Name PSGallery -InstallationPolicy Trusted

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ megawar.war
 pct.jar
 plugin-manager.jar
 updatecli.d/
+.env
+.envrc

--- a/updatecli/generate-manifests.ps1
+++ b/updatecli/generate-manifests.ps1
@@ -201,7 +201,7 @@ foreach ($bom in $bills) {
       name         = "Get last $name version"
       kind         = "shell"
       spec         = @{
-        command = "java -jar {{ requiredEnv `"PLUGIN_MANAGER_JAR_PATH`" }} --no-download --available-updates --output txt --jenkins-version $jenkinsVersion --plugins ${artifact}:${version}"
+        command = "java -jar {{ requiredEnv `"PLUGIN_MANAGER_JAR_PATH`" }} --no-download --available-updates --output txt --jenkins-version $jenkinsVersion --plugins ${artifactId}:${version}"
       }
       transformers = @(
         @{

--- a/updatecli/update-jenkins.ps1
+++ b/updatecli/update-jenkins.ps1
@@ -1,20 +1,30 @@
 param(
-  [Parameter(Position=0)]
+  [Parameter(Position = 0)]
+  [string] $BomVersion,
+  [Parameter(Position = 1)]
   [string] $JenkinsVersion
 )
 
 $changed = $false
+if ($null -eq $ENV:DRY_RUN) {
+  $ENV:DRY_RUN = $false
+}
 
 $pomPath = "sample-plugin/pom.xml"
 $pom = New-Object System.Xml.XmlDocument
 $pom.PreserveWhitespace = $true
 $pom.Load($pomPath)
 
-if ($JenkinsVersion -imatch "^\d+\.\d+\.\d+$") {
-  $JenkinsVersionX = $JenkinsVersion -replace '\d+$', 'x'
-  $pomProfile = $pom.project.profiles.profile | Where-Object { $_.id -eq $JenkinsVersionX } | Select-Object -First 1
+if ($BomVersion -eq "weekly") {
+  $currentVersion = $pom.project.properties.'jenkins.version'
+  if ($null -ne $currentVersion -and $currentVersion -ne $JenkinsVersion) {
+    $changed = $true
+    $pom.project.properties.'jenkins.version' = $JenkinsVersion
+  }
+} else {
+  $pomProfile = $pom.project.profiles.profile | Where-Object { $_.id -eq $BomVersion } | Select-Object -First 1
   if ($null -eq $pomProfile) {
-    Write-Host "Profile for Jenkins version $JenkinsVersionX not found in $pomPath"
+    Write-Host "Profile for Jenkins version $BomVersion not found in $pomPath"
     exit 1
   }
 
@@ -22,23 +32,16 @@ if ($JenkinsVersion -imatch "^\d+\.\d+\.\d+$") {
   if ($null -ne $currentVersion -and $currentVersion -ne $JenkinsVersion) {
     $changed = $true
     $pomProfile.Properties.'jenkins.version' = $JenkinsVersion
-    Write-Output "$JenkinsVersion"
   }
-} elseif ($JenkinsVersion -imatch "^\d+\.\d+$") {
-  $currentVersion = $pom.project.properties.'jenkins.version'
-  if ($null -ne $currentVersion -and $currentVersion -ne $JenkinsVersion) {
-    $changed = $true
-    $pom.project.properties.'jenkins.version' = $JenkinsVersion
-    Write-Output "$JenkinsVersion"
-  }
-} else {
-  Write-Host "Invalid Jenkins version $JenkinsVersion"
-  exit 1
 }
 
 if ($changed) {
-  $utf8WithoutBom = New-Object System.Text.UTF8Encoding($false)
-  $streamWriter = New-Object System.IO.StreamWriter($pomPath, $false, $utf8WithoutBom)
-  $pom.Save($streamWriter)
-  $streamWriter.Close()
+  Write-Output "$JenkinsVersion"
+
+  if ($ENV:DRY_RUN -eq $false) {
+    $utf8WithoutBom = New-Object System.Text.UTF8Encoding($false)
+    $streamWriter = New-Object System.IO.StreamWriter($pomPath, $false, $utf8WithoutBom)
+    $pom.Save($streamWriter)
+    $streamWriter.Close()
+  }
 }


### PR DESCRIPTION
Send bom version ie. `2.346.x` or `weekly` to `update-jenkins.ps1`
So we know exactly the part of the sample pom that needs updating.
This avoids smart lookup of profile vs property

Support property version update for plugins, allows updatecli takeover dependabot

Add back DRY RUN check

Ensure dot is escaped in pattern

add `.env` `.envrc` to gitignore

~I have fully tested the changes 😅~
~Lies found a new bug... it sticks to the same name 😓~
There all bugs are squashed 👶

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
