### PR TITLE
Add JaCoCo to the managed set

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -399,6 +399,11 @@
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>jacoco</artifactId>
+                <version>3.3.3</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>javadoc</artifactId>
                 <version>226.v71211feb_e7e9</version>
             </dependency>

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -322,6 +322,18 @@
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>jacoco</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <!-- TODO RequireUpperBoundDeps with pipeline-utility-steps -->
+                <exclusion>
+                    <groupId>org.codehaus.plexus</groupId>
+                    <artifactId>plexus-utils</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>javadoc</artifactId>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
JaCoCo has a custom PCT hook, so adding it to `jenkinsci/bom` will facilitate PCT testing. I tested this change locally with `PLUGINS=jacoco bash local-test.sh`.