### PR TITLE
Backport of `ClassCastException` fix for JDK 11u16

### DIFF
--- a/bom-2.319.x/pom.xml
+++ b/bom-2.319.x/pom.xml
@@ -111,12 +111,12 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins.workflow</groupId>
                 <artifactId>workflow-cps</artifactId>
-                <version>2660.vb_c0412dc4e6d</version>
+                <version>2660.2664.v4c114e93f4c1</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins.workflow</groupId>
                 <artifactId>workflow-cps</artifactId>
-                <version>2660.vb_c0412dc4e6d</version>
+                <version>2660.2664.v4c114e93f4c1</version>
                 <classifier>tests</classifier>
             </dependency>
             <dependency>


### PR DESCRIPTION
In https://github.com/jenkinsci/workflow-cps-plugin/releases/tag/2660.2664.v4c114e93f4c1 I backported https://github.com/jenkinsci/workflow-cps-plugin/pull/543 which (among other things) solves an error reproducible when using JDK 11u16 but not 11u15:


```bash
JAVA_HOME=…/jdk-11.0.16+8 LINE=2.319.x PLUGINS=pipeline-model-definition TEST=DurabilityTest bash local-test.sh
```

I guess CI agents recently updated Java versions @dduportal? Blocking an important https://github.com/jenkinsci/bom/pull/1379#issuecomment-1206354571 and also seen in #1380 (https://github.com/jenkinsci/bom/pull/1380/checks?check_run_id=7686555358). Originally released in https://github.com/jenkinsci/workflow-cps-plugin/releases/tag/2705.v0449852ee36f but https://github.com/jenkinsci/workflow-cps-plugin/pull/512 restricted that to a newer line so #940 did not pick this up on 2.319.x.