### PR TITLE
[JENKINS-70528] Bump `workflow-durable-task-step` and `workflow-basic-steps` together

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -617,7 +617,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins.workflow</groupId>
                 <artifactId>workflow-basic-steps</artifactId>
-                <version>994.vd57e3ca_46d24</version>
+                <version>1010.vf7a_b_98e847c1</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -633,7 +633,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins.workflow</groupId>
                 <artifactId>workflow-durable-task-step</artifactId>
-                <version>1223.v7f1a_98a_8863e</version>
+                <version>1234.v019404b_3832a</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins.workflow</groupId>


### PR DESCRIPTION
Picks up https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/292 and https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/293. Closes #1768.