### PR TITLE
Test Guice 6.0 upgrade in Jenkins core

### DIFF
--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -14,7 +14,7 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <bom>weekly</bom>
-    <jenkins.version>2.404</jenkins.version>
+    <jenkins.version>2.405-rc33686.8eb_cd889f740</jenkins.version>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>
   <dependencyManagement>


### PR DESCRIPTION
## Test Guice 6.0 upgrade in Jenkins core

https://github.com/jenkinsci/jenkins/pull/7990 proposes to upgrade to Guice 6.0 in Jenkins core as part of the transition away from the `javax.*` bindings to the `jakarta.*` bindings.

See the [Guice 6.0.0 changelog](https://github.com/google/guice/wiki/Guice600) for details of the Guice 6.0.0 changes.

### Testing done

Confirmed that `mvn --pl sample-plugin -DforkCount=1C verify` passes.  Will rely on ci.jenkins.io to perform more testing.

### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
