### PR TITLE
Upgrade PCT to latest

### DIFF
--- a/pct.sh
+++ b/pct.sh
@@ -75,7 +75,6 @@ java \
 	-reportFile "$(pwd)/pct-report.xml" \
 	$PCT_S_ARG \
 	-mavenProperties "${MAVEN_PROPERTIES}" \
-	-excludeHooks org.jenkins.tools.test.hook.TransformPom \
 	-mavenPropertiesFile "$(pwd)/maven.properties" \
 	-skipTestCache true
 

--- a/prep.sh
+++ b/prep.sh
@@ -41,7 +41,7 @@ for LINE in $LINEZ; do
 done
 
 # TODO find a way to encode this in some POM so that it can be managed by Dependabot
-version=1210.vb_cf2fd804739
+version=1217.v2db_71d83fff3
 pct=$HOME/.m2/repository/org/jenkins-ci/tests/plugins-compat-tester-cli/${version}/plugins-compat-tester-cli-${version}.jar
 [ -f "${pct}" ] || $MVN dependency:get -Dartifact=org.jenkins-ci.tests:plugins-compat-tester-cli:${version}:jar -DremoteRepositories=https://repo.jenkins-ci.org/public/,https://repo.jenkins-ci.org/incrementals/ -Dtransitive=false
 cp "${pct}" target/pct.jar


### PR DESCRIPTION
Pulls in:

* Bump dom4j from 2.1.3 to 2.1.4 (jenkinsci/plugin-compat-tester#420) @dependabot
* Remove `SystemIOLoggerFilter` (jenkinsci/plugin-compat-tester#418) @basil
* Remove `src/test/resources/test.log` (jenkinsci/plugin-compat-tester#417) @basil
* Remove `NonStandardTagHook` (jenkinsci/plugin-compat-tester#416) @basil
* Remove usages of `org.springframework.core.io.ClassPathResource` (jenkinsci/plugin-compat-tester#415) @basil
* Remove 500 lines of dead code (jenkinsci/plugin-compat-tester#414) @basil
* Remove dependency on Jenkins core (jenkinsci/plugin-compat-tester#410) @basil

With jenkinsci/plugin-compat-tester#414 `TransformPom` has been deleted, so there is no need to maintain any references to it in this code base.

### Testing done

Each of the above changes was tested individually. This PR's build will test all the changes altogether including the merges.