### PR TITLE
[JENKINS-69229] Use newer `trilead-api` on Java 11+ lines

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,17 +10,12 @@ updates:
     schedule:
       interval: "daily"
   - package-ecosystem: "maven"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 25
     directory: "/bom-weekly"
     reviewers:
       - "jglick"
     schedule:
       interval: "daily"
-    ignore:
-      # TODO https://github.com/jenkinsci/bom/pull/1374#issuecomment-1205302760 pending new version
-      - dependency-name: org.jenkins-ci.plugins:trilead-api
-        versions:
-          - 1.71.v9e7860a_67a_df
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/bom-2.346.x/pom.xml
+++ b/bom-2.346.x/pom.xml
@@ -53,6 +53,11 @@
                 <version>1.821.vd834f8a_c390e</version>
             </dependency>
             <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>trilead-api</artifactId>
+                <version>1.67.vc3938a_35172f</version>
+            </dependency>
+            <dependency>
                 <groupId>org.jenkins-ci.plugins.workflow</groupId>
                 <artifactId>workflow-job</artifactId>
                 <version>1207.ve6191ff089f8</version>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -565,7 +565,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>trilead-api</artifactId>
-                <version>1.67.vc3938a_35172f</version>
+                <version>2.72.v2a_3236754f73</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>

--- a/excludes.txt
+++ b/excludes.txt
@@ -14,13 +14,7 @@ org.jenkinsci.plugins.gitclient.FilePermissionsTest
 org.jenkinsci.plugins.pipeline.modeldefinition.TriggersTest
 
 # TODO https://github.com/jenkinsci/git-client-plugin/pull/920
-org.jenkinsci.plugins.gitclient.CliGitAPIImplTest#test_submodule_update_shallow
-org.jenkinsci.plugins.gitclient.CliGitAPIImplTest#test_submodule_update_shallow_with_depth
-org.jenkinsci.plugins.gitclient.CliGitAPIImplTest#test_trackingSubmodule
-org.jenkinsci.plugins.gitclient.CliGitAPIImplTest#test_trackingSubmoduleBranches
-org.jenkinsci.plugins.gitclient.GitClientTest#testSubmoduleUrlEndsWithDotUrl[git]
-org.jenkinsci.plugins.gitclient.GitClientTest#testSubmodulesUsedFromOtherBranches[git]
-org.jenkinsci.plugins.gitclient.JGitAPIImplTest#test_submodule_update_shallow
-org.jenkinsci.plugins.gitclient.JGitAPIImplTest#test_submodule_update_shallow_with_depth
-org.jenkinsci.plugins.gitclient.JGitApacheAPIImplTest#test_submodule_update_shallow
-org.jenkinsci.plugins.gitclient.JGitApacheAPIImplTest#test_submodule_update_shallow_with_depth
+org.jenkinsci.plugins.gitclient.CliGitAPIImplTest
+org.jenkinsci.plugins.gitclient.GitClientTest
+org.jenkinsci.plugins.gitclient.JGitAPIImplTest
+org.jenkinsci.plugins.gitclient.JGitApacheAPIImplTest

--- a/excludes.txt
+++ b/excludes.txt
@@ -12,3 +12,15 @@ org.jenkinsci.plugins.gitclient.FilePermissionsTest
 
 # TODO tends to run out of memory
 org.jenkinsci.plugins.pipeline.modeldefinition.TriggersTest
+
+# TODO https://github.com/jenkinsci/git-client-plugin/pull/920
+org.jenkinsci.plugins.gitclient.CliGitAPIImplTest#test_submodule_update_shallow
+org.jenkinsci.plugins.gitclient.CliGitAPIImplTest#test_submodule_update_shallow_with_depth
+org.jenkinsci.plugins.gitclient.CliGitAPIImplTest#test_trackingSubmodule
+org.jenkinsci.plugins.gitclient.CliGitAPIImplTest#test_trackingSubmoduleBranches
+org.jenkinsci.plugins.gitclient.GitClientTest#testSubmoduleUrlEndsWithDotUrl[git]
+org.jenkinsci.plugins.gitclient.GitClientTest#testSubmodulesUsedFromOtherBranches[git]
+org.jenkinsci.plugins.gitclient.JGitAPIImplTest#test_submodule_update_shallow
+org.jenkinsci.plugins.gitclient.JGitAPIImplTest#test_submodule_update_shallow_with_depth
+org.jenkinsci.plugins.gitclient.JGitApacheAPIImplTest#test_submodule_update_shallow
+org.jenkinsci.plugins.gitclient.JGitApacheAPIImplTest#test_submodule_update_shallow_with_depth


### PR DESCRIPTION
See https://github.com/jenkinsci/trilead-api-plugin/pull/55, #1374, #1378, #1379, & #1382.