### PR TITLE
Revert "Bump mina-sshd-api.version from 2.9.2-62.v199162f0a_2f8 to 2.10.0-69.v28e3e36d18eb_ in /bom-weekly"

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -16,7 +16,7 @@
     <declarative-pipeline-migration-assistant-plugin.version>1.5.6</declarative-pipeline-migration-assistant-plugin.version>
     <forensics-api.version>2.1.0</forensics-api.version>
     <git-plugin.version>5.0.2</git-plugin.version>
-    <mina-sshd-api.version>2.10.0-69.v28e3e36d18eb_</mina-sshd-api.version>
+    <mina-sshd-api.version>2.9.2-62.v199162f0a_2f8</mina-sshd-api.version>
     <pipeline-model-definition-plugin.version>2.2131.vb_9788088fdb_5</pipeline-model-definition-plugin.version>
     <pipeline-stage-view-plugin.version>2.32</pipeline-stage-view-plugin.version>
     <plugin-util-api.version>3.2.1</plugin-util-api.version>


### PR DESCRIPTION
Reverts jenkinsci/bom#2075 because it shows a failure when running with full-test.  See https://ci.jenkins.io/job/Tools/job/bom/view/change-requests/job/PR-2071/4/ and https://github.com/jenkinsci/bom/pull/2071/checks