### PR TITLE
Add JaCoCo to the managed set

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -394,6 +394,11 @@
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>jacoco</artifactId>
+                <version>3.3.3-rc931.593159b_700c5</version> <!-- TODO https://github.com/jenkinsci/jacoco-plugin/pull/206 -->
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>javadoc</artifactId>
                 <version>226.v71211feb_e7e9</version>
             </dependency>

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -324,6 +324,18 @@
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>jacoco</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <!-- TODO RequireUpperBoundDeps with pipeline-utility-steps -->
+                <exclusion>
+                    <groupId>org.codehaus.plexus</groupId>
+                    <artifactId>plexus-utils</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>javadoc</artifactId>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
This is both a popular plugin and a plugin with a custom PCT hook, so it is beneficial to include it in the managed set. Additionally, had we included it before, we would have discovered a Java 17 test failure sooner.