### PR TITLE
Update `workflow-support`

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -25,7 +25,7 @@
         <workflow-job-plugin.version>1232.v5a_4c994312f1</workflow-job-plugin.version>
         <workflow-multibranch-plugin.version>716.vc692a_e52371b_</workflow-multibranch-plugin.version>
         <workflow-step-api-plugin.version>639.v6eca_cd8c04a_a_</workflow-step-api-plugin.version>
-        <workflow-support-plugin.version>833.va_1c71061486b_</workflow-support-plugin.version>
+        <workflow-support-plugin.version>838.va_3a_087b_4055b</workflow-support-plugin.version>
     </properties>
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
https://github.com/jenkinsci/workflow-support-plugin/releases/tag/838.va_3a_087b_4055b has not appeared in https://github.com/jenkinsci/bom/network/updates/446183713

```
updater | INFO <job_446183713> Checking if org.jenkins-ci.plugins.workflow:workflow-support 833.va_1c71061486b_ needs updating
  proxy | 2022/08/25 14:17:36 [188] GET https://repo.jenkins-ci.org:443/public/org/jenkins-ci/jenkins/1.85/jenkins-1.85.pom
  proxy | 2022/08/25 14:17:37 [188] 200 https://repo.jenkins-ci.org:443/public/org/jenkins-ci/jenkins/1.85/jenkins-1.85.pom
  proxy | 2022/08/25 14:17:37 [190] GET https://repo.jenkins-ci.org:443/public/org/jenkins-ci/plugins/workflow/workflow-support/maven-metadata.xml
  proxy | 2022/08/25 14:17:37 [190] 200 https://repo.jenkins-ci.org:443/public/org/jenkins-ci/plugins/workflow/workflow-support/maven-metadata.xml
  proxy | 2022/08/25 14:17:37 [192] GET https://repo.maven.apache.org:443/maven2/org/jenkins-ci/plugins/workflow/workflow-support/maven-metadata.xml
  proxy | 2022/08/25 14:17:37 [192] 404 https://repo.maven.apache.org:443/maven2/org/jenkins-ci/plugins/workflow/workflow-support/maven-metadata.xml
  proxy | 2022/08/25 14:17:37 [194] HEAD https://repo.jenkins-ci.org:443/public/org/jenkins-ci/plugins/workflow/workflow-support/833.va_1c71061486b_/workflow-support-833.va_1c71061486b_.jar
  proxy | 2022/08/25 14:17:37 [194] 200 https://repo.jenkins-ci.org:443/public/org/jenkins-ci/plugins/workflow/workflow-support/833.va_1c71061486b_/workflow-support-833.va_1c71061486b_.jar
updater | INFO <job_446183713> Latest version is 833.va_1c71061486b_
updater | INFO <job_446183713> No update needed for org.jenkins-ci.plugins.workflow:workflow-support 833.va_1c71061486b_
```

despite

```console
$ curl -s https://repo.jenkins-ci.org:443/public/org/jenkins-ci/plugins/workflow/workflow-support/maven-metadata.xml | fgrep release
    <release>838.va_3a_087b_4055b</release>
```

Not sure why. Perhaps https://github.com/jenkinsci/incrementals-tools/pull/31 was mistaken?

Anyway, need to release https://github.com/jenkinsci/workflow-support-plugin/pull/188 for e.g. https://github.com/jenkinsci/pipeline-stage-step-plugin/pull/70.
