### PR TITLE
Suppressing builds on `master` branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 properties([disableConcurrentBuilds(abortPrevious: true), buildDiscarder(logRotator(numToKeepStr: '7'))])
 
-error "TODO causes in $BRANCH_NAME: ${currentBuild.buildCauses*._class}"
+error "in $BRANCH_NAME, triggered by push?: ${currentBuild.buildCauses*._class == ['jenkins.branch.BranchEventCause']}"
 
 def mavenEnv(Map params = [:], Closure body) {
   def attempt = 0

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 properties([disableConcurrentBuilds(abortPrevious: true), buildDiscarder(logRotator(numToKeepStr: '7'))])
 
-error "TODO causes: $currentBuild.buildCauses"
+error "TODO causes in $BRANCH_NAME: $currentBuild.buildCauses"
 
 def mavenEnv(Map params = [:], Closure body) {
   def attempt = 0

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,8 @@
 properties([disableConcurrentBuilds(abortPrevious: true), buildDiscarder(logRotator(numToKeepStr: '7'))])
 
-error "in $BRANCH_NAME, triggered by push?: ${currentBuild.buildCauses*._class == ['jenkins.branch.BranchEventCause']}"
+if (BRANCH_NAME == 'master' && currentBuild.buildCauses*._class == ['jenkins.branch.BranchEventCause']) {
+  error 'No longer running builds on response to master branch pushes. If you wish to cut a release, use “Re-run checks” from this failing check in https://github.com/jenkinsci/bom/commits/master'
+}
 
 def mavenEnv(Map params = [:], Closure body) {
   def attempt = 0

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 properties([disableConcurrentBuilds(abortPrevious: true), buildDiscarder(logRotator(numToKeepStr: '7'))])
 
-error "TODO causes in $BRANCH_NAME: $currentBuild.buildCauses*._class"
+error "TODO causes in $BRANCH_NAME: ${currentBuild.buildCauses*._class}"
 
 def mavenEnv(Map params = [:], Closure body) {
   def attempt = 0

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 properties([disableConcurrentBuilds(abortPrevious: true), buildDiscarder(logRotator(numToKeepStr: '7'))])
 
-error "TODO causes in $BRANCH_NAME: $currentBuild.buildCauses"
+error "TODO causes in $BRANCH_NAME: $currentBuild.buildCauses*._class"
 
 def mavenEnv(Map params = [:], Closure body) {
   def attempt = 0

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,8 +48,8 @@ stage('prep') {
     dir('target') {
       pluginsByRepository = readFile('plugins.txt').split('\n')
       lines = readFile('lines.txt').split('\n')
-      if (!fullTest) {
-        // run PCT only on newest and oldest lines, to save resources
+      if (env.CHANGE_ID && !fullTest) {
+        // run PCT only on newest and oldest lines, to save resources (but check all lines on deliberate master builds)
         lines = [lines[0], lines[-1]]
       }
       launchable.install()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,7 @@
 properties([disableConcurrentBuilds(abortPrevious: true), buildDiscarder(logRotator(numToKeepStr: '7'))])
 
+error "TODO causes: $currentBuild.buildCauses"
+
 def mavenEnv(Map params = [:], Closure body) {
   def attempt = 0
   def attempts = 3

--- a/README.md
+++ b/README.md
@@ -193,9 +193,11 @@ This flag also allows all tests to be run even after some failures are recorded.
 
 ## Releasing
 
-Automatic given [JEP-229](https://jenkins.io/jep/229) when PRs matching certain label patterns are merged.
+You can cut a release using [JEP-229](https://jenkins.io/jep/229).
+To save resources, `master` is built only on demand, so use **Re-run checks**  in https://github.com/jenkinsci/bom/commits/master if you wish to start.
+If that build passes, a release should be published automatically when PRs matching certain label patterns are merged.
 For the common case that only lots of `dependencies` PRs have been merged,
-can be triggered manually from the **Actions** tab after a `master` build has succeeded.
+the release can be triggered manually from the **Actions** tab after a `master` build has succeeded.
 
 ## Incrementals
 


### PR DESCRIPTION
Trying to minimize load on ci.jenkins.io by only building PRs by default; if and when you want to run a release, use **Re-run** in GitHub to do a `master` build that could trigger CD. https://github.com/jenkins-infra/helpdesk/issues/3521#issuecomment-1511477537