### PR TITLE
Test git client plugin 4.0.0 incremental

### DIFF
--- a/bom-2.346.x/pom.xml
+++ b/bom-2.346.x/pom.xml
@@ -48,7 +48,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>git-client</artifactId>
-                <version>3.13.0</version>
+                <version>3.13.1</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>

--- a/bom-2.346.x/pom.xml
+++ b/bom-2.346.x/pom.xml
@@ -39,6 +39,11 @@
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>git-client</artifactId>
+                <version>3.13.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>git-server</artifactId>
                 <version>1.11</version>
             </dependency>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -343,7 +343,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>git-client</artifactId>
-                <version>4.0.0-rc3319.9a_f9cb_53e5da</version>
+                <version>4.0.0-rc3303.656c06003c66</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -343,7 +343,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>git-client</artifactId>
-                <version>4.0.0-rc3316.a_69b_9b_03e2b_9</version>
+                <version>4.0.0-rc3319.9a_f9cb_53e5da</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -343,7 +343,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>git-client</artifactId>
-                <version>3.13.0</version>
+                <version>4.0.0-rc3300.80c23f8e08ec</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -343,7 +343,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>git-client</artifactId>
-                <version>4.0.0-rc3300.80c23f8e08ec</version>
+                <version>4.0.0-rc3308.8d1c3e0715dd</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -343,7 +343,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>git-client</artifactId>
-                <version>4.0.0-rc3308.8d1c3e0715dd</version>
+                <version>4.0.0-rc3316.a_69b_9b_03e2b_9</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
## Test git client 4.0.0 incremental

The git client plugin 4.0.0 will upgrade from JGit 5.13.1 to JGit 6.4.0 and will drop support for Java 8.  JGit 6.4.0 is scheduled to release Dec 7, 2022.

This pull request evaluates the bill of materials with git client plugin 4.0.0 to see what problems it detects.

* https://github.com/jenkinsci/git-client-plugin/pull/939

A future pull request will be created to evaluate a similar change in the git plugin:

* https://github.com/jenkinsci/git-plugin/pull/1367

Does not resolve the test failures when a shallow clone is used.  That is a separate effort that is resolved in:

* https://github.com/jenkinsci/git-client-plugin/pull/944 released as [git client plugin 3.13.1](ttps://github.com/jenkinsci/git-client-plugin/releases/tag/git-client-3.13.1)
* https://github.com/jenkinsci/git-plugin/pull/1365 planned to release as git plugin 4.14.2

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
