### PR TITLE
Update plugins related to 2022-10-19 security advisory; add `ionicons-api`

### DIFF
--- a/bom-2.319.x/pom.xml
+++ b/bom-2.319.x/pom.xml
@@ -84,6 +84,11 @@
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>pipeline-input-step</artifactId>
+                <version>451.vf1a_a_4f405289</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>saml</artifactId>
                 <version>2.298.vc7a_2b_3958628</version>
             </dependency>

--- a/bom-2.332.x/pom.xml
+++ b/bom-2.332.x/pom.xml
@@ -71,6 +71,11 @@
             </dependency>
             <dependency>
                 <groupId>io.jenkins.plugins</groupId>
+                <artifactId>pipeline-groovy-lib</artifactId>
+                <version>612.v84da_9c54906d</version>
+            </dependency>
+            <dependency>
+                <groupId>io.jenkins.plugins</groupId>
                 <artifactId>plugin-util-api</artifactId>
                 <version>2.17.0</version>
             </dependency>

--- a/bom-2.332.x/pom.xml
+++ b/bom-2.332.x/pom.xml
@@ -122,6 +122,11 @@
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>script-security</artifactId>
+                <version>1183.v774b_0b_0a_a_451</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>ssh-credentials</artifactId>
                 <version>277.280.v1e86b_7d0056b_</version>
             </dependency>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -21,7 +21,7 @@
         <scm-api-plugin.version>621.vda_a_b_055e58f7</scm-api-plugin.version>
         <subversion-plugin.version>2.16.0</subversion-plugin.version>
         <workflow-api-plugin.version>1200.v8005c684b_a_c6</workflow-api-plugin.version>
-        <workflow-cps-plugin.version>2759.v87459c4eea_ca_</workflow-cps-plugin.version>
+        <workflow-cps-plugin.version>2803.v1a_f77ffcc773</workflow-cps-plugin.version>
         <workflow-job-plugin.version>1236.vc3a_d1602f439</workflow-job-plugin.version>
         <workflow-multibranch-plugin.version>716.vc692a_e52371b_</workflow-multibranch-plugin.version>
         <workflow-step-api-plugin.version>639.v6eca_cd8c04a_a_</workflow-step-api-plugin.version>
@@ -196,7 +196,7 @@
             <dependency>
                 <groupId>io.jenkins.plugins</groupId>
                 <artifactId>pipeline-groovy-lib</artifactId>
-                <version>612.v84da_9c54906d</version>
+                <version>613.v9c41a_160233f</version>
             </dependency>
             <dependency>
                 <groupId>io.jenkins.plugins</groupId>
@@ -504,7 +504,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>script-security</artifactId>
-                <version>1183.v774b_0b_0a_a_451</version>
+                <version>1189.vb_a_b_7c8fd5fde</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -25,7 +25,7 @@
         <workflow-job-plugin.version>1236.vc3a_d1602f439</workflow-job-plugin.version>
         <workflow-multibranch-plugin.version>716.vc692a_e52371b_</workflow-multibranch-plugin.version>
         <workflow-step-api-plugin.version>639.v6eca_cd8c04a_a_</workflow-step-api-plugin.version>
-        <workflow-support-plugin.version>838.va_3a_087b_4055b</workflow-support-plugin.version>
+        <workflow-support-plugin.version>839.v35e2736cfd5c</workflow-support-plugin.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -458,7 +458,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>pipeline-input-step</artifactId>
-                <version>451.vf1a_a_4f405289</version>
+                <version>456.vd8a_957db_5b_e9</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -140,6 +140,11 @@
             </dependency>
             <dependency>
                 <groupId>io.jenkins.plugins</groupId>
+                <artifactId>ionicons-api</artifactId>
+                <version>31.v4757b_6987003</version>
+            </dependency>
+            <dependency>
+                <groupId>io.jenkins.plugins</groupId>
                 <artifactId>jakarta-activation-api</artifactId>
                 <version>2.0.1-2</version>
             </dependency>

--- a/sample-plugin/check.groovy
+++ b/sample-plugin/check.groovy
@@ -7,7 +7,8 @@ assert artifactMap['junit:junit'] == project.artifactMap['junit:junit']
 def managedPluginDeps = managedDeps.collect {stripAllButGA(it)}.grep { ga ->
     def art = artifactMap[ga]
     if (art == null) {
-        if (ga.contains('.plugins')) { // TODO without an Artifact, we have no reliable way of checking whether it is actually a plugin
+        if (ga.contains('.plugins') // TODO without an Artifact, we have no reliable way of checking whether it is actually a plugin
+                && !(ga == 'io.jenkins.plugins:ionicons-api' && settings.activeProfiles.any {it ==~ /^2[.](332|319)[.]x$/})) { // TODO: Remove once 2.332.x is no longer part of the BOM (or if MNG-5600 is fixed and we can exclude this dependency in the BOM for old LTS lines)
             throw new org.apache.maven.plugin.MojoFailureException("Managed plugin dependency $ga not listed in test classpath of sample plugin")
         } else {
             println "Do not see managed dependency $ga"

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -126,10 +126,6 @@
         </dependency>
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
-            <artifactId>ionicons-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.jenkins.plugins</groupId>
             <artifactId>jakarta-activation-api</artifactId>
             <scope>test</scope>
         </dependency>

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -126,6 +126,10 @@
         </dependency>
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
+            <artifactId>ionicons-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
             <artifactId>jakarta-activation-api</artifactId>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
Replaces #1506, #1504, #1501, and #1496. We have to add `ionicons-api`, whose oldest version requires Jenkins 2.346.1, and I am not sure how we exclude it from `bom-2.332.x` and `bom-2.319.x` (if it is even possible ([MNG-5600](https://issues.apache.org/jira/browse/MNG-5600)), and if we even care).

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
