### PR TITLE
Adding `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @jenkinsci/bom-developers


### PR DESCRIPTION
Should automatically request review on all PRs, which I guess is desirable. Consistent with plugin repos anyway.