### PR TITLE
[JEP-230] [JENKINS-55582] Test `instance-identity` as a detached plugin

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,7 +37,6 @@ stage('prep') {
         dir('target') {
             plugins = readFile('plugins.txt').split('\n')
             lines = readFile('lines.txt').split('\n')
-            lines = [lines[0], lines[-1]] // run PCT only on newest and oldest lines, to save resources
             stash name: 'pct', includes: 'pct.jar'
             lines.each {stash name: "megawar-$it", includes: "megawar-${it}.war"}
         }

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -236,6 +236,11 @@
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.modules</groupId>
+                <artifactId>instance-identity</artifactId>
+                <version>116.vf8f487400980</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.modules</groupId>
                 <artifactId>sshd</artifactId>
                 <version>3.249.v2dc2ea_416e33</version>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -20,9 +20,6 @@
     </licenses>
     <modules>
         <module>bom-weekly</module>
-        <module>bom-2.346.x</module>
-        <module>bom-2.332.x</module>
-        <module>bom-2.319.x</module>
         <module>sample-plugin</module>
     </modules>
     <scm child.scm.connection.inherit.append.path="false" child.scm.developerConnection.inherit.append.path="false" child.scm.url.inherit.append.path="false">

--- a/prep.sh
+++ b/prep.sh
@@ -11,7 +11,6 @@ $MVN clean install ${SAMPLE_PLUGIN_OPTS:-}
 
 ALL_LINEZ=$(
 	echo weekly
-	grep -F '.x</bom>' sample-plugin/pom.xml | sed -E 's, *<bom>(.+)</bom>,\1,g' | sort -rn
 )
 : "${LINEZ:=$ALL_LINEZ}"
 echo "${LINEZ}" >target/lines.txt

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -544,28 +544,4 @@
             </plugin>
         </plugins>
     </build>
-    <profiles>
-        <!-- Use .1 of most recent active line, and .3 (or later) of previous lines: https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/#choosing-a-version -->
-        <profile>
-            <id>2.346.x</id>
-            <properties>
-                <bom>2.346.x</bom>
-                <jenkins.version>2.346.1</jenkins.version>
-            </properties>
-        </profile>
-        <profile>
-            <id>2.332.x</id>
-            <properties>
-                <bom>2.332.x</bom>
-                <jenkins.version>2.332.4</jenkins.version>
-            </properties>
-        </profile>
-        <profile>
-            <id>2.319.x</id>
-            <properties>
-                <bom>2.319.x</bom>
-                <jenkins.version>2.319.3</jenkins.version>
-            </properties>
-        </profile>
-    </profiles>
 </project>


### PR DESCRIPTION
#1159 rebased on top of #1337. Note that this is actually testing the new detached `instance-identity` plugin in cases when a plugin currently depends on the module, as does the current version of `git-server`:

```
[INFO] Updating direct dependency org.jenkins-ci.modules:instance-identity from 2.2 to 116.vf8f487400980
```