### PR TITLE
Missing argument to `--head`

### DIFF
--- a/.github/workflows/run-full-test.yaml
+++ b/.github/workflows/run-full-test.yaml
@@ -26,6 +26,6 @@ jobs:
         git commit --allow-empty --message 'Phony commit'
         git push origin full-tests
         # Not using --draft to ensure notifications are sent:
-        gh pr create --head --title 'Testing master (do not merge)' --body 'Close this PR if it passes; otherwise please fix failures.' --reviewer jenkinsci/bom-developers --label full-test
+        gh pr create --head full-tests --title 'Testing master (do not merge)' --body 'Close this PR if it passes; otherwise please fix failures.' --reviewer jenkinsci/bom-developers --label full-test
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Trouble-shooting the workflow added in #2034. AFAIK it is not possible to test these things in GHA before merging.