### PR TITLE
chore(updatecli) update powershell to generate valid updatecli manifest for version 0.49.x

### DIFF
--- a/updatecli/generate-manifests.ps1
+++ b/updatecli/generate-manifests.ps1
@@ -64,7 +64,7 @@ foreach ($bom in $bills) {
     sources      = [ordered]@{}
     conditions   = [ordered]@{}
     targets      = [ordered]@{}
-    pullrequests = [ordered]@{}
+    actions      = [ordered]@{}
   }
 
   $bomVersion = $bom -replace "bom-", ""
@@ -131,9 +131,9 @@ foreach ($bom in $bills) {
       command      = "pwsh -NoProfile -File {{ requiredEnv `"GITHUB_WORKSPACE`" }}/updatecli/update-jenkins.ps1 $bomVersion"
     }
   }
-  $updateJenkinsManifest.pullrequests["jenkins"] = [ordered]@{
+  $updateJenkinsManifest.actions["jenkins"] = [ordered]@{
     title   = "Bump jenkins.version from $jenkinsVersion to {{ source `"jenkins`" }} for bom-$bomVersion"
-    kind    = "github"
+    kind    = "github/pullrequest"
     scmid   = "github"
     targets = @("jenkins")
     spec    = [ordered]@{
@@ -194,7 +194,7 @@ foreach ($bom in $bills) {
       sources      = [ordered]@{}
       conditions   = [ordered]@{}
       targets      = [ordered]@{}
-      pullrequests = [ordered]@{}
+      actions      = [ordered]@{}
     }
 
     $updatePluginsManifest.sources["plugin"] = [ordered]@{
@@ -232,9 +232,9 @@ foreach ($bom in $bills) {
         command = "pwsh -NoProfile -File {{ requiredEnv `"GITHUB_WORKSPACE`" }}/updatecli/update-plugin.ps1 $pomPath $name"
       }
     }
-    $updatePluginsManifest.pullrequests["plugin"] = [ordered]@{
+    $updatePluginsManifest.actions["plugin"] = [ordered]@{
       title   = "Bump $name from $version to {{ source `"plugin`" }} in /bom-$bomVersion"
-      kind    = "github"
+      kind    = "github/pullrequest"
       scmid   = "github"
       targets = @("plugin")
       spec    = [ordered]@{


### PR DESCRIPTION
This PR only updates the updatecli manifest: the associated Jenkins build will be canceled (as updatecli runs in GH actions).

It fixes the `WARNING`  messages below due to outdated syntax for the generated updatecli manifests:

```
WARNING: The `pullrequests` keyword is deprecated in favor of `actions`, please update this manifest. Updatecli will continue the execution while trying to translate `pullrequests` to `actions`.
WARNING: The kind "github" for actions is deprecated in favor of 'github/pullrequest'
```

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- ~[ ] Link to relevant issues in GitHub or Jira~
- ~[ ] Link to relevant pull requests, esp. upstream and downstream changes~
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
