### PR TITLE
Use artifact caching proxy for BOM builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,10 +8,7 @@ def mavenEnv(Map params = [:], Closure body) {
     node("maven-$params.jdk") { // no Dockerized tests; https://github.com/jenkins-infra/documentation/blob/master/ci.adoc#container-agents
         timeout(90) {
             sh 'mvn -version'
-            def settingsXml = "$WORKSPACE_TMP/settings.xml"
-            def ok = infra.retrieveMavenSettingsFile(settingsXml)
-            assert ok
-            withEnv(["MAVEN_SETTINGS=$settingsXml"]) {
+            infra.withArtifactCachingProxy {
                 body()
             }
             if (junit(testResults: '**/target/*-reports/TEST-*.xml').failCount > 0) {


### PR DESCRIPTION
This PR uses the artifact caching proxy for Maven builds, which should strongly decrease our JFrog Artifactory bandwidth consumption and increase builds reliability.

Note: a `skip-artifact-caching-proxy` label can be added on pull request to punctually disable it and use repo.jenkins-ci.org if needed.

Closes #1508

Ref: https://github.com/jenkins-infra/helpdesk/issues/2752 & https://github.com/jenkins-infra/pipeline-library/pull/583

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue
