### PR TITLE
Record Launchable builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,11 @@ stage('prep') {
     mavenEnv(jdk: 11) {
         checkout scm
         withEnv(['SAMPLE_PLUGIN_OPTS=-Dset.changelist']) {
-            sh 'bash prep.sh'
+            withCredentials([
+                usernamePassword(credentialsId: 'app-ci.jenkins.io', usernameVariable: 'GITHUB_APP', passwordVariable: 'GITHUB_OAUTH')
+            ]) {
+                sh 'bash prep.sh'
+            }
         }
         dir('target') {
             plugins = readFile('plugins.txt').split('\n')
@@ -39,7 +43,14 @@ stage('prep') {
                 lines = [lines[0], lines[-1]] // run PCT only on newest and oldest lines, to save resources
             }
             stash name: 'pct', includes: 'pct.jar'
-            lines.each {stash name: "megawar-$it", includes: "megawar-${it}.war"}
+            lines.each { line ->
+                def commitHashes = readFile "commit-hashes-${line}.txt"
+                launchable.install()
+                launchable("record build --name \"${BUILD_TAG}-${line}\" --no-commit-collection " + commitHashes)
+                launchable("record session --build \"${BUILD_TAG}-${line}\" --observation >launchable-session-${line}.txt")
+                stash name: "megawar-${line}", includes: "megawar-${line}.war"
+                stash name: "launchable-session-${line}.txt", includes: "launchable-session-${line}.txt"
+            }
         }
         stash name: 'pct.sh', includes: 'pct.sh'
         stash name: 'excludes.txt', includes: 'excludes.txt'
@@ -56,6 +67,7 @@ lines.each {line ->
                 deleteDir()
                 unstash 'pct.sh'
                 unstash 'excludes.txt'
+                unstash "launchable-session-${line}.txt"
                 unstash 'pct'
                 unstash "megawar-$line"
                 launchable.install()
@@ -63,7 +75,8 @@ lines.each {line ->
                 withEnv(["PLUGINS=$plugin", "LINE=$line", 'EXTRA_MAVEN_PROPERTIES=maven.test.failure.ignore=true:surefire.rerunFailingTestsCount=4']) {
                     sh 'mv megawar-$LINE.war megawar.war && bash pct.sh'
                 }
-                launchable("record tests --no-build maven './**/target/surefire-reports'")
+                def launchableSession = readFile "launchable-session-${line}.txt"
+                launchable("record tests --session ${launchableSession} maven './**/target/surefire-reports'") // TODO add failsafe reports
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -75,7 +75,7 @@ lines.each {line ->
                 withEnv(["PLUGINS=$plugin", "LINE=$line", 'EXTRA_MAVEN_PROPERTIES=maven.test.failure.ignore=true:surefire.rerunFailingTestsCount=4']) {
                     sh 'mv megawar-$LINE.war megawar.war && bash pct.sh'
                 }
-                def launchableSession = readFile "launchable-session-${line}.txt"
+                def launchableSession = readFile("launchable-session-${line}.txt").trim()
                 launchable("record tests --session ${launchableSession} maven './**/target/surefire-reports'") // TODO add failsafe reports
             }
         }

--- a/prep.sh
+++ b/prep.sh
@@ -38,6 +38,16 @@ for LINE in $LINEZ; do
 	cd "megawar-${LINE}"
 	jar c0Mf "../../../target/megawar-${LINE}.war" *
 	popd
+	if [[ ${LINE} != weekly ]]; then
+		PROFILE="-P${LINE}"
+	fi
+	# TODO https://github.com/jenkinsci/maven-hpi-plugin/pull/464
+	$MVN -f sample-plugin hpi:resolve-test-dependencies \
+		${SAMPLE_PLUGIN_OPTS:-} ${PROFILE:-} \
+		-DoverrideWar="../target/megawar-${LINE}.war" -DuseUpperBounds \
+		-Dhpi-plugin.version=3.42-rc1408.b_fb_b_75ef46e7 \
+		-DcommitHashes=target/commit-hashes.txt
+	mv sample-plugin/target/commit-hashes.txt "target/commit-hashes-${LINE}.txt"
 done
 
 # Tracked by ./updatecli/updatecli.d/plugin-compat-tester.yml
@@ -46,4 +56,4 @@ pct="$($MVN -Dset.changelist -Dexpression=settings.localRepository -q -DforceStd
 [ -f "${pct}" ] || $MVN dependency:get -Dartifact=org.jenkins-ci.tests:plugins-compat-tester-cli:${version}:jar -DremoteRepositories=repo.jenkins-ci.org::default::https://repo.jenkins-ci.org/public/,incrementals::default::https://repo.jenkins-ci.org/incrementals/ -Dtransitive=false
 cp "${pct}" target/pct.jar
 
-# produces: target/{megawar-*.war,pct.jar,plugins.txt,lines.txt}
+# produces: target/{megawar-*.war,commit-hashes-*.txt,pct.jar,plugins.txt,lines.txt}

--- a/prep.sh
+++ b/prep.sh
@@ -42,10 +42,14 @@ for LINE in $LINEZ; do
 		PROFILE="-P${LINE}"
 	fi
 	# TODO https://github.com/jenkinsci/maven-hpi-plugin/pull/464
-	$MVN -f sample-plugin hpi:resolve-test-dependencies \
-		${SAMPLE_PLUGIN_OPTS:-} ${PROFILE:-} \
-		-DoverrideWar="../target/megawar-${LINE}.war" -DuseUpperBounds \
-		-Dhpi-plugin.version=3.42-rc1408.b_fb_b_75ef46e7 \
+	$MVN \
+		-f sample-plugin \
+		hpi:resolve-test-dependencies \
+		${SAMPLE_PLUGIN_OPTS:-} \
+		${PROFILE:-} \
+		-DoverrideWar="../target/megawar-${LINE}.war" \
+		-DuseUpperBounds \
+		-Dhpi-plugin.version=3.42-rc1409.669de6d1a_866 \
 		-DcommitHashes=target/commit-hashes.txt
 	mv sample-plugin/target/commit-hashes.txt "target/commit-hashes-${LINE}.txt"
 done


### PR DESCRIPTION
This is the next step in Launchable data collection: recording builds and test sessions. This PR depends on https://github.com/jenkins-infra/pipeline-library/pull/632 and https://github.com/jenkinsci/jenkins/pull/7780 to collect commits.

These two pages are extremely useful to understand this approach:

- https://www.launchableinc.com/docs/sending-data-to-launchable/using-the-launchable-cli/recording-builds-with-the-launchable-cli/recording-builds-from-multiple-repositories/
- https://www.launchableinc.com/docs/sending-data-to-launchable/using-the-launchable-cli/recording-test-results-with-the-launchable-cli/managing-complex-test-session-layouts/

Here I am defining a build per BOM line, so each PR build would have 2 or 4 Launchable builds (based on whether or not the pull request labels contain `full-test`). This is losing some information, because each plugin under test depends on a subset of the other plugins under test, not the entire set of other plugins under test. So we could define builds with a smaller set of commits, per plugin under test. That might make the results more difficult to aggregate, though. There is some discussion of the tradeoffs in this page:

- https://www.launchableinc.com/docs/concepts/test-session/#running-tests-in-parallel

For now I am defining the Launchable build per BOM line because it is easy to implement, but the matter is not closed for me. I still think it is worth clarifying what the preferred granularity of a Launchable build should be.

To capture the commit hashes of all the components (Jenkins core, other plugins, other libraries maintained by the Jenkins project) I am using https://github.com/jenkinsci/maven-hpi-plugin/pull/464 to fetch the POM of each component and resolve the Git tag to a commit hash using the GitHub API. This is particularly painful, and I think there must be some better way to do this. This also requires a GitHub authentication token to be passed to the build.

Assuming we also get commits flowing by merging https://github.com/jenkins-infra/pipeline-library/pull/632 and https://github.com/jenkinsci/jenkins/pull/7780, then this PR puts a stake in the ground with a first attempt at getting useful data flowing into Launchable.