### PR TITLE
chore(Jenkinsfile) only keep the past 7 builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,7 @@
-properties([disableConcurrentBuilds(abortPrevious: true)])
+properties([
+    disableConcurrentBuilds(abortPrevious: true),
+    buildDiscarder(logRotator(numToKeepStr: '7'))
+])
 
 def mavenEnv(Map params = [:], Closure body) {
     def attempt = 0


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/3492

There is no "global" build history configuration on ci.jenkins.io as for today: this PR adds a specific rotator policy on the BOM build until we have a better solution