### PR TITLE
Move `pct-work/` inside `target/`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 target
 .idea/
 *.iml
-pct-work/
 pct-report.*
 logs/
 megawar.war

--- a/pct.sh
+++ b/pct.sh
@@ -4,7 +4,7 @@ cd "$(dirname "$0")"
 
 # expects: excludes.txt, target/megawar-$LINE.war, target/pct.jar, $PLUGINS, $LINE
 
-rm -rf pct-work
+rm -rf target/pct-work
 
 PCT_D_ARGS=
 if [[ -n ${EXTRA_MAVEN_PROPERTIES-} ]]; then
@@ -18,7 +18,7 @@ exec java \
 	test-plugins \
 	--war "$(pwd)/target/megawar-$LINE.war" \
 	--include-plugins "${PLUGINS}" \
-	--working-dir "$(pwd)/pct-work" \
+	--working-dir "$(pwd)/target/pct-work" \
 	$PCT_D_ARGS \
 	-DforkCount=.75C \
 	-Djth.jenkins-war.path="$(pwd)/target/megawar-$LINE.war" \


### PR DESCRIPTION
Fixes #1996. I guess; using `target/pct-work/` for simplicity since there is no remaining reason for `target/local-test/` to exist. No explanation was given for why this directory location would be significant, or to whom. GitHub search turns up nothing. All I can guess is that it is desired for `mvn clean` to delete unversioned files. (`git clean -fdx` will not suffice otherwise, though `git clean -ffdx` would.)