### PR TITLE
Add missing Mina SSHD plugins to the managed set

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -242,6 +242,16 @@
                 <version>${mina-sshd-api.version}</version>
             </dependency>
             <dependency>
+                <groupId>io.jenkins.plugins.mina-sshd-api</groupId>
+                <artifactId>mina-sshd-api-scp</artifactId>
+                <version>${mina-sshd-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.jenkins.plugins.mina-sshd-api</groupId>
+                <artifactId>mina-sshd-api-sftp</artifactId>
+                <version>${mina-sshd-api.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.6wind.jenkins</groupId>
                 <artifactId>lockable-resources</artifactId>
                 <version>1131.vb_7c3d377e723</version>

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -189,7 +189,12 @@
         </dependency>
         <dependency>
             <groupId>io.jenkins.plugins.mina-sshd-api</groupId>
-            <artifactId>mina-sshd-api-core</artifactId>
+            <artifactId>mina-sshd-api-scp</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jenkins.plugins.mina-sshd-api</groupId>
+            <artifactId>mina-sshd-api-sftp</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -437,6 +442,13 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>subversion</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <!-- TODO RequireUpperBoundDeps with mina-sshd-api-plugin -->
+                <exclusion>
+                    <groupId>org.apache.sshd</groupId>
+                    <artifactId>sshd-common</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Not sure why half of the Mina SSHD plugins were in the managed set and half were not.