### PR TITLE
Upgrade PCT to latest

### DIFF
--- a/pct.sh
+++ b/pct.sh
@@ -110,7 +110,7 @@ elif grep -q -F -e '<status>TEST_FAILURES</status>' pct-report.xml; then
 	# only plugin affected by this issue, we work around the issue by deleting the relevant
 	# class rather than making the detection logic more complex.
 	#
-	[[ $PLUGINS == pipeline-model-extensions ]] && rm -fv pct-work/pipeline-model-definition/pipeline-model-api/target/test-classes/InjectedTest.class
+	[[ $PLUGINS == pipeline-model-extensions ]] && rm -fv pct-work/pipeline-model-definition-plugin/pipeline-model-api/target/test-classes/InjectedTest.class
 	for t in pct-work/*/{,*/}target; do
 		if [[ -f "${t}/test-classes/InjectedTest.class" ]] && [[ ! -f "${t}/surefire-reports/TEST-InjectedTest.xml" ]] && [[ ! -f "${t}/failsafe-reports/TEST-InjectedTest.xml" ]]; then
 			mkdir -p "${t}/surefire-reports"

--- a/prep.sh
+++ b/prep.sh
@@ -41,7 +41,7 @@ for LINE in $LINEZ; do
 done
 
 # TODO find a way to encode this in some POM so that it can be managed by Dependabot
-version=1201.vb_4f0b_b_63dd3b
+version=1206.vfc56d5a_a_cf40
 pct=$HOME/.m2/repository/org/jenkins-ci/tests/plugins-compat-tester-cli/${version}/plugins-compat-tester-cli-${version}.jar
 [ -f "${pct}" ] || $MVN dependency:get -Dartifact=org.jenkins-ci.tests:plugins-compat-tester-cli:${version}:jar -DremoteRepositories=https://repo.jenkins-ci.org/public/,https://repo.jenkins-ci.org/incrementals/ -Dtransitive=false
 cp "${pct}" target/pct.jar


### PR DESCRIPTION
Pulls in:

* Clean up hooks (jenkinsci/plugin-compat-tester#403) @basil
* Bump jna from 5.12.1 to 5.13.0 (jenkinsci/plugin-compat-tester#406) @dependabot
* Remove no-longer-necessary SpotBugs suppressions (jenkinsci/plugin-compat-tester#401) @basil
* Rationalize logging subsystem (jenkinsci/plugin-compat-tester#400) @basil
* Miscellaneous code cleanup (jenkinsci/plugin-compat-tester#399) @basil

Of these the only breaking change was a change to the checkout directory of `pipeline-model-definition-plugin` which now matches the Git repository. We adapted the calling code accordingly.


### Testing done

Each PR was tested individually except for the JNA upgrade and SpotBugs fix. This PR's build will test them altogether including the merges.