### PR TITLE
Add Pipeline: GitHub Groovy Libraries to the managed set

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -479,6 +479,11 @@
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>pipeline-github-lib</artifactId>
+                <version>42.v0739460cda_c4</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>pipeline-graph-analysis</artifactId>
                 <version>202.va_d268e64deb_3</version>
             </dependency>

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -393,6 +393,11 @@
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>pipeline-github-lib</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>pipeline-graph-analysis</artifactId>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
Reasons for including this:

- It's in the top 75 with 222,459 installations
- CloudBees supports it as well, so this keeps this repository "competitive"