### PR TITLE
Add Spotless to build

### DIFF
--- a/bom-2.361.x/pom.xml
+++ b/bom-2.361.x/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,40 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <version>2.35.0</version>
+                <configuration>
+                    <pom>
+                        <sortPom>
+                            <encoding>${project.build.sourceEncoding}</encoding>
+                            <expandEmptyElements>false</expandEmptyElements>
+                            <lineSeparator>\n</lineSeparator>
+                            <nrOfIndentSpace>4</nrOfIndentSpace>
+                            <sortDependencies>scope,groupId,artifactId</sortDependencies>
+                            <sortDependencyExclusions>groupId,artifactId</sortDependencyExclusions>
+                            <spaceBeforeCloseEmptyElement>true</spaceBeforeCloseEmptyElement>
+                        </sortPom>
+                    </pom>
+                    <groovy>
+                        <includes>
+                            <include>Jenkinsfile</include>
+                            <include>**/*.groovy</include>
+                        </includes>
+                        <greclipse>
+                            <file>src/spotless/greclipse.properties</file>
+                        </greclipse>
+                    </groovy>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>flatten-maven-plugin</artifactId>
                 <executions>

--- a/sample-plugin/check.groovy
+++ b/sample-plugin/check.groovy
@@ -7,7 +7,8 @@ assert artifactMap['junit:junit'] == project.artifactMap['junit:junit']
 def managedPluginDeps = managedDeps.collect {stripAllButGA(it)}.grep { ga ->
     def art = artifactMap[ga]
     if (art == null) {
-        if (ga.contains('.plugins')) { // TODO without an Artifact, we have no reliable way of checking whether it is actually a plugin
+        // TODO without an Artifact, we have no reliable way of checking whether it is actually a plugin
+        if (ga.contains('.plugins')) {
             throw new org.apache.maven.plugin.MojoFailureException("Managed plugin dependency $ga not listed in test classpath of sample plugin")
         } else {
             println "Do not see managed dependency $ga"
@@ -33,7 +34,6 @@ if (settings.activeProfiles.any {it ==~ /^2[.][0-9]+[.]x$/}) {
 
 expected: $sortedDeps
 """)
-        // TODO also check sorting of sample plugin dependencies
     }
 }
 

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
@@ -28,6 +28,10 @@
         </dependencies>
     </dependencyManagement>
     <dependencies>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>jsch</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
@@ -203,11 +207,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.jenkins-ci.plugins.pipeline-stage-view</groupId>
-            <artifactId>pipeline-stage-view</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>ansicolor</artifactId>
             <scope>test</scope>
@@ -349,10 +348,6 @@
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>jsch</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
@@ -404,6 +399,11 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>pipeline-input-step</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>pipeline-milestone-step</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -487,11 +487,6 @@
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>pipeline-milestone-step</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>variant</artifactId>
             <scope>test</scope>
         </dependency>
@@ -566,6 +561,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.jenkins-ci.plugins.pipeline-stage-view</groupId>
+            <artifactId>pipeline-stage-view</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jenkins-ci.plugins.to-declarative</groupId>
             <artifactId>declarative-pipeline-migration-assistant</artifactId>
             <scope>test</scope>
@@ -635,6 +635,40 @@
     </pluginRepositories>
     <build>
         <plugins>
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <configuration>
+                    <java>
+                        <endWithNewline />
+                        <importOrder />
+                        <indent>
+                            <spaces>true</spaces>
+                        </indent>
+                        <palantirJavaFormat />
+                        <removeUnusedImports />
+                        <trimTrailingWhitespace />
+                    </java>
+                    <pom>
+                        <sortPom>
+                            <encoding>${project.build.sourceEncoding}</encoding>
+                            <expandEmptyElements>false</expandEmptyElements>
+                            <lineSeparator>\n</lineSeparator>
+                            <nrOfIndentSpace>4</nrOfIndentSpace>
+                            <sortDependencies>scope,groupId,artifactId</sortDependencies>
+                            <sortDependencyExclusions>groupId,artifactId</sortDependencyExclusions>
+                            <spaceBeforeCloseEmptyElement>true</spaceBeforeCloseEmptyElement>
+                        </sortPom>
+                    </pom>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.codehaus.gmaven</groupId>
                 <artifactId>groovy-maven-plugin</artifactId>

--- a/sample-plugin/src/main/java/io/jenkins/tools/bom/sample/ExampleStep.java
+++ b/sample-plugin/src/main/java/io/jenkins/tools/bom/sample/ExampleStep.java
@@ -14,11 +14,14 @@ import org.kohsuke.stapler.DataBoundSetter;
 
 public final class ExampleStep extends Step {
 
-    @DataBoundSetter public String x;
+    @DataBoundSetter
+    public String x;
 
-    @DataBoundConstructor public ExampleStep() {}
+    @DataBoundConstructor
+    public ExampleStep() {}
 
-    @Override public StepExecution start(StepContext context) throws Exception {
+    @Override
+    public StepExecution start(StepContext context) throws Exception {
         return new Execution(context, x);
     }
 
@@ -30,24 +33,25 @@ public final class ExampleStep extends Step {
             super(context);
             this.x = x;
         }
-        
-        @Override protected Void run() throws Exception {
+
+        @Override
+        protected Void run() throws Exception {
             getContext().get(TaskListener.class).getLogger().println("Ran on " + x + "!");
             return null;
         }
-
     }
 
-    @Extension public static final class DescriptorImpl extends StepDescriptor {
+    @Extension
+    public static final class DescriptorImpl extends StepDescriptor {
 
-        @Override public String getFunctionName() {
+        @Override
+        public String getFunctionName() {
             return "example";
         }
 
-        @Override public Set<? extends Class<?>> getRequiredContext() {
+        @Override
+        public Set<? extends Class<?>> getRequiredContext() {
             return Collections.singleton(TaskListener.class);
         }
-
     }
-
 }

--- a/sample-plugin/src/test/java/io/jenkins/tools/bom/sample/ConfigurationAsCodeTest.java
+++ b/sample-plugin/src/test/java/io/jenkins/tools/bom/sample/ConfigurationAsCodeTest.java
@@ -1,13 +1,13 @@
 package io.jenkins.tools.bom.sample;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
 import jenkins.model.Jenkins;
 import org.junit.ClassRule;
 import org.junit.Test;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
 
 public class ConfigurationAsCodeTest {
 

--- a/sample-plugin/src/test/java/io/jenkins/tools/bom/sample/ExampleStepTest.java
+++ b/sample-plugin/src/test/java/io/jenkins/tools/bom/sample/ExampleStepTest.java
@@ -1,27 +1,32 @@
 package io.jenkins.tools.bom.sample;
 
+import static org.junit.Assert.*;
+
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.cps.SnippetizerTester;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.steps.StepConfigTester;
 import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
-import static org.junit.Assert.*;
 import org.junit.ClassRule;
-import org.junit.Test;
 import org.junit.Rule;
+import org.junit.Test;
 import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.JenkinsRule;
 
 public class ExampleStepTest {
 
-    @ClassRule public static BuildWatcher buildWatcher = new BuildWatcher();
+    @ClassRule
+    public static BuildWatcher buildWatcher = new BuildWatcher();
 
-    @Rule public JenkinsRule r = new JenkinsRule();
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
 
-    @Test public void smokes() throws Exception {
+    @Test
+    public void smokes() throws Exception {
         WorkflowJob p = r.createProject(WorkflowJob.class);
-        p.setDefinition(new CpsFlowDefinition("node {example(x: 'some value')}; semaphore 'wait'; echo 'more stuff too'", true));
+        p.setDefinition(new CpsFlowDefinition(
+                "node {example(x: 'some value')}; semaphore 'wait'; echo 'more stuff too'", true));
         WorkflowRun b = p.scheduleBuild2(0).waitForStart();
         SemaphoreStep.waitForStart("wait/1", b);
         SemaphoreStep.success("wait/1", null);
@@ -34,5 +39,4 @@ public class ExampleStepTest {
         assertEquals("sample", s2.x);
         new SnippetizerTester(r).assertRoundTrip(s2, "example x: 'sample'");
     }
-
 }

--- a/src/spotless/greclipse.properties
+++ b/src/spotless/greclipse.properties
@@ -1,0 +1,26 @@
+# Whether to use 'space', 'tab' or 'mixed' (both) characters for indentation. The default value is 'tab'.
+org.eclipse.jdt.core.formatter.tabulation.char=space
+
+# Number of spaces used for indentation in case 'space' characters have been selected. The default value is 4.
+org.eclipse.jdt.core.formatter.tabulation.size=4
+
+# Number of spaces used for indentation in case 'mixed' characters have been selected. The default value is 4.
+org.eclipse.jdt.core.formatter.indentation.size=4
+
+# Whether or not indentation characters are inserted into empty lines. The default value is 'true'.
+org.eclipse.jdt.core.formatter.indent_empty_lines=false
+
+# Number of spaces used for multiline indentation. The default value is 2.
+groovy.formatter.multiline.indentation=2
+
+# Length after which list are considered too long. These will be wrapped. The default value is 30.
+groovy.formatter.longListLength=90
+
+# Whether opening braces position shall be the next line. The default value is 'same'.
+groovy.formatter.braces.start=same
+
+# Whether closing braces position shall be the next line. The default value is 'next'.
+groovy.formatter.braces.end=next
+
+# Remove unnecessary semicolons. The default value is 'false'.
+groovy.formatter.remove.unnecessary.semicolons=true


### PR DESCRIPTION
My first line of defense when working on Groovy code is Spotless: if Spotless can't format it, then Groovy certainly won't be able to interpret it. "Testing" Groovy code with Spotless saves me time. So I am introducing Spotless in this repository. This PR applies Spotless to all `pom.xml`, Java, and Groovy files in this repository. I recommend reviewing this with the **Hide Whitespace** changes feature enabled.