### PR TITLE
Remove redundant 2.332.x credentials dependency

### DIFF
--- a/bom-2.332.x/pom.xml
+++ b/bom-2.332.x/pom.xml
@@ -121,6 +121,11 @@
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>credentials</artifactId>
+                <version>1087.1089.v2f1b_9a_b_040e4</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>ldap</artifactId>
                 <version>2.11</version>
             </dependency>

--- a/bom-2.332.x/pom.xml
+++ b/bom-2.332.x/pom.xml
@@ -26,11 +26,6 @@
                 <version>5.2.0-1</version>
             </dependency>
             <dependency>
-                <groupId>org.jenkins-ci.plugins</groupId>
-                <artifactId>credentials</artifactId>
-                <version>1143.vb_e8b_b_ceee347</version>
-            </dependency>
-            <dependency>
                 <groupId>io.jenkins.plugins</groupId>
                 <artifactId>dark-theme</artifactId>
                 <version>156.v6cf16af6f9ef</version>
@@ -123,11 +118,6 @@
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>config-file-provider</artifactId>
                 <version>3.10.0</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jenkins-ci.plugins</groupId>
-                <artifactId>credentials</artifactId>
-                <version>1087.1089.v2f1b_9a_b_040e4</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
## Remove redundant 2.332.x credentials dependency

A credentials dependency was declared twice in the 2.332.x pom.  One of the two dependencies declared the wrong version. 
 Remove the incorrect dependency.

https://github.com/jenkinsci/bom/pull/1564#discussion_r1018093662

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
