### PR TITLE
Resume stashing megawars

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,8 +58,8 @@ stage('prep') {
         }
       }
     }
-    lines.each {
-      stash name: it, includes: "pct.sh,excludes.txt,target/pct.jar,target/megawar-$it.war"
+    lines.each { line ->
+      stash name: line, includes: "pct.sh,excludes.txt,target/pct.jar,target/megawar-${line}.war"
     }
     infra.prepareToPublishIncrementals()
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,6 +58,9 @@ stage('prep') {
         }
       }
     }
+    lines.each {
+      stash name: it, includes: "pct.sh,excludes.txt,target/pct.jar,target/megawar-$it.war"
+    }
     infra.prepareToPublishIncrementals()
   }
 }
@@ -68,14 +71,13 @@ lines.each {line ->
     branches["pct-$plugins-$line"] = {
       def jdk = line == 'weekly' ? 17 : 11
       mavenEnv(jdk: jdk) {
-        deleteDir()
-        checkout scm
+        unstash line
         withEnv([
           "PLUGINS=$plugins",
           "LINE=$line",
           'EXTRA_MAVEN_PROPERTIES=maven.test.failure.ignore=true:surefire.rerunFailingTestsCount=1'
         ]) {
-          sh 'bash prep-megawar.sh && bash prep-pct.sh && bash pct.sh'
+          sh 'bash pct.sh'
         }
         launchable.install()
         withCredentials([string(credentialsId: 'launchable-jenkins-bom', variable: 'LAUNCHABLE_TOKEN')]) {

--- a/pct.sh
+++ b/pct.sh
@@ -2,7 +2,7 @@
 set -euxo pipefail
 cd "$(dirname "$0")"
 
-# expects: target/megawar-$LINE.war, target/pct.jar, $PLUGINS, $LINE
+# expects: excludes.txt, target/megawar-$LINE.war, target/pct.jar, $PLUGINS, $LINE
 
 rm -rf pct-work
 


### PR DESCRIPTION
Reverts the essence of #1955, though a literal revert proved impractical since #1955 cleaned up stuff like `MAVEN_ARGS` usage, there were some minor subsequent changes, and mainly because #1970 made subtle changes I am not familiar with and do not wish to mess with. Instead keeping the Bash scripts as they were and reintroducing a simplified stash system just for CI. Requested by https://github.com/jenkins-infra/helpdesk/issues/3496#issuecomment-1517986500 due to https://github.com/jenkinsci/bom/pull/1969#issuecomment-1515909374.