### PR TITLE
[JENKINS-70301] Test WMI Windows Agents plugin removal

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -413,7 +413,8 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>ldap</artifactId>
-                <version>2.12</version>
+                <!-- TODO https://github.com/jenkinsci/ldap-plugin/pull/211 -->
+                <version>2.13-rc654.ef0c8553e0c7</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -14,7 +14,8 @@
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
         <bom>weekly</bom>
-        <jenkins.version>2.384</jenkins.version>
+        <!-- TODO https://github.com/jenkinsci/jenkins/pull/7568 -->
+        <jenkins.version>2.386-rc33284.8078de3d1cda</jenkins.version>
     </properties>
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
## Test removal of WMI Windows Agents plugin from core

- Test ldap plugin pre-release with 'Advanced' test fix
- Test Jenkins incremental without windows-slaves

[JENKINS-70301](https://issues.jenkins.io/browse/JENKINS-70301) describes the implied dependency situation with the WMI Windows Agents plugin.  Confirm with PCT that the full set of tests run without requiring the WMI Windows Agents plugin in core.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
