### PR TITLE
Adapt to jenkinsci/plugin-compat-tester#505

### DIFF
--- a/excludes.txt
+++ b/excludes.txt
@@ -10,5 +10,8 @@ org.jenkinsci.plugins.durabletask.BourneShellScriptTest
 # TODO fails for one reason in (non-PCT) official sources, run locally; and for another reason in PCT in Docker; passes in official sources in Docker, or locally in PCT
 org.jenkinsci.plugins.gitclient.FilePermissionsTest
 
+# TODO https://github.com/jenkinsci/matrix-auth-plugin/pull/136
+org.jenkinsci.plugins.matrixauth.integrations.casc.ImportTest
+
 # TODO tends to run out of memory
 org.jenkinsci.plugins.pipeline.modeldefinition.TriggersTest

--- a/pct.sh
+++ b/pct.sh
@@ -28,7 +28,6 @@ exec java \
 	$PCT_D_ARGS \
 	-DforkCount=.75C \
 	-Djth.jenkins-war.path="$(pwd)/megawar.war" \
-	-DoverrideWarAdditions=true \
 	-Dsurefire.excludesFile="$(pwd)/excludes.txt"
 
 # produces: **/target/surefire-reports/TEST-*.xml

--- a/prep.sh
+++ b/prep.sh
@@ -41,7 +41,7 @@ for LINE in $LINEZ; do
 done
 
 # Tracked by ./updatecli/updatecli.d/plugin-compat-tester.yml
-version=1286.v5a_54b_fd87db_f
+version=1290.v353fb_2a_fa_b_06
 pct="$($MVN -Dset.changelist -Dexpression=settings.localRepository -q -DforceStdout help:evaluate)/org/jenkins-ci/tests/plugins-compat-tester-cli/${version}/plugins-compat-tester-cli-${version}.jar"
 [ -f "${pct}" ] || $MVN dependency:get -Dartifact=org.jenkins-ci.tests:plugins-compat-tester-cli:${version}:jar -DremoteRepositories=repo.jenkins-ci.org::default::https://repo.jenkins-ci.org/public/,incrementals::default::https://repo.jenkins-ci.org/incrementals/ -Dtransitive=false
 cp "${pct}" target/pct.jar


### PR DESCRIPTION
Adapt to jenkinsci/plugin-compat-tester#505 by:

- Upgrading PCT to the latest release
- Removing `-DoverrideWarAdditions=true` which has now been removed from Maven HPI plugin
- Excluding `org.jenkinsci.plugins.matrixauth.integrations.casc.ImportTest` because https://github.com/jenkinsci/matrix-auth-plugin/pull/136 still has not been merged and released

Closes #1912