### PR TITLE
Lower `surefire.rerunFailingTestsCount` from 4 to 1

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -78,7 +78,7 @@ lines.each {line ->
                 withEnv([
                     "PLUGINS=$plugin",
                     "LINE=$line",
-                    'EXTRA_MAVEN_PROPERTIES=maven.test.failure.ignore=true:surefire.rerunFailingTestsCount=4'
+                    'EXTRA_MAVEN_PROPERTIES=maven.test.failure.ignore=true:surefire.rerunFailingTestsCount=1'
                 ]) {
                     sh 'mv megawar-$LINE.war megawar.war && bash pct.sh'
                 }


### PR DESCRIPTION
While the tests and infrastructure may have been flakier at one point in time, I took a look at recent runs and found that there were only a handful of flaky tests that remain, and they all passed on the second try. So there is no longer a need to re-run tests 4 times hoping that they pass: a single re-run is sufficient. This helps prevent even flakier tests from being introduced unnoticed. While ideally we would fix these tests and remove this option entirely, having it set to 1 seems to strike a reasonable balance between keeping the existing test runs passing and preventing even worse flakiness from being introduced.