### PR TITLE
chore(pipeline) switch to dedicated agent resources

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,6 @@ def mavenEnv(Map params = [:], Closure body) {
     node('maven-bom') {
       timeout(120) {
         withEnv(["JAVA_HOME=/opt/jdk-$params.jdk"]) {
-          sh 'mvn -version'
           infra.withArtifactCachingProxy {
             withEnv([
               "MAVEN_ARGS=${env.MAVEN_ARGS != null ? MAVEN_ARGS : ''} -B -ntp -Dmaven.repo.local=${WORKSPACE_TMP}/m2repo"
@@ -52,7 +51,10 @@ stage('prep') {
       withCredentials([
         usernamePassword(credentialsId: 'app-ci.jenkins.io', usernameVariable: 'GITHUB_APP', passwordVariable: 'GITHUB_OAUTH')
       ]) {
-        sh 'bash prep.sh'
+        sh '''
+        mvn -v
+        bash prep.sh
+        '''
       }
     }
     dir('target') {
@@ -96,7 +98,10 @@ lines.each {line ->
           "LINE=$line",
           'EXTRA_MAVEN_PROPERTIES=maven.test.failure.ignore=true:surefire.rerunFailingTestsCount=1'
         ]) {
-          sh 'bash pct.sh'
+          sh '''
+          mvn -v
+          bash pct.sh
+          '''
         }
         launchable.install()
         withCredentials([string(credentialsId: 'launchable-jenkins-bom', variable: 'LAUNCHABLE_TOKEN')]) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,21 +10,23 @@ def mavenEnv(Map params = [:], Closure body) {
   retry(count: attempts, conditions: [kubernetesAgent(handleNonKubernetes: true), nonresumable()]) {
     echo 'Attempt ' + ++attempt + ' of ' + attempts
     // no Dockerized tests; https://github.com/jenkins-infra/documentation/blob/master/ci.adoc#container-agents
-    node("maven-$params.jdk") {
+    node('maven-bom') {
       timeout(120) {
-        sh 'mvn -version'
-        // Exclude DigitalOcean artifact caching proxy provider, currently unreliable on BOM builds
-        // TODO: remove when https://github.com/jenkins-infra/helpdesk/issues/3481 is fixed
-        infra.withArtifactCachingProxy(env.ARTIFACT_CACHING_PROXY_PROVIDER != 'do') {
-          withEnv([
-            "MAVEN_ARGS=${env.MAVEN_ARGS != null ? MAVEN_ARGS : ''} -B -ntp -Dmaven.repo.local=${WORKSPACE_TMP}/m2repo"
-          ]) {
-            body()
+        withEnv(["JAVA_HOME=/opt/jdk-$params.jdk"]) {
+          sh 'mvn -version'
+          // Exclude DigitalOcean artifact caching proxy provider, currently unreliable on BOM builds
+          // TODO: remove when https://github.com/jenkins-infra/helpdesk/issues/3481 is fixed
+          infra.withArtifactCachingProxy(env.ARTIFACT_CACHING_PROXY_PROVIDER != 'do') {
+            withEnv([
+              "MAVEN_ARGS=${env.MAVEN_ARGS != null ? MAVEN_ARGS : ''} -B -ntp -Dmaven.repo.local=${WORKSPACE_TMP}/m2repo"
+            ]) {
+              body()
+            }
           }
-        }
-        if (junit(testResults: '**/target/surefire-reports/TEST-*.xml,**/target/failsafe-reports/TEST-*.xml').failCount > 0) {
-          // TODO JENKINS-27092 throw up UNSTABLE status in this case
-          error 'Some test failures, not going to continue'
+          if (junit(testResults: '**/target/surefire-reports/TEST-*.xml,**/target/failsafe-reports/TEST-*.xml').failCount > 0) {
+            // TODO JENKINS-27092 throw up UNSTABLE status in this case
+            error 'Some test failures, not going to continue'
+          }
         }
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,9 +14,7 @@ def mavenEnv(Map params = [:], Closure body) {
       timeout(120) {
         withEnv(["JAVA_HOME=/opt/jdk-$params.jdk"]) {
           sh 'mvn -version'
-          // Exclude DigitalOcean artifact caching proxy provider, currently unreliable on BOM builds
-          // TODO: remove when https://github.com/jenkins-infra/helpdesk/issues/3481 is fixed
-          infra.withArtifactCachingProxy(env.ARTIFACT_CACHING_PROXY_PROVIDER != 'do') {
+          infra.withArtifactCachingProxy {
             withEnv([
               "MAVEN_ARGS=${env.MAVEN_ARGS != null ? MAVEN_ARGS : ''} -B -ntp -Dmaven.repo.local=${WORKSPACE_TMP}/m2repo"
             ]) {


### PR DESCRIPTION
This PR is motivated by https://github.com/jenkins-infra/helpdesk/issues/3521.

This PR switches to a set of resources dedciated to the BOM, to avoid blocking other plugins/projects builds on ci.jenkins.io.

Unlike the experiments in https://github.com/jenkinsci/bom/pull/1969, there is no change in the VM or agent sizing to deliver one change at a time.

Please note there are 2 minors changes in this PR:

- Removing the "Digital Ocean Artifact Caching Proxy" exception as this PR forces all builds to run in AWS only (and it should stay like this)
- Merge the `mvn -v` SH steps into the principal steps

----

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- ~[ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue~
