### PR TITLE
Try re-enabling TriggersTest with bounded heap size

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,6 +50,7 @@ stage('prep') {
 branches = [failFast: failFast]
 lines.each {line ->
     plugins.each { plugin ->
+      if (plugin == 'pipeline-model-definition') {
         branches["pct-$plugin-$line"] = {
             def jdk = line == 'weekly' ? 17 : 11
             mavenEnv(jdk: jdk) {
@@ -63,6 +64,7 @@ lines.each {line ->
                 }
             }
         }
+      }
     }
 }
 parallel branches

--- a/excludes.txt
+++ b/excludes.txt
@@ -9,6 +9,3 @@ org.jenkinsci.plugins.durabletask.BourneShellScriptTest
 
 # TODO fails for one reason in (non-PCT) official sources, run locally; and for another reason in PCT in Docker; passes in official sources in Docker, or locally in PCT
 org.jenkinsci.plugins.gitclient.FilePermissionsTest
-
-# TODO tends to run out of memory
-org.jenkinsci.plugins.pipeline.modeldefinition.TriggersTest

--- a/failFast
+++ b/failFast
@@ -1,1 +1,1 @@
-true
+false

--- a/pct.sh
+++ b/pct.sh
@@ -91,6 +91,7 @@ fi
 MAVEN_PROPERTIES+=:enforcer.skip=true
 
 java \
+	-Xmx256m \
 	-jar pct.jar \
 	-war "$(pwd)/megawar.war" \
 	-includePlugins "${PLUGINS}" \


### PR DESCRIPTION
Checking to see if bounding the heap size of the PCT Java process results in a noticeable increase in stability compared to the baseline in #1363.