### PR TITLE
Make PowerShell scripts conform to Spotless formatting rules

### DIFF
--- a/updatecli/update-jenkins.ps1
+++ b/updatecli/update-jenkins.ps1
@@ -43,5 +43,6 @@ if ($changed) {
     $streamWriter = New-Object System.IO.StreamWriter($pomPath, $false, $utf8WithoutBom)
     $pom.Save($streamWriter)
     $streamWriter.Close()
+    (Get-Content $pomPath) -creplace 'utf-8', 'UTF-8' | Set-Content $pomPath
   }
 }

--- a/updatecli/update-plugin.ps1
+++ b/updatecli/update-plugin.ps1
@@ -46,5 +46,6 @@ if ($changed) {
     $streamWriter = New-Object System.IO.StreamWriter($PomPath, $false, $utf8WithoutBom)
     $pom.Save($streamWriter)
     $streamWriter.Close()
+    (Get-Content $PomPath) -creplace 'utf-8', 'UTF-8' | Set-Content $PomPath
   }
 }


### PR DESCRIPTION
By introducing Spotless I broke the bot that was updating the Jenkins version, apparently using a PowerShell script which writes a lowercase character encoding in the prolog. This PR patches up the output to conform to our Spotless checks. I tested this locally by running the relevant line on my system after installing PowerShell for Linux (which I didn't even know existed before today). See [this documentation](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_comparison_operators?view=powershell-7.3) for an explanation of the syntax.