### PR TITLE
Test git plugin 5.0.0 incremental

### DIFF
--- a/bom-2.346.x/pom.xml
+++ b/bom-2.346.x/pom.xml
@@ -9,6 +9,7 @@
     <artifactId>bom-2.346.x</artifactId>
     <packaging>pom</packaging>
     <properties>
+        <git-plugin.version>4.14.2</git-plugin.version>
         <workflow-cps-plugin.version>3536.vb_8a_6628079d5</workflow-cps-plugin.version>
     </properties>
     <dependencyManagement>
@@ -39,6 +40,17 @@
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>credentials</artifactId>
                 <version>1143.vb_e8b_b_ceee347</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>git</artifactId>
+                <version>${git-plugin.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>git</artifactId>
+                <version>${git-plugin.version}</version>
+                <classifier>tests</classifier>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>

--- a/bom-2.346.x/pom.xml
+++ b/bom-2.346.x/pom.xml
@@ -39,6 +39,11 @@
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>git-client</artifactId>
+                <version>3.13.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>git-server</artifactId>
                 <version>1.11</version>
             </dependency>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -343,7 +343,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>git-client</artifactId>
-                <version>3.13.0</version>
+                <version>4.0.0-rc3300.80c23f8e08ec</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
## Test git plugin 4.0.0 incremental

- Prototype git 5.0.0 (without the symbols addition)
- Pin git plugin 4.14.2 for 2.346.x and earlier

The git plugin 5.0.0 release will drop support for Java 8. A later commit is intended to add symbols for better Pipeline authoring experiences.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
