### PR TITLE
feat: updatecli manifest to keep PCT version up to date in prep.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ logs/
 megawar.war
 pct.jar
 plugin-manager.jar
-updatecli.d/
+!updatecli.d/
+updatecli.d/*
+!updatecli.d/plugin-compat-tester.yml
 .env
 .envrc

--- a/prep.sh
+++ b/prep.sh
@@ -40,7 +40,7 @@ for LINE in $LINEZ; do
 	popd
 done
 
-# TODO find a way to encode this in some POM so that it can be managed by Dependabot
+# Tracked by ./updatecli/updatecli.d/plugin-compat-tester.yml
 version=1221.vb_b_1b_53b_646c4
 pct=$HOME/.m2/repository/org/jenkins-ci/tests/plugins-compat-tester-cli/${version}/plugins-compat-tester-cli-${version}.jar
 [ -f "${pct}" ] || $MVN dependency:get -Dartifact=org.jenkins-ci.tests:plugins-compat-tester-cli:${version}:jar -DremoteRepositories=https://repo.jenkins-ci.org/public/,https://repo.jenkins-ci.org/incrementals/ -Dtransitive=false

--- a/updatecli/updatecli.d/plugin-compat-tester.yml
+++ b/updatecli/updatecli.d/plugin-compat-tester.yml
@@ -1,0 +1,45 @@
+---
+name: Bump `plugin-compat-tester` version in prep.sh
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  pctVersion:
+    kind: githubrelease
+    spec:
+      owner: "jenkinsci"
+      repository: "plugin-compat-tester"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+
+targets:
+  setPctInPrep:
+    sourceid: pctVersion
+    name: "Change the plugin-compat-tester version in prep.sh"
+    kind: file
+    spec:
+      file: prep.sh
+      matchpattern: >-
+        version=(.*)
+      replacepattern: >-
+        version={{ source `pctVersion` }}
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Bump `plugin-compat-tester` version in prep.sh
+    spec:
+      labels:
+        - plugin-compat-tester


### PR DESCRIPTION
This PR add an updatecli manifest to keep PCT version up to date in prep.sh

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [N/A] Link to relevant issues in GitHub or Jira
- [N/A] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

cc @jetersen I've looked at your powershell scripts and kept a .gitignore compatible with it. I think this addition should not interfere with your manifests.