### PR TITLE
Upgrade PCT to latest

### DIFF
--- a/prep.sh
+++ b/prep.sh
@@ -41,7 +41,7 @@ for LINE in $LINEZ; do
 done
 
 # TODO find a way to encode this in some POM so that it can be managed by Dependabot
-version=1206.vfc56d5a_a_cf40
+version=1210.vb_cf2fd804739
 pct=$HOME/.m2/repository/org/jenkins-ci/tests/plugins-compat-tester-cli/${version}/plugins-compat-tester-cli-${version}.jar
 [ -f "${pct}" ] || $MVN dependency:get -Dartifact=org.jenkins-ci.tests:plugins-compat-tester-cli:${version}:jar -DremoteRepositories=https://repo.jenkins-ci.org/public/,https://repo.jenkins-ci.org/incrementals/ -Dtransitive=false
 cp "${pct}" target/pct.jar


### PR DESCRIPTION
Pulls in:

* Bump jenkins from 1.93 to 1.94 (jenkinsci/plugin-compat-tester#413) @dependabot
* Do not force Windows users to set a Maven installation (jenkinsci/plugin-compat-tester#412) @jtnord
* Remove the example hook (jenkinsci/plugin-compat-tester#411) @jtnord
* Remove usage of Maven SCM API (jenkinsci/plugin-compat-tester#404) @basil

### Testing done

The main change (#404) was tested individually. This PR's build will test all the changes altogether including the merges.