### PR TITLE
Revert latest copyartifact upgrade

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -314,7 +314,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>copyartifact</artifactId>
-        <version>702.va_c09cb_6e51cf</version>
+        <version>698.v393f578eb_ddc</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Update of copyartifact requires a newer version of the maven plugin. That would require bringing the maven plugin into the plugin bill of materials.  That's not an attractive option.  Will need to investigate possible changes in copyartifact to not require a newer version of the maven plugin.

This reverts commit fe7e570f8bf4620e73e0fc7fa1e81880500dccd8.

### Testing done

Confirmed that the failing config file provider plugin tests are fixed by reverting this change.

### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
