### PR TITLE
Remove ACE Editor from the managed set

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -21,7 +21,7 @@
         <scm-api-plugin.version>631.v9143df5b_e4a_a</scm-api-plugin.version>
         <subversion-plugin.version>2.17.0</subversion-plugin.version>
         <workflow-api-plugin.version>1208.v0cc7c6e0da_9e</workflow-api-plugin.version>
-        <workflow-cps-plugin.version>3606.v0b_d8b_e512dcf</workflow-cps-plugin.version>
+        <workflow-cps-plugin.version>3611.v201b_d9f9eb_f7</workflow-cps-plugin.version>
         <workflow-job-plugin.version>1254.v3f64639b_11dd</workflow-job-plugin.version>
         <workflow-multibranch-plugin.version>716.vc692a_e52371b_</workflow-multibranch-plugin.version>
         <workflow-step-api-plugin.version>639.v6eca_cd8c04a_a_</workflow-step-api-plugin.version>
@@ -682,11 +682,6 @@
                 <artifactId>workflow-support</artifactId>
                 <version>${workflow-support-plugin.version}</version>
                 <classifier>tests</classifier>
-            </dependency>
-            <dependency>
-                <groupId>org.jenkins-ci.ui</groupId>
-                <artifactId>ace-editor</artifactId>
-                <version>1.1</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkinsci.plugins</groupId>


### PR DESCRIPTION
`workflow-cps` no longer depends on `ace-editor`, so remove it from the managed set because it has not been refreshed in a long time and represents a maintenance liability (requiring a custom PCT hook to ignore its failures).