### PR TITLE
Fix #1739 - Remove bootstrap4 & popper api plugins

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -53,11 +53,6 @@
             </dependency>
             <dependency>
                 <groupId>io.jenkins.plugins</groupId>
-                <artifactId>bootstrap4-api</artifactId>
-                <version>4.6.0-5</version>
-            </dependency>
-            <dependency>
-                <groupId>io.jenkins.plugins</groupId>
                 <artifactId>bootstrap5-api</artifactId>
                 <version>5.2.0-1</version>
             </dependency>
@@ -214,11 +209,6 @@
                 <artifactId>plugin-util-api</artifactId>
                 <version>${plugin-util-api.version}</version>
                 <classifier>tests</classifier>
-            </dependency>
-            <dependency>
-                <groupId>io.jenkins.plugins</groupId>
-                <artifactId>popper-api</artifactId>
-                <version>1.16.1-3</version>
             </dependency>
             <dependency>
                 <groupId>io.jenkins.plugins</groupId>

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -60,11 +60,6 @@
         </dependency>
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
-            <artifactId>bootstrap4-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.jenkins.plugins</groupId>
             <artifactId>bootstrap5-api</artifactId>
             <scope>test</scope>
         </dependency>
@@ -176,11 +171,6 @@
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>plugin-util-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.jenkins.plugins</groupId>
-            <artifactId>popper-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Remove bootstrap4 & popper API plugins

Fix #1739

Library plugins used by very few plugins

Plugin consumers are generally not maintained

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
