### PR TITLE
Fix Maven remote repositories ambiguity

### DIFF
--- a/prep.sh
+++ b/prep.sh
@@ -43,7 +43,7 @@ done
 # Tracked by ./updatecli/updatecli.d/plugin-compat-tester.yml
 version=1244.vb_0641fa_d4826
 pct=$HOME/.m2/repository/org/jenkins-ci/tests/plugins-compat-tester-cli/${version}/plugins-compat-tester-cli-${version}.jar
-[ -f "${pct}" ] || $MVN dependency:get -Dartifact=org.jenkins-ci.tests:plugins-compat-tester-cli:${version}:jar -DremoteRepositories=https://repo.jenkins-ci.org/public/,https://repo.jenkins-ci.org/incrementals/ -Dtransitive=false
+[ -f "${pct}" ] || $MVN dependency:get -Dartifact=org.jenkins-ci.tests:plugins-compat-tester-cli:${version}:jar -DremoteRepositories=repo.jenkins-ci.org::default::https://repo.jenkins-ci.org/public/,incrementals::default::https://repo.jenkins-ci.org/incrementals/ -Dtransitive=false
 cp "${pct}" target/pct.jar
 
 # produces: target/{megawar-*.war,pct.jar,plugins.txt,lines.txt}


### PR DESCRIPTION
Resolve the ambiguity for incrementals when there is [a `*` in the `mirrorOf` section of the settings.xml](https://github.com/lemeurherve/jenkins-infra/blob/b571893125f41cb5fe31dd7a97c5828b6c8fd720/dist/profile/templates/jenkinscontroller/casc/artifact-caching-proxy.yaml.erb#L14) (which we want in order to cache the maximum of Maven repositories)

Tested in #1765:

>  [INFO] Resolving org.jenkins-ci.tests:plugins-compat-tester-cli:jar:1249.v93361f4ff6dd
>  [INFO] Downloading from aws-proxy: https://repo.aws.jenkins.io/public/org/jenkins-ci/tests/plugins-compat-tester-cli/1249.v93361f4ff6dd/plugins-compat-tester-cli-1249.v93361f4ff6dd.pom
>  [INFO] Downloading from aws-proxy-incrementals: https://repo.aws.jenkins.io/incrementals/org/jenkins-ci/tests/plugins-compat-tester-cli/1249.v93361f4ff6dd/plugins-compat-tester-cli-1249.v93361f4ff6dd.pom
>  [INFO] Downloaded from aws-proxy-incrementals: https://repo.aws.jenkins.io/incrementals/org/jenkins-ci/tests/plugins-compat-tester-cli/1249.v93361f4ff6dd/plugins-compat-tester-cli-1249.v93361f4ff6dd.pom (5.0 kB at 64 kB/s)
>  [INFO] Downloading from aws-proxy: https://repo.aws.jenkins.io/public/org/jenkins-ci/tests/plugins-compat-tester-cli/1249.v93361f4ff6dd/plugins-compat-tester-cli-1249.v93361f4ff6dd.jar
>  [INFO] Downloading from aws-proxy-incrementals: https://repo.aws.jenkins.io/incrementals/org/jenkins-ci/tests/plugins-compat-tester-cli/1249.v93361f4ff6dd/plugins-compat-tester-cli-1249.v93361f4ff6dd.jar
>  [INFO] Downloaded from aws-proxy-incrementals: https://repo.aws.jenkins.io/incrementals/org/jenkins-ci/tests/plugins-compat-tester-cli/1249.v93361f4ff6dd/plugins-compat-tester-cli-1249.v93361f4ff6dd.jar (3.0 MB at 44 MB/s)

Ref: https://github.com/jenkins-infra/helpdesk/issues/3392