### PR TITLE
Exclude `HttpRequestStepRoundTripTest`

### DIFF
--- a/excludes.txt
+++ b/excludes.txt
@@ -1,6 +1,9 @@
 # TODO cryptic PCT-only errors: https://github.com/jenkinsci/bom/pull/251#issuecomment-645012427
 hudson.matrix.AxisTest
 
+# TODO tends to time out
+jenkins.plugins.http_request.HttpRequestStepRoundTripTest
+
 # TODO flakes on CI for inscrutable reasons
 org.jenkinsci.plugins.durabletask.BourneShellScriptTest
 


### PR DESCRIPTION
I have seen `jenkins.plugins.http_request.HttpRequestStepRoundTripTest#configRoundTripGroup1` time out a few times recently, including in:

- https://ci.jenkins.io/job/Tools/job/bom/job/master/1157/testReport/junit/jenkins.plugins.http_request/HttpRequestStepRoundTripTest/pct_http_request_2_319_x___configRoundTripGroup1/
- https://ci.jenkins.io/job/Tools/job/bom/job/PR-1337/8/testReport/junit/jenkins.plugins.http_request/HttpRequestStepRoundTripTest/pct_http_request_2_319_x___configRoundTripGroup1/

A quick look at the thread dumps doesn't reveal anything suspicious. I don't have the time to investigate further right now, but since this is destabilizing our builds/releases I think it is worth excluding it for now. If accepted, I plan to file an issue to track the investigation and re-enabling of this test.