### PR TITLE
Do not allow empty results

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ def mavenEnv(Map params = [:], Closure body) {
             withEnv(["MAVEN_SETTINGS=$settingsXml"]) {
                 body()
             }
-            if (junit(testResults: '**/target/surefire-reports/TEST-*.xml', allowEmptyResults: true).failCount > 0) {
+            if (junit(testResults: '**/target/*-reports/TEST-*.xml').failCount > 0) {
                 // TODO JENKINS-27092 throw up UNSTABLE status in this case
                 error 'Some test failures, not going to continue'
             }

--- a/pct.sh
+++ b/pct.sh
@@ -58,6 +58,11 @@ MAVEN_PROPERTIES+=:hpi-plugin.version=3.38
 echo upperBoundsExcludes=javax.servlet:servlet-api >maven.properties
 
 #
+# This test has been broken for a very long time.
+#
+[[ $PLUGINS == gitlab-plugin ]] && MAVEN_PROPERTIES+=:failsafe.excludes=com.dabsquared.gitlabjenkins.testing.integration.GitLabIT
+
+#
 # Testing plugins against a version of Jenkins that requires Java 11 exposes
 # jenkinsci/plugin-pom#563. This was fixed in plugin parent POM 4.42, but many plugins under test
 # still use an older plugin parent POM. As a temporary workaround, we skip Enforcer.


### PR DESCRIPTION
As of #1732 PCT is out of the business of test results, so lean on the JUnit plugin for the important task of marking the build unstable if no tests were executed. Ulli's plugins put their results in `**/target/failsafe-reports/TEST-*.xml` rather than `**/target/surefire-reports/TEST-*.xml`, so adjusting the regular expression to match as well. That, in turn, exposed the fact that the GitLab plugin was running an integration test that has been failing for years, so I excluded that. And with that everything is passing.