### PR TITLE
Add Amazon Web Services SDK to the managed set

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -9,6 +9,7 @@
     <artifactId>bom-weekly</artifactId>
     <packaging>pom</packaging>
     <properties>
+        <aws-java-sdk-plugin.version>1.12.406-370.v8f993c987059</aws-java-sdk-plugin.version>
         <checks-api.version>1.8.1</checks-api.version>
         <configuration-as-code-plugin.version>1569.vb_72405b_80249</configuration-as-code-plugin.version>
         <data-tables-api.version>1.12.1-4</data-tables-api.version>
@@ -582,6 +583,71 @@
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>ws-cleanup</artifactId>
                 <version>0.44</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins.aws-java-sdk</groupId>
+                <artifactId>aws-java-sdk-cloudformation</artifactId>
+                <version>${aws-java-sdk-plugin.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins.aws-java-sdk</groupId>
+                <artifactId>aws-java-sdk-codebuild</artifactId>
+                <version>${aws-java-sdk-plugin.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins.aws-java-sdk</groupId>
+                <artifactId>aws-java-sdk-ec2</artifactId>
+                <version>${aws-java-sdk-plugin.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins.aws-java-sdk</groupId>
+                <artifactId>aws-java-sdk-ecr</artifactId>
+                <version>${aws-java-sdk-plugin.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins.aws-java-sdk</groupId>
+                <artifactId>aws-java-sdk-ecs</artifactId>
+                <version>${aws-java-sdk-plugin.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins.aws-java-sdk</groupId>
+                <artifactId>aws-java-sdk-efs</artifactId>
+                <version>${aws-java-sdk-plugin.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins.aws-java-sdk</groupId>
+                <artifactId>aws-java-sdk-elasticbeanstalk</artifactId>
+                <version>${aws-java-sdk-plugin.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins.aws-java-sdk</groupId>
+                <artifactId>aws-java-sdk-iam</artifactId>
+                <version>${aws-java-sdk-plugin.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins.aws-java-sdk</groupId>
+                <artifactId>aws-java-sdk-logs</artifactId>
+                <version>${aws-java-sdk-plugin.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins.aws-java-sdk</groupId>
+                <artifactId>aws-java-sdk-minimal</artifactId>
+                <version>${aws-java-sdk-plugin.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins.aws-java-sdk</groupId>
+                <artifactId>aws-java-sdk-sns</artifactId>
+                <version>${aws-java-sdk-plugin.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins.aws-java-sdk</groupId>
+                <artifactId>aws-java-sdk-sqs</artifactId>
+                <version>${aws-java-sdk-plugin.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins.aws-java-sdk</groupId>
+                <artifactId>aws-java-sdk-ssm</artifactId>
+                <version>${aws-java-sdk-plugin.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins.pipeline-stage-view</groupId>

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -462,6 +462,71 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.jenkins-ci.plugins.aws-java-sdk</groupId>
+            <artifactId>aws-java-sdk-cloudformation</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.aws-java-sdk</groupId>
+            <artifactId>aws-java-sdk-codebuild</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.aws-java-sdk</groupId>
+            <artifactId>aws-java-sdk-ec2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.aws-java-sdk</groupId>
+            <artifactId>aws-java-sdk-ecr</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.aws-java-sdk</groupId>
+            <artifactId>aws-java-sdk-ecs</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.aws-java-sdk</groupId>
+            <artifactId>aws-java-sdk-efs</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.aws-java-sdk</groupId>
+            <artifactId>aws-java-sdk-elasticbeanstalk</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.aws-java-sdk</groupId>
+            <artifactId>aws-java-sdk-iam</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.aws-java-sdk</groupId>
+            <artifactId>aws-java-sdk-logs</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.aws-java-sdk</groupId>
+            <artifactId>aws-java-sdk-minimal</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.aws-java-sdk</groupId>
+            <artifactId>aws-java-sdk-sns</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.aws-java-sdk</groupId>
+            <artifactId>aws-java-sdk-sqs</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.aws-java-sdk</groupId>
+            <artifactId>aws-java-sdk-ssm</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jenkins-ci.plugins.to-declarative</groupId>
             <artifactId>declarative-pipeline-migration-assistant</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
These plugins meet our criteria by being both library plugins as well as being popular plugins. In addition, they exercise custom PCT hooks, making them worthwhile to include in `jenkinsci/bom`.