### PR TITLE
chore(pipeline) handle retry for non-Kubernetes agents (#1934

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ properties([disableConcurrentBuilds(abortPrevious: true)])
 def mavenEnv(Map params = [:], Closure body) {
     def attempt = 0
     def attempts = 3
-    retry(count: attempts, conditions: [kubernetesAgent(), nonresumable()]) {
+    retry(count: attempts, conditions: [kubernetesAgent(handleNonKubernetes()), nonresumable()]) {
         echo 'Attempt ' + ++attempt + ' of ' + attempts
         // no Dockerized tests; https://github.com/jenkins-infra/documentation/blob/master/ci.adoc#container-agents
         node("maven-$params.jdk") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ properties([disableConcurrentBuilds(abortPrevious: true)])
 def mavenEnv(Map params = [:], Closure body) {
     def attempt = 0
     def attempts = 3
-    retry(count: attempts, conditions: [kubernetesAgent(handleNonKubernetes()), nonresumable()]) {
+    retry(count: attempts, conditions: [kubernetesAgent(handleNonKubernetes: true), nonresumable()]) {
         echo 'Attempt ' + ++attempt + ' of ' + attempts
         // no Dockerized tests; https://github.com/jenkins-infra/documentation/blob/master/ci.adoc#container-agents
         node("maven-$params.jdk") {


### PR DESCRIPTION
Ref. https://github.com/jenkinsci/jenkins/pull/7788#issuecomment-1493377057

For info, I'm going to kill this builds once the first step starts, to avoid unneeded steps to cost us money for...nothing (Only want to validate the pipeline parsing).