### PR TITLE
Use DigitalOcean agents exclusively as temporary fix for "Out of space" error

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,8 @@ def mavenEnv(Map params = [:], Closure body) {
   def attempts = 3
   retry(count: attempts, conditions: [kubernetesAgent(), nonresumable()]) {
     echo 'Attempt ' + ++attempt + ' of ' + attempts
+    // Forcing the execution on DigitalOcean for now.
+    // TODO: remove 'doks' when AWS agents are fixed cf https://github.com/jenkins-infra/helpdesk/issues/3423#issuecomment-1473642909
     node("maven-$params.jdk && doks") { // no Dockerized tests; https://github.com/jenkins-infra/documentation/blob/master/ci.adoc#container-agents
         timeout(90) {
             sh 'mvn -version'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ def mavenEnv(Map params = [:], Closure body) {
   def attempts = 3
   retry(count: attempts, conditions: [kubernetesAgent(), nonresumable()]) {
     echo 'Attempt ' + ++attempt + ' of ' + attempts
-    node("maven-$params.jdk") { // no Dockerized tests; https://github.com/jenkins-infra/documentation/blob/master/ci.adoc#container-agents
+    node("maven-$params.jdk && doks") { // no Dockerized tests; https://github.com/jenkins-infra/documentation/blob/master/ci.adoc#container-agents
         timeout(90) {
             sh 'mvn -version'
             infra.withArtifactCachingProxy {


### PR DESCRIPTION
As noted in https://github.com/jenkins-infra/helpdesk/issues/3423#issuecomment-1473642909, only the AWS agents have an available space problem.

This PR is forcing the BOM builds to run on DigitalOcean cluster as a short term fix until we resolve the AWS agents space issue.