### PR TITLE
[JENKINS-69229] Revert `trilead-api` update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,11 @@ updates:
       - "jglick"
     schedule:
       interval: "daily"
+    ignore:
+      # TODO https://github.com/jenkinsci/bom/pull/1374#issuecomment-1205302760 pending new version
+      - dependency-name: trilead-api
+        versions:
+          - 1.71.v9e7860a_67a_df
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -545,7 +545,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>trilead-api</artifactId>
-                <version>1.71.v9e7860a_67a_df</version>
+                <version>1.67.vc3938a_35172f</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Reverting #1374. https://github.com/jenkinsci/bom/pull/1378#issuecomment-1205330558
