### PR TITLE
Record Launchable test results without a build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,9 +58,12 @@ lines.each {line ->
                 unstash 'excludes.txt'
                 unstash 'pct'
                 unstash "megawar-$line"
+                launchable.install()
+                launchable('verify')
                 withEnv(["PLUGINS=$plugin", "LINE=$line", 'EXTRA_MAVEN_PROPERTIES=maven.test.failure.ignore=true:surefire.rerunFailingTestsCount=4']) {
                     sh 'mv megawar-$LINE.war megawar.war && bash pct.sh'
                 }
+                launchable("record tests --no-build maven './**/target/surefire-reports'")
             }
         }
     }


### PR DESCRIPTION
The first baby step toward getting data flowing into Launchable. Currently blocked on https://github.com/jenkins-infra/pipeline-library/pull/630 and cannot be merged until https://github.com/jenkins-infra/pipeline-library/pull/630 is merged.

Tested successfully in https://ci.jenkins.io/job/Tools/job/bom/job/PR-1914/3/