### PR TITLE
Freeze versions of JS plug-ins for Jenkins 2.332.x

### DIFF
--- a/bom-2.332.x/pom.xml
+++ b/bom-2.332.x/pom.xml
@@ -19,13 +19,71 @@
             </dependency>
             <dependency>
                 <groupId>io.jenkins.plugins</groupId>
+                <artifactId>bootstrap5-api</artifactId>
+                <version>5.2.0-1</version>
+            </dependency>
+            <dependency>
+                <groupId>io.jenkins.plugins</groupId>
                 <artifactId>dark-theme</artifactId>
                 <version>156.v6cf16af6f9ef</version>
             </dependency>
             <dependency>
                 <groupId>io.jenkins.plugins</groupId>
+                <artifactId>data-tables-api</artifactId>
+                <version>1.12.1-3</version>
+            </dependency>
+            <dependency>
+                <groupId>io.jenkins.plugins</groupId>
+                <artifactId>data-tables-api</artifactId>
+                <version>1.12.1-3</version>
+                <classifier>tests</classifier>
+            </dependency>
+            <dependency>
+                <groupId>io.jenkins.plugins</groupId>
+                <artifactId>echarts-api</artifactId>
+                <version>5.3.3-1</version>
+            </dependency>
+            <dependency>
+                <groupId>io.jenkins.plugins</groupId>
+                <artifactId>font-awesome-api</artifactId>
+                <version>6.1.2-1</version>
+            </dependency>
+            <dependency>
+                <groupId>io.jenkins.plugins</groupId>
+                <artifactId>forensics-api</artifactId>
+                <version>1.15.1</version>
+            </dependency>
+            <dependency>
+                <groupId>io.jenkins.plugins</groupId>
+                <artifactId>forensics-api</artifactId>
+                <classifier>tests</classifier>
+                <version>1.15.1</version>
+            </dependency>
+            <dependency>
+                <groupId>io.jenkins.plugins</groupId>
+                <artifactId>jquery3-api</artifactId>
+                <version>3.6.1-1</version>
+            </dependency>
+            <dependency>
+                <groupId>io.jenkins.plugins</groupId>
                 <artifactId>jnr-posix-api</artifactId>
                 <version>3.1.7-3</version>
+            </dependency>
+            <dependency>
+                <groupId>io.jenkins.plugins</groupId>
+                <artifactId>plugin-util-api</artifactId>
+                <version>2.17.0</version>
+            </dependency>
+            <dependency>
+                <groupId>io.jenkins.plugins</groupId>
+                <artifactId>plugin-util-api</artifactId>
+                <version>2.17.0</version>
+                <classifier>tests</classifier>
+            </dependency>
+            <dependency>
+                <groupId>io.jenkins.plugins</groupId>
+                <artifactId>popper2-api</artifactId>
+                <version>2.11.6-1</version>
             </dependency>
             <dependency>
                 <groupId>io.jenkins.plugins</groupId>


### PR DESCRIPTION
I'm in the progress of upgrading all my plugins to 2.346.x right now:
- JS libraries
- forensics-api
- plugin-util  
