### PR TITLE
Remove workaround for github plugin test failure

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,9 +50,6 @@ lines.each {line ->
     plugins.each { plugin ->
         branches["pct-$plugin-$line"] = {
             def jdk = line == 'weekly' ? 17 : 11
-            if (plugin == 'github') {
-                jdk = 11 // TODO JENKINS-69353 DefaultPushGHEventListenerTest does not yet pass on Java 17
-            }
             mavenEnv(jdk: jdk) {
                 deleteDir()
                 unstash 'pct.sh'


### PR DESCRIPTION
## Remove workaround for github plugin test failure

The test failures in github plugin are resolved in github plugin 1.37.0.

https://github.com/jenkinsci/bom/pull/1783#issuecomment-1439338077 provides more details

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
