### PR TITLE
Temporarily exclude DigitalOcean artifact caching proxy provider

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,9 @@ def mavenEnv(Map params = [:], Closure body) {
     node("maven-$params.jdk") { // no Dockerized tests; https://github.com/jenkins-infra/documentation/blob/master/ci.adoc#container-agents
         timeout(120) {
             sh 'mvn -version'
-            infra.withArtifactCachingProxy {
+            // Exclude DigitalOcean artifact caching proxy provider, currently unreliable on BOM builds
+            // TODO: remove when https://github.com/jenkins-infra/helpdesk/issues/3481 is fixed
+            infra.withArtifactCachingProxy(env.ARTIFACT_CACHING_PROXY_PROVIDER != 'do') {
                 withEnv(["MAVEN_ARGS=-Dmaven.repo.local=${WORKSPACE_TMP}/m2repo"]) {
                     body()
                 }


### PR DESCRIPTION
As `infra.withArtifactCachingProxy` accepts a boolean since https://github.com/jenkins-infra/pipeline-library/pull/615, this PR excludes the DigitalOcean ACP provider while working on https://github.com/jenkins-infra/helpdesk/issues/3481
The AWS provider isn't concerned by the issue and is working as intended.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [N/A] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
