### PR TITLE
Test `jenkinsci/jenkins@8eae71e546`

### DIFF
--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
         <bom>weekly</bom>
-        <jenkins.version>2.379</jenkins.version>
+        <jenkins.version>2.381-rc33179.8ea_e71e5464f</jenkins.version>
     </properties>
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
https://ci.jenkins.io/job/Tools/job/bom/job/master/ ought to be usable as a baseline against which to measure BOM PRs whose `jenkins.version` is an incremental build of core (to test forthcoming core PRs), but it is currently not usable for this purpose due to #1611. I intend to test some forthcoming core PRs and need a baseline to compare the results against, hence this PR. Note that jenkinsci/jenkins@8eae71e546 is the current `HEAD`.