### PR TITLE
Fix update CLI

### DIFF
--- a/updatecli/updatecli.d/plugin-compat-tester.yml
+++ b/updatecli/updatecli.d/plugin-compat-tester.yml
@@ -30,7 +30,7 @@ targets:
     spec:
       file: prep.sh
       matchpattern: >-
-        ^pct_version=(.*)
+        pct_version=(.*)
       replacepattern: >-
         pct_version={{ source `pctVersion` }}
     scmid: default


### PR DESCRIPTION
The ostensible suggestion in https://github.com/jenkinsci/bom/pull/1920#discussion_r1154157939 appears to have caused

```
setPctInPrep
------------

ERROR: something went wrong in target "setPctInPrep" : "No line matched in the file \"/tmp/updatecli/github/jenkinsci/bom/prep.sh\" for the pattern \"^pct_version=(.*)\""

Pipeline "Bump `plugin-compat-tester`" failed
Skipping due to:
	targets stage:	"something went wrong during target execution"
```

thereby making it a non-suggestion. This PR restores my original PR before the non-suggestion was made.