### PR TITLE
Use upstream Spotless configuration where it does not conflict with our own

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci</groupId>
         <artifactId>jenkins</artifactId>
-        <version>1.97</version>
+        <version>1.98</version>
         <relativePath />
     </parent>
     <groupId>io.jenkins.tools.bom</groupId>
@@ -34,6 +34,7 @@
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/bom</gitHubRepo>
+        <spotless.check.skip>false</spotless.check.skip>
     </properties>
     <repositories>
         <repository>
@@ -52,17 +53,10 @@
             <plugin>
                 <groupId>com.diffplug.spotless</groupId>
                 <artifactId>spotless-maven-plugin</artifactId>
-                <version>2.36.0</version>
                 <configuration>
                     <pom>
                         <sortPom>
-                            <encoding>${project.build.sourceEncoding}</encoding>
-                            <expandEmptyElements>false</expandEmptyElements>
-                            <lineSeparator>\n</lineSeparator>
                             <nrOfIndentSpace>4</nrOfIndentSpace>
-                            <sortDependencies>scope,groupId,artifactId</sortDependencies>
-                            <sortDependencyExclusions>groupId,artifactId</sortDependencyExclusions>
-                            <spaceBeforeCloseEmptyElement>true</spaceBeforeCloseEmptyElement>
                         </sortPom>
                     </pom>
                     <groovy>
@@ -82,13 +76,6 @@
                         <version>1.0</version>
                     </dependency>
                 </dependencies>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.60</version>
+        <version>4.61</version>
         <relativePath />
     </parent>
     <groupId>io.jenkins.tools.bom</groupId>
@@ -15,6 +15,7 @@
         <changelist>999999-SNAPSHOT</changelist>
         <bom>weekly</bom>
         <jenkins.version>2.401</jenkins.version>
+        <spotless.check.skip>false</spotless.check.skip>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -638,37 +639,13 @@
             <plugin>
                 <groupId>com.diffplug.spotless</groupId>
                 <artifactId>spotless-maven-plugin</artifactId>
-                <version>2.36.0</version>
                 <configuration>
-                    <java>
-                        <endWithNewline />
-                        <importOrder />
-                        <indent>
-                            <spaces>true</spaces>
-                        </indent>
-                        <palantirJavaFormat />
-                        <removeUnusedImports />
-                        <trimTrailingWhitespace />
-                    </java>
                     <pom>
                         <sortPom>
-                            <encoding>${project.build.sourceEncoding}</encoding>
-                            <expandEmptyElements>false</expandEmptyElements>
-                            <lineSeparator>\n</lineSeparator>
                             <nrOfIndentSpace>4</nrOfIndentSpace>
-                            <sortDependencies>scope,groupId,artifactId</sortDependencies>
-                            <sortDependencyExclusions>groupId,artifactId</sortDependencyExclusions>
-                            <spaceBeforeCloseEmptyElement>true</spaceBeforeCloseEmptyElement>
                         </sortPom>
                     </pom>
                 </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.gmaven</groupId>


### PR DESCRIPTION
This PR should eliminate some of the maintenance burden associated with this repository by using upstream Spotless configuration wherever it does not conflict with our own. We still retain some of our own configuration, like configuration for Groovy files (which I intend to eventually move upstream) and the 4-space indentation for `pom.xml` files (which could be easily removed if the maintainers are willing to tolerate some merge conflicts with Dependabot PRs).