### PR TITLE
Update several plugins related to warnings-ng

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -12,14 +12,14 @@
         <aws-java-sdk-plugin.version>1.12.406-374.v4cdf53953691</aws-java-sdk-plugin.version>
         <checks-api.version>2.0.0</checks-api.version>
         <configuration-as-code-plugin.version>1616.v11393eccf675</configuration-as-code-plugin.version>
-        <data-tables-api.version>1.13.3-2</data-tables-api.version>
+        <data-tables-api.version>1.13.3-3</data-tables-api.version>
         <declarative-pipeline-migration-assistant-plugin.version>1.5.5</declarative-pipeline-migration-assistant-plugin.version>
-        <forensics-api.version>2.0.1</forensics-api.version>
+        <forensics-api.version>2.1.0</forensics-api.version>
         <git-plugin.version>5.0.0</git-plugin.version>
         <mina-sshd-api.version>2.9.2-62.v199162f0a_2f8</mina-sshd-api.version>
         <pipeline-model-definition-plugin.version>2.2125.vddb_a_44a_d605e</pipeline-model-definition-plugin.version>
         <pipeline-stage-view-plugin.version>2.31</pipeline-stage-view-plugin.version>
-        <plugin-util-api.version>3.1.0</plugin-util-api.version>
+        <plugin-util-api.version>3.2.0</plugin-util-api.version>
         <scm-api-plugin.version>631.v9143df5b_e4a_a</scm-api-plugin.version>
         <subversion-plugin.version>2.17.1</subversion-plugin.version>
         <workflow-api-plugin.version>1208.v0cc7c6e0da_9e</workflow-api-plugin.version>
@@ -60,7 +60,7 @@
             <dependency>
                 <groupId>io.jenkins.plugins</groupId>
                 <artifactId>bootstrap5-api</artifactId>
-                <version>5.2.2-1</version>
+                <version>5.2.2-2</version>
             </dependency>
             <dependency>
                 <groupId>io.jenkins.plugins</groupId>
@@ -112,7 +112,7 @@
             <dependency>
                 <groupId>io.jenkins.plugins</groupId>
                 <artifactId>echarts-api</artifactId>
-                <version>5.4.0-2</version>
+                <version>5.4.0-3</version>
             </dependency>
             <dependency>
                 <groupId>io.jenkins.plugins</groupId>
@@ -122,7 +122,7 @@
             <dependency>
                 <groupId>io.jenkins.plugins</groupId>
                 <artifactId>font-awesome-api</artifactId>
-                <version>6.3.0-1</version>
+                <version>6.3.0-2</version>
             </dependency>
             <dependency>
                 <groupId>io.jenkins.plugins</groupId>
@@ -193,7 +193,7 @@
             <dependency>
                 <groupId>io.jenkins.plugins</groupId>
                 <artifactId>jquery3-api</artifactId>
-                <version>3.6.3-1</version>
+                <version>3.6.4-1</version>
             </dependency>
             <dependency>
                 <groupId>io.jenkins.plugins</groupId>


### PR DESCRIPTION
## Update several plugins related to warnings-ng plugin

* forensics-api from 2.0.1 to 2.1.0 https://github.com/jenkinsci/forensics-api-plugin/compare/v2.0.1...v2.1.0
* bootstrap5-api from 5.2.2-1 to 5.2.2-2 https://github.com/jenkinsci/bootstrap5-api-plugin/releases/tag/v5.2.2-2
* data-tables-api from 1.13.3-2 to 1.13.3-3 https://github.com/jenkinsci/data-tables-api-plugin/releases/tag/v1.13.3-3
* echarts-api from 5.4.0-2 to 5.4.0-3 https://github.com/jenkinsci/echarts-api-plugin/releases/tag/v5.4.0-3
* font-awesome-api from 6.3.0-1 to 6.3.0-2 https://github.com/jenkinsci/font-awesome-api-plugin/releases/tag/v6.3.0-2
* plugin-util-api from 3.1.0 to 3.2.0 https://github.com/jenkinsci/plugin-util-api-plugin/releases/tag/v3.2.0
* jquery3-api from 3.6.3-1 to 3.6.4-1 https://github.com/jenkinsci/jquery3-api-plugin/releases/tag/v3.6.4-1

All updated versions were released recently.  Cheaper to evaluate multiple plugins in a single pull request rather than evaluating as individual changes.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
