### PR TITLE
Remove obsolete `handlebars` and `momentjs` plugins

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -689,16 +689,6 @@
                 <version>1.1</version>
             </dependency>
             <dependency>
-                <groupId>org.jenkins-ci.ui</groupId>
-                <artifactId>handlebars</artifactId>
-                <version>3.0.8</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jenkins-ci.ui</groupId>
-                <artifactId>momentjs</artifactId>
-                <version>1.1.1</version>
-            </dependency>
-            <dependency>
                 <groupId>org.jenkinsci.plugins</groupId>
                 <artifactId>pipeline-model-api</artifactId>
                 <version>${pipeline-model-definition-plugin.version}</version>


### PR DESCRIPTION
See https://github.com/jenkins-infra/update-center2/pull/677 and https://github.com/jenkinsci/pipeline-stage-view-plugin/pull/257. As of recent releases, these plugins are completely unused in the Jenkins ecosystem. Since these plugins are abandoned and unmaintained (and require custom PCT hooks), simplify maintenance by removing them from the bill of materials (BOM).