### PR TITLE
Pin git client plugin 3.12.4 for Jenkins 2.332.x tests

### DIFF
--- a/bom-2.332.x/pom.xml
+++ b/bom-2.332.x/pom.xml
@@ -88,7 +88,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>git-client</artifactId>
-                <version>3.12.2</version>
+                <version>3.12.4</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
## Pin git client plugin 3.12.4 for Jenkins 2.332.x tests

https://issues.jenkins.io/browse/JENKINS-70174 notes that the git client plugin automated tests failed when using a shallow clone (depth == 1) of a single branch.  The issue was fixed for Jenkins 2.346.3 and newer with the release of git client plugin 3.13.1.  This release is a backport of that fix.

No plugin functionality was changed in this release.  It changes the automated tests when run from a shallow clone (depth == 1) of a single branch.

https://github.com/jenkinsci/bom/pull/1613 is the key consumer in the plugin bill of materials.

https://github.com/jenkinsci/plugin-compat-tester/pull/382 is the key consumer in the plugin compatibility tester.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

@olamy and @jglick I believe we'll need a release of the bom that includes this update.
