### PR TITLE
Fix Launchable group names

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,7 +36,7 @@ def parsePlugins(plugins) {
   def pluginsByRepository = [:]
   plugins.each { plugin ->
     def splits = plugin.split('\t')
-    pluginsByRepository[splits[0]] = splits[1].split(',')
+    pluginsByRepository[splits[0].split('/')[1]] = splits[1].split(',')
   }
   pluginsByRepository
 }


### PR DESCRIPTION
It turns out that Launchable group names can't contain slashes. I was using group names of e.g. `jenkinsci/text-finder-plugin` which Launchable rejects when recording test results. This should fix the problem by defining the group name as e.g. `text-finder-plugin`.