### PR TITLE
Silence version warning for spotless

### DIFF
--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -638,6 +638,7 @@
             <plugin>
                 <groupId>com.diffplug.spotless</groupId>
                 <artifactId>spotless-maven-plugin</artifactId>
+                <version>2.35.0</version>
                 <configuration>
                     <java>
                         <endWithNewline />


### PR DESCRIPTION
## Silence the version warning from spotless

The `mvn --pl sample-plugin spotless:apply` generates a warning about the version of spotless.  This change resolves the warning.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
