### PR TITLE
Skip PCT by default on PRs

### DIFF
--- a/.github/workflows/dependabot-automerge.yaml
+++ b/.github/workflows/dependabot-automerge.yaml
@@ -1,0 +1,17 @@
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#enable-auto-merge-on-a-pull-request
+---
+name: Dependabot auto-merge
+on: pull_request
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  dependabot-automerge:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Enable auto-merge for Dependabot PRs
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/run-full-test.yaml
+++ b/.github/workflows/run-full-test.yaml
@@ -1,0 +1,31 @@
+name: Run full tests
+on:
+  schedule:
+    - cron: '0 1 * * 6'
+  workflow_dispatch:
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - run: |
+        set -x
+        git fetch
+        if gh pr checkout full-tests
+        then
+          gh pr close --comment 'Recreating'
+          git checkout master
+          git branch -d full-tests
+          git push origin :full-tests
+          git reset --hard master
+        fi
+        git checkout -b full-tests
+        # GitHub apparently does not let you create a PR with no commits:
+        echo 'Just rerunning PCT, do not merge me!' > DO-NOT-MERGE-ME
+        git add DO-NOT-MERGE-ME
+        git commit --message 'Phony commit'
+        git push origin full-tests
+        # Not using --draft to ensure notifications are sent:
+        gh pr create --head --title 'Testing master (do not merge)' --body 'Check test results, then close' --reviewer jenkinsci/bom-developers --label full-test
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/run-full-test.yaml
+++ b/.github/workflows/run-full-test.yaml
@@ -15,7 +15,7 @@ jobs:
         then
           gh pr close --comment 'Recreating'
           git checkout master
-          git branch -d full-tests
+          git branch -D full-tests
           git push origin :full-tests
           git reset --hard master
         fi

--- a/.github/workflows/run-full-test.yaml
+++ b/.github/workflows/run-full-test.yaml
@@ -21,11 +21,9 @@ jobs:
         fi
         git checkout -b full-tests
         # GitHub apparently does not let you create a PR with no commits:
-        echo 'Just rerunning PCT, do not merge me!' > DO-NOT-MERGE-ME
-        git add DO-NOT-MERGE-ME
-        git commit --message 'Phony commit'
+        git commit --allow-empty --message 'Phony commit'
         git push origin full-tests
         # Not using --draft to ensure notifications are sent:
-        gh pr create --head --title 'Testing master (do not merge)' --body 'Check test results, then close' --reviewer jenkinsci/bom-developers --label full-test
+        gh pr create --head --title 'Testing master (do not merge)' --body 'Close this PR if it passes; otherwise please fix failures.' --reviewer jenkinsci/bom-developers --label full-test
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,17 +4,17 @@ if (BRANCH_NAME == 'master' && currentBuild.buildCauses*._class == ['jenkins.bra
   error 'No longer running builds on response to master branch pushes. If you wish to cut a release, use “Re-run checks” from this failing check in https://github.com/jenkinsci/bom/commits/master'
 }
 
-def mavenEnv(Map params = [:], Closure body) {
+def mavenEnv(boolean nodePool, int jdk, Closure body) {
   def attempt = 0
   def attempts = 3
   retry(count: attempts, conditions: [kubernetesAgent(handleNonKubernetes: true), nonresumable()]) {
     echo 'Attempt ' + ++attempt + ' of ' + attempts
     // no Dockerized tests; https://github.com/jenkins-infra/documentation/blob/master/ci.adoc#container-agents
-    node('maven-bom') {
+    node(nodePool ? 'maven-bom': "maven-$jdk") {
       timeout(120) {
         infra.withArtifactCachingProxy {
           withEnv([
-            "JAVA_HOME=/opt/jdk-$params.jdk",
+            "JAVA_HOME=/opt/jdk-$jdk",
             "MAVEN_ARGS=${env.MAVEN_ARGS != null ? MAVEN_ARGS : ''} -B -ntp -Dmaven.repo.local=${WORKSPACE_TMP}/m2repo"
           ]) {
             body()
@@ -43,7 +43,7 @@ def pluginsByRepository
 def lines
 
 stage('prep') {
-  mavenEnv(jdk: 11) {
+  mavenEnv(false, 11) {
     checkout scm
     withEnv(['SAMPLE_PLUGIN_OPTS=-Dset.changelist']) {
       withCredentials([
@@ -86,7 +86,7 @@ if (BRANCH_NAME == 'master' || env.CHANGE_ID && pullRequest.labels.contains('ful
     pluginsByRepository.each { repository, plugins ->
       branches["pct-$repository-$line"] = {
         def jdk = line == 'weekly' ? 17 : 11
-        mavenEnv(jdk: jdk) {
+        mavenEnv(true, jdk) {
           unstash line
           withEnv([
             "PLUGINS=${plugins.join(',')}",

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ If the build fails due to an unmanaged transitive plugin dependency, add it to
 
 ## PCT
 
-The CI build tries running the [Plugin Compatibility Tester (PCT)](https://github.com/jenkinsci/plugin-compat-tester/)
+The CI build can run the [Plugin Compatibility Tester (PCT)](https://github.com/jenkinsci/plugin-compat-tester/)
 on the particular combination of plugins being managed by the BOM.
 This catches mutual incompatibilities between plugins
 (as revealed by their `JenkinsRule` tests)
@@ -168,7 +168,10 @@ DOCKERIZED=true
 
 to reproduce image-specific failures.
 
-Note that to minimize build time, tests are run only on Linux, against JDK 8, and without Docker support.
+To minimize cloud resources, PCT is not run at all by default on pull requests, only some basic sanity checks.
+Add the label `full-test` to run PCT in a PR.
+
+To further minimize build time, tests are run only on Linux, against Java 11, and without Docker support.
 It is unusual but possible for cross-component incompatibilities to only be visible in more specialized environments (such as Windows).
 
 ## LTS lines
@@ -186,10 +189,6 @@ according to the `jenkins-infra/update-center2`.
 The UC currently maintains releases for the [past 400 days](https://groups.google.com/g/jenkins-infra/c/LTrRUqkgeQA/m/UmQMD5gDAgAJ)
 so it is reasonable to retire BOMs for lines older than that,
 or otherwise when the number of accumulated version overrides becomes large.
-
-Add the label `full-test` in dangerous-looking PRs to make sure you are running tests in all LTS lines;
-by default tests are only run in the oldest line and weeklies.
-This flag also allows all tests to be run even after some failures are recorded.
 
 ## Releasing
 

--- a/updatecli/updatecli.d/plugin-compat-tester.yml
+++ b/updatecli/updatecli.d/plugin-compat-tester.yml
@@ -43,3 +43,4 @@ actions:
     spec:
       labels:
         - dependencies
+        - full-test


### PR DESCRIPTION
Simpler alternative to #2031 to consider. By comparison, it retains the straightforward release-from-`master` behavior, so CD configuration should not need any adjustment, and there is no need to track the status of release branch merges. Also keeps #1993, so PCT will be run only when you ask for it in a PR, or explicitly test `master` (perhaps when planning a release). We can also consider running `master` builds on a schedule, such as `@nightly`.

I believe it is unnecessary to use a dedicated release branch. Such a system makes sense for repositories which:
* Have a lot of untested code coming in which is likely to cause frequent test failures or genuine regressions.
* Must be able to be released on short notice, for example to address a security vulnerability.
* Cannot tolerate much risk of regression.

None of those criteria seem to apply to a developer tool like a BOM which after all is merely a convenience to help you manage a dependency list. If some change introduced a PCT regression, we can generally take our time fixing it, whether by releasing some plugin with a test or behavioral change and integrating it; reverting the problematic update; or adding a test to an exclusion list.
