### PR TITLE
Temporarily exclude ExtendedEmailPublisherDescriptorTest

### DIFF
--- a/excludes.txt
+++ b/excludes.txt
@@ -15,3 +15,6 @@ org.jenkinsci.plugins.matrixauth.integrations.casc.ImportTest
 
 # TODO tends to run out of memory
 org.jenkinsci.plugins.pipeline.modeldefinition.TriggersTest
+
+# TODO depends on page content that changed in 2.409 or earlier
+hudson.plugins.emailext.ExtendedEmailPublisherDescriptorTest


### PR DESCRIPTION
UI changes in https://github.com/jenkinsci/jenkins/pull/7717 changed
the contents of the DOM that the groovyClassPath() test was using for
its assertion.  Temporarily ignore that test result until a pull request
to email-ext resolves the issue.

The email-ext pull request is not ready but I will do my best to have
it ready within 48 hours so that this exclusion can truly be temporary.
