### PR TITLE
Add Apache Mina sftp API for use by git client

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -240,6 +240,11 @@
                 <version>${mina-sshd-api.version}</version>
             </dependency>
             <dependency>
+                <groupId>io.jenkins.plugins.mina-sshd-api</groupId>
+                <artifactId>mina-sshd-api-sftp</artifactId>
+                <version>${mina-sshd-api.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.6wind.jenkins</groupId>
                 <artifactId>lockable-resources</artifactId>
                 <version>1106.vc9153f1a_ff25</version>

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -199,6 +199,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.jenkins.plugins.mina-sshd-api</groupId>
+            <artifactId>mina-sshd-api-sftp</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.6wind.jenkins</groupId>
             <artifactId>lockable-resources</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
## Add Apache Mina sftp API for use by git client

[JENKINS-69159](https://issues.jenkins.io/browse/JENKINS-69159) notes that the jsch implementation used by the git client plugin is not being maintained.

https://github.com/jenkinsci/git-client-plugin/pull/956 notes that JGit has deprecated the jsch library that they provide.  They provide an Apache Mina based library that replaces it.  The git client plugin will benefit from using the sftp API plugin rather than including the sftp API as a transitive dependency.

https://github.com/jenkinsci/mina-sshd-api-plugin/pull/46 proposes to also add the Apache Mina OSGi library as an API plugin so that the git client plugin can use it as well.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
