### PR TITLE
Implement a staging workflow to reduce costs

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -3,12 +3,16 @@
 name: cd
 on:
   workflow_dispatch:
-  check_run:
-    types:
-      - completed
+  # TODO how can we trigger releases after a passing build of the "release"
+  # branch?
+#  check_run:
+#    types:
+#      - completed
 
 jobs:
   maven-cd:
+    # TODO this always releases the default branch, but we want to release only
+    # the "release" branch
     uses: jenkins-infra/github-reusable-workflows/.github/workflows/maven-cd.yml@v1
     secrets:
       MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -11,8 +11,6 @@ on:
 
 jobs:
   maven-cd:
-    # TODO this always releases the default branch, but we want to release only
-    # the "release" branch
     uses: jenkins-infra/github-reusable-workflows/.github/workflows/maven-cd.yml@v1
     secrets:
       MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -3,11 +3,7 @@
 name: cd
 on:
   workflow_dispatch:
-  # TODO how can we trigger releases after a passing build of the "release"
-  # branch?
-#  check_run:
-#    types:
-#      - completed
+  # no check_run trigger since releases are not made from the default branch
 
 jobs:
   maven-cd:

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,19 @@
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#enable-auto-merge-on-a-pull-request
+---
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Enable auto-merge for Dependabot PRs
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -6,7 +6,7 @@ permissions:
   contents: write
   pull-requests: write
 jobs:
-  dependabot:
+  dependabot-automerge:
     runs-on: ubuntu-latest
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -2,11 +2,9 @@
 ---
 name: Dependabot auto-merge
 on: pull_request
-
 permissions:
   contents: write
   pull-requests: write
-
 jobs:
   dependabot:
     runs-on: ubuntu-latest

--- a/.github/workflows/sync-release-branch.yml
+++ b/.github/workflows/sync-release-branch.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           title: Merge branch `master` into `release`
           body: |
-            Do not modify this PR
+            Do not modify this PR.
             If it cannot be merged, fix the default branch and rerun the sync job.
           branch: sync-release-branch
           delete-branch: true

--- a/.github/workflows/sync-release-branch.yml
+++ b/.github/workflows/sync-release-branch.yml
@@ -1,0 +1,22 @@
+---
+name: Sync release branch
+on:
+  schedule:
+    - cron: '30 10 * * 3,5,7'
+  workflow_dispatch:
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: release
+      - run: |
+          git fetch origin
+          git reset --hard origin/master
+          git rebase origin/release
+      - uses: peter-evans/create-pull-request@v5
+        with:
+          title: Merge branch `master` into `release`
+          branch: sync-release-branch
+          delete-branch: true

--- a/.github/workflows/sync-release-branch.yml
+++ b/.github/workflows/sync-release-branch.yml
@@ -5,7 +5,7 @@ on:
     - cron: '30 10 * * 3,5,7'
   workflow_dispatch:
 jobs:
-  sync:
+  sync-release-branch:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/sync-release-branch.yml
+++ b/.github/workflows/sync-release-branch.yml
@@ -2,7 +2,7 @@
 name: Sync release branch
 on:
   schedule:
-    - cron: '30 10 * * 3,5,7'
+    - cron: '30 10 * * 0,3,5'
   workflow_dispatch:
 jobs:
   sync-release-branch:

--- a/.github/workflows/sync-release-branch.yml
+++ b/.github/workflows/sync-release-branch.yml
@@ -18,5 +18,8 @@ jobs:
       - uses: peter-evans/create-pull-request@v5
         with:
           title: Merge branch `master` into `release`
+          body: |
+            Do not modify this PR
+            If it cannot be merged, fix the default branch and rerun the sync job.
           branch: sync-release-branch
           delete-branch: true

--- a/README.md
+++ b/README.md
@@ -194,10 +194,9 @@ This flag also allows all tests to be run even after some failures are recorded.
 ## Releasing
 
 You can cut a release using [JEP-229](https://jenkins.io/jep/229).
-To save resources, `master` is built only on demand, so use **Re-run checks**  in https://github.com/jenkinsci/bom/commits/master if you wish to start.
-If that build passes, a release should be published automatically when PRs matching certain label patterns are merged.
-For the common case that only lots of `dependencies` PRs have been merged,
-the release can be triggered manually from the **Actions** tab after a `master` build has succeeded.
+To save resources, `master` is built only on demand, so use **Re-run checks** in https://github.com/jenkinsci/bom/commits/release if you wish to start.
+If that build passes, trigger the CD workflow manually from the **Actions** tab,
+being sure to specify `release` rather than `master` as the branch to run the workflow from.
 
 ## Incrementals
 


### PR DESCRIPTION
This PR proposes turning `master` into a staging area as a cost reduction strategy.

The idea is as follows: for PRs to `master` (including all Dependabot PRs), we only run `prep.sh` (in the future, we could add a very small amount of Launchable testing to increase confidence) and mark the build as passing, unless a `skip-subset` label is present. For `master` builds, we only run `prep.sh` as well. This effectively turns `master` into a staging area where untested/broken code may be present.

To ensure quality releases, we would stop doing releases from the `master` branch and start doing them from a new `release` branch. On some cadence (e.g., Wednesday, Friday, and Sunday), a GitHub action runs to merge the `master` branch into the `release` branch. There should never be any conflicts here, since the only commits to the `release` branch will be coming from this job, which is doing a one-way sync from `master` to `release`. Unlike PRs to `master`, PRs to the `release` branch do run the full test suite, so we can catch any problems and fix them throughout the week. Non-PR builds of `release` fail just like current non-PR builds of `master` to avoid duplicated work.

So how would releases happen in this system? I am not too sure. The `maven-cd` workflow currently in use does not support doing releases from non-default branches and relies on https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#check_run which "will only trigger a workflow run if the workflow file is on the default branch." In our case we want to only do releases from the `release` branch, since that is the only branch that has been tested. For now this PR triggers a build of the `release` branch on Monday in preparation for a Tuesday CD release of some sort but does not actually implement the necessary changes in `.github/workflows/cd.yaml`. I would be looking for someone else to work on this.

The idea is that once this is adopted, the vast majority of builds would be "subset" builds, with "subset" being currently defined as just `prep.sh` but eventually including some tests from Launchable to improve our confidence. The only "full" builds would be on Wednesday, Friday, and Sunday when PRs are created against the `release` branch, as well as any non-PR builds of the `release` branch right before an actual release.

This would drastically reduce costs while still retaining stability. Maintainers would have to merge the automatically created PRs on Wednesday, Friday, and Sunday, and bisect/revert any offending changes if necessary. (Those changes would be fixed & resubmitted with the `skip-subset` label to properly test them before re-integration.) This seems like a small price to pay for a more sustainable operational deployment.

---

This is just a starting point, so please propose alternative ideas and start implementing them. It is much easier to talk about a proposal when looking at code (even if the code is still incomplete). For example, an alternative proposal would be to run the `error` step for any Dependabot PR build (making them unmergable) and write a more complicated GitHub Action workflow to periodically (say, Wednesday, Friday, and Sunday) gather these into a batch and offer a combined PR for full testing. That would be harder to implement, and while it would solve the CD problems described above, it would introduce new problems such as merge conflicts. It also would not decrease costs for non-Dependabot, non-combined PRs. So for these reasons, I didn't try this out, but I would not be upset if someone else made a competing PR with an alternative strategy for discussion.