### PR TITLE
Implement Launchable subsetting

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -80,7 +80,7 @@ stage('prep') {
           launchable("record build --name ${env.BUILD_TAG}-${line} --no-commit-collection " + commitHashes + " --link \"View build in CI\"=${env.BUILD_URL}")
           def jdk = line == 'weekly' ? 17 : 11
           def sessionFile = "launchable-session-${line}.txt"
-          launchable("record session --build ${env.BUILD_TAG}-${line} --flavor platform=linux --flavor jdk=${jdk} ${isSubset ? '--observation ' : ''}--link \"View session in CI\"=${env.BUILD_URL} >${sessionFile}")
+          launchable("record session --build ${env.BUILD_TAG}-${line} --flavor platform=linux --flavor jdk=${jdk} ${isSubset ? '' : '--observation '}--link \"View session in CI\"=${env.BUILD_URL} >${sessionFile}")
           def session = readFile(sessionFile).trim()
           def subsetFile = "launchable-subset-${line}.txt"
           launchable("subset --session ${session} --split --target 20% --get-tests-from-previous-sessions --output-exclusion-rules maven >${subsetFile}")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -83,7 +83,7 @@ stage('prep') {
           launchable("record session --build ${env.BUILD_TAG}-${line} --flavor platform=linux --flavor jdk=${jdk} ${isSubset ? '--observation ' : ''}--link \"View session in CI\"=${env.BUILD_URL} >${sessionFile}")
           def session = readFile(sessionFile).trim()
           def subsetFile = "launchable-subset-${line}.txt"
-          launchable("launchable subset --session ${session} --split --target 20% --get-tests-from-previous-sessions --output-exclusion-rules maven >${subsetFile}")
+          launchable("subset --session ${session} --split --target 20% --get-tests-from-previous-sessions --output-exclusion-rules maven >${subsetFile}")
           def subset = readFile(subsetFile).trim()
           launchable("inspect subset --subset-id ${subset}")
           launchable("split-subset --subset-id ${subset} --split-by-groups --output-exclusion-rules maven")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,13 +93,13 @@ stage('prep') {
             sh 'rm subset-groups.txt'
           }
           subsets[line] = createSubset(pluginsByRepository, subsetGroups)
-          sh "cat excludes.txt subset-*.txt | grep -v InjectedTest | sort -u >excludes-${line}.txt"
+          sh "cat ../excludes.txt subset-*.txt | grep -v InjectedTest | sort -u >excludes-${line}.txt"
           sh "cat excludes-${line}.txt"
         }
       }
     }
     lines.each { line ->
-      stash name: line, includes: "pct.sh,excludes-${line}.txt,launchable-session-${line}.txt,target/pct.jar,target/megawar-${line}.war"
+      stash name: line, includes: "pct.sh,target/excludes-${line}.txt,launchable-session-${line}.txt,target/pct.jar,target/megawar-${line}.war"
     }
     infra.prepareToPublishIncrementals()
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -94,7 +94,7 @@ stage('prep') {
           }
           subsets[line] = createSubset(pluginsByRepository, subsetGroups)
           sh "cat excludes.txt subset-*.txt | grep -v InjectedTest | sort -u >excludes-${line}.txt"
-          cat "excludes-${line}.txt"
+          sh "cat excludes-${line}.txt"
         }
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,7 +93,8 @@ stage('prep') {
             sh 'rm subset-groups.txt'
           }
           subsets[line] = createSubset(pluginsByRepository, subsetGroups)
-          sh "cat ../excludes.txt subset-*.txt | grep -v InjectedTest | sort -u >excludes-${line}.txt"
+          sh "ls ../excludes.txt subset-*.txt | xargs -I{} bash -c 'cat {} >>excludes-${line}.txt && echo >>excludes-${line}.txt'"
+          sh "cat excludes-${line}.txt | grep -v ^\$ | grep -v ^# | grep -v InjectedTest | sort -u >excludes-${line}.txt.new && mv excludes-${line}.txt.new excludes-${line}.txt"
           sh "cat excludes-${line}.txt"
         }
       }

--- a/pct.sh
+++ b/pct.sh
@@ -2,7 +2,7 @@
 set -euxo pipefail
 cd "$(dirname "$0")"
 
-# expects: excludes.txt, target/megawar-$LINE.war, target/pct.jar, $PLUGINS, $LINE
+# expects: excludes-$LINE.txt, target/megawar-$LINE.war, target/pct.jar, $PLUGINS, $LINE
 
 rm -rf target/pct-work
 
@@ -22,6 +22,6 @@ exec java \
 	$PCT_D_ARGS \
 	-DforkCount=.75C \
 	-Djth.jenkins-war.path="$(pwd)/target/megawar-$LINE.war" \
-	-Dsurefire.excludesFile="$(pwd)/excludes.txt"
+	-Dsurefire.excludesFile="$(pwd)/excludes-$LINE.txt"
 
 # produces: **/target/surefire-reports/TEST-*.xml

--- a/pct.sh
+++ b/pct.sh
@@ -22,6 +22,6 @@ exec java \
 	$PCT_D_ARGS \
 	-DforkCount=.75C \
 	-Djth.jenkins-war.path="$(pwd)/target/megawar-$LINE.war" \
-	-Dsurefire.excludesFile="$(pwd)/excludes-$LINE.txt"
+	-Dsurefire.excludesFile="$(pwd)/target/excludes-$LINE.txt"
 
 # produces: **/target/surefire-reports/TEST-*.xml


### PR DESCRIPTION
This PR explores one possible cost reduction strategy using Launchable. The high-level strategy is as follows: lower the acceptance criteria for PRs from a passing run of `prep.sh` and a passing run of 100% of the tests to merely a passing run of `prep.sh` and a passing run of 20% of the tests, as selected by Launchable (unless the `skip-launchable-subset` label is applied). Yes, this means we would merge PRs to the main branch even if we have not run 80% of the tests. Yes, this means that a plugin upgrade that causes a test to start failing would break the main branch. To some degree, this is how Launchable is designed to work: run fewer tests at time of integration, but run the full test suite _at some point_ later before shipping. In the Launchable world, it is up to each project to define what "at some point" means for them.

Since the Launchable model isn't fully trained yet, and since the only training data is coming from BOM repository CI runs (where tests do not fail very often) and not plugin repository CI runs, the subset generated by Launchable is essentially a random 20% of the test suite. Over time, that accuracy should improve as the model gets trained. It could be improved even more if we find a way to train the model from CI runs in individual plugin repositories; Launchable product management tells me this might be possible in a few months.

Obviously, we need to run the full suite of tests _at some point_ later, so one proposal is to set up a scheduled build on the main branch once a week. For example, we could schedule a build every Tuesday and plan for a BOM release every Tuesday. If no regressions were introduced, this build would go off as planned and a release would be performed every Tuesday. If a regression was introduced, someone would need to bisect the problem and revert the offending upgrade. Yes, this is work someone would need to do whenever a regression is introduced. There might not be a regression every single week, but I imagine there would be one every month or so? This seems like a burden that is best shared by a group of people rather than placed on one individual. I would be willing to be one of the members of such a group.

Is such a system ideal? Decidedly not. But the status quo is not sustainable from a cost perspective, either. There are other options. For example, we could design a system where PR builds that pass a very loose set of criteria (e.g., just `prep.sh`, or `prep.sh` + 20% of the test suite) get cleared not for merging to the main branch but rather for merging into a staging branch of some sort. Someone would then have to periodically run the full test suite against the staging branch and merge the staging branch to the main branch. This is safer but requires constant manual effort to test and promote the staging branch. That manual process could be automated, but that is a significant development effort in and of itself. And of course such automation code would itself need to be maintained as well.

Ultimately, whatever strategy we decide on needs to balance development effort, maintenance effort, group participation in development, and group participation in maintenance. Lower development effort that results in higher maintenance effort may be acceptable given sufficient participation in that maintenance effort. I would like to make it clear that this PR is not a discussion where people vote on what they would like to see me implement and then I go and implement whatever elaborate project someone manages to envision. This PR is one decidedly not ideal but nevertheless actual solution to a cost problem. Others are welcome to propose and implement alternative solutions that achieve cost reduction; I am not attached to this one. Nor am I a BOM maintainer, so the decision is ultimately not mine to make. This PR puts a stake in the ground to start the conversation.