### PR TITLE
Upgrade PCT; Launchable improvements

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,6 +31,16 @@ def mavenEnv(Map params = [:], Closure body) {
   }
 }
 
+@NonCPS
+def parsePlugins(plugins) {
+  def pluginsByRepository = [:]
+  plugins.each { plugin ->
+    def splits = plugin.split('\t')
+    pluginsByRepository[splits[0]] = splits[1].split(',')
+  }
+  pluginsByRepository
+}
+
 def pluginsByRepository
 def lines
 def fullTest = env.CHANGE_ID && pullRequest.labels.contains('full-test')
@@ -46,7 +56,9 @@ stage('prep') {
       }
     }
     dir('target') {
-      pluginsByRepository = readFile('plugins.txt').split('\n')
+      def plugins = readFile('plugins.txt').split('\n')
+      pluginsByRepository = parsePlugins(plugins)
+
       lines = readFile('lines.txt').split('\n')
       if (env.CHANGE_ID && !fullTest) {
         // run PCT only on newest and oldest lines, to save resources (but check all lines on deliberate master builds)
@@ -56,9 +68,12 @@ stage('prep') {
       withCredentials([string(credentialsId: 'launchable-jenkins-bom', variable: 'LAUNCHABLE_TOKEN')]) {
         lines.each { line ->
           def commitHashes = readFile "commit-hashes-${line}.txt"
-          launchable("record build --name \"${BUILD_TAG}-${line}\" --no-commit-collection " + commitHashes)
-          launchable("record session --build \"${BUILD_TAG}-${line}\" --observation >launchable-session-${line}.txt")
-          stash name: "launchable-session-${line}.txt", includes: "launchable-session-${line}.txt"
+          launchable("record build --name ${env.BUILD_TAG}-${line} --no-commit-collection " + commitHashes + " --link \"View build in CI\"=${env.BUILD_URL}")
+
+          def jdk = line == 'weekly' ? 17 : 11
+          def sessionFile = "launchable-session-${line}.txt"
+          launchable("record session --build ${env.BUILD_TAG}-${line} --flavor platform=linux --flavor jdk=${jdk} --observation --link \"View session in CI\"=${env.BUILD_URL} >${sessionFile}")
+          stash name: sessionFile, includes: sessionFile
         }
       }
     }
@@ -68,14 +83,14 @@ stage('prep') {
 
 branches = [failFast: !fullTest]
 lines.each {line ->
-  pluginsByRepository.each { plugins ->
-    branches["pct-$plugins-$line"] = {
+  pluginsByRepository.each { repository, plugins ->
+    branches["pct-$repository-$line"] = {
       def jdk = line == 'weekly' ? 17 : 11
       mavenEnv(jdk: jdk) {
         deleteDir()
         checkout scm
         withEnv([
-          "PLUGINS=$plugins",
+          "PLUGINS=${plugins.join(',')}",
           "LINE=$line",
           'EXTRA_MAVEN_PROPERTIES=maven.test.failure.ignore=true:surefire.rerunFailingTestsCount=1'
         ]) {
@@ -84,9 +99,10 @@ lines.each {line ->
         launchable.install()
         withCredentials([string(credentialsId: 'launchable-jenkins-bom', variable: 'LAUNCHABLE_TOKEN')]) {
           launchable('verify')
-          unstash "launchable-session-${line}.txt"
-          def launchableSession = readFile("launchable-session-${line}.txt").trim()
-          launchable("record tests --session ${launchableSession} maven './**/target/surefire-reports' './**/target/failsafe-reports'")
+          def sessionFile = "launchable-session-${line}.txt"
+          unstash sessionFile
+          def session = readFile(sessionFile).trim()
+          launchable("record tests --session ${session} --group ${repository} maven './**/target/surefire-reports' './**/target/failsafe-reports'")
         }
       }
     }

--- a/prep-pct.sh
+++ b/prep-pct.sh
@@ -3,7 +3,7 @@ set -euxo pipefail
 cd "$(dirname "${0}")"
 
 # Tracked by ./updatecli/updatecli.d/plugin-compat-tester.yml
-pct_version=1316.v57c72c3efc5e
+pct_version=1324.vd087503ca_c0c
 pct="$(mvn -Dexpression=settings.localRepository -q -DforceStdout help:evaluate)/org/jenkins-ci/tests/plugins-compat-tester-cli/${pct_version}/plugins-compat-tester-cli-${pct_version}.jar"
 [ -f "${pct}" ] || mvn dependency:get -Dartifact=org.jenkins-ci.tests:plugins-compat-tester-cli:${pct_version}:jar -DremoteRepositories=repo.jenkins-ci.org::default::https://repo.jenkins-ci.org/public/,incrementals::default::https://repo.jenkins-ci.org/incrementals/ -Dtransitive=false
 cp "${pct}" target/pct.jar


### PR DESCRIPTION
Adapting to https://github.com/jenkinsci/plugin-compat-tester/pull/536 by using the repository name to improve the display of the Pipeline stage view steps as well as passing this information to Launchable as the group name for [Launchable zero-input subsetting](https://www.launchableinc.com/docs/features/predictive-test-selection/requesting-and-running-a-subset-of-tests/subsetting-with-the-launchable-cli/zero-input-subsetting/using-groups-to-split-subsets/). I tested this with a passing CI build with these changes (using my admin powers to replay the build with the `Jenkinsfile` changes).