### PR TITLE
Upgrade `sshd` from 3.275.v9e17c10f2571 to 3.303.vefc7119b_ec23

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -264,7 +264,7 @@
       <dependency>
         <groupId>org.jenkins-ci.modules</groupId>
         <artifactId>sshd</artifactId>
-        <version>3.275.v9e17c10f2571</version>
+        <version>3.303.vefc7119b_ec23</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Alternative to #2083. Tested with `PLUGINS=sshd bash local-test.sh`, which was failing prior to this PR and passes with this PR.

Closes #2083