### PR TITLE
Use 'chore' label for pct version updates

### DIFF
--- a/updatecli/updatecli.d/plugin-compat-tester.yml
+++ b/updatecli/updatecli.d/plugin-compat-tester.yml
@@ -39,7 +39,7 @@ actions:
   default:
     kind: github/pullrequest
     scmid: default
-    title: Bump `plugin-compat-tester` version in prep.sh
+    title: Bump `plugin-compat-tester` version in prep.sh to {{ source `pctVersion` }}
     spec:
       labels:
         - chore

--- a/updatecli/updatecli.d/plugin-compat-tester.yml
+++ b/updatecli/updatecli.d/plugin-compat-tester.yml
@@ -42,4 +42,4 @@ actions:
     title: Bump `plugin-compat-tester` version in prep.sh
     spec:
       labels:
-        - plugin-compat-tester
+        - chore

--- a/updatecli/updatecli.d/plugin-compat-tester.yml
+++ b/updatecli/updatecli.d/plugin-compat-tester.yml
@@ -43,3 +43,4 @@ actions:
     spec:
       labels:
         - chore
+        - plugin-compat-tester


### PR DESCRIPTION
## Use `chore` label for PCT version updates

Use an existing label so that release drafter correctly categorizes the pull request message in the changelog.

There is no label 'plugin-compat-tester' and release drafter would not recognize it if there were.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
