### PR TITLE
Add GitHub Branch Source to the managed set

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -364,6 +364,11 @@
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>github-branch-source</artifactId>
+                <version>1703.vd5a_2b_29c6cdc</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>gitlab-oauth</artifactId>
                 <version>1.16</version>
             </dependency>

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -285,6 +285,11 @@
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>github-branch-source</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>gitlab-oauth</artifactId>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
This plugin is sufficiently critical to the Jenkins ecosystem that it surely deserves regular compatibility testing.