### PR TITLE
Set `NOT_BUILT` status on `master` with `BranchEventCause`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,7 @@
 properties([disableConcurrentBuilds(abortPrevious: true), buildDiscarder(logRotator(numToKeepStr: '7'))])
 
 if (BRANCH_NAME == 'master' && currentBuild.buildCauses*._class == ['jenkins.branch.BranchEventCause']) {
+  currentBuild.result = 'NOT_BUILT'
   error 'No longer running builds on response to master branch pushes. If you wish to cut a release, use “Re-run checks” from this failing check in https://github.com/jenkinsci/bom/commits/master'
 }
 


### PR DESCRIPTION
Amending #1993. Should improve display in https://ci.jenkins.io/job/Tools/job/bom/job/master/buildTimeTrend for example. https://issues.jenkins.io/browse/JENKINS-27092 worked around.