### PR TITLE
Remove deprecated popper2 plugin from managed set

### DIFF
--- a/bom-2.375.x/pom.xml
+++ b/bom-2.375.x/pom.xml
@@ -87,6 +87,11 @@
         <version>${plugin-util-api.version}</version>
       </dependency>
       <dependency>
+        <groupId>io.jenkins.plugins</groupId>
+        <artifactId>popper2-api</artifactId>
+        <version>2.11.6-2</version>
+      </dependency>
+      <dependency>
         <groupId>org.6wind.jenkins</groupId>
         <artifactId>lockable-resources</artifactId>
         <version>1131.vb_7c3d377e723</version>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -218,11 +218,6 @@
       </dependency>
       <dependency>
         <groupId>io.jenkins.plugins</groupId>
-        <artifactId>popper2-api</artifactId>
-        <version>2.11.6-2</version>
-      </dependency>
-      <dependency>
-        <groupId>io.jenkins.plugins</groupId>
         <artifactId>snakeyaml-api</artifactId>
         <version>1.33-95.va_b_a_e3e47b_fa_4</version>
       </dependency>

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -179,11 +179,6 @@
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
-      <artifactId>popper2-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.jenkins.plugins</groupId>
       <artifactId>snakeyaml-api</artifactId>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
## Remove deprecated popper2 plugin from managed set

https://plugins.jenkins.io/popper2-api/dependencies/ shows no declared dependencies on the plugin.

https://github.com/jenkinsci/bootstrap5-api-plugin/releases/tag/v5.2.2-6 embedded popper2 api into the Bootstrap 5 API plugin.

### Testing done

Tested a plugin build without this plugin and confirmed there were no surprises.

### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
