### PR TITLE
Retry tasks up to 6 times

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ if (BRANCH_NAME == 'master' && currentBuild.buildCauses*._class == ['jenkins.bra
 
 def mavenEnv(boolean nodePool, int jdk, Closure body) {
   def attempt = 0
-  def attempts = 3
+  def attempts = 6
   retry(count: attempts, conditions: [kubernetesAgent(handleNonKubernetes: true), nonresumable()]) {
     echo 'Attempt ' + ++attempt + ' of ' + attempts
     // no Dockerized tests; https://github.com/jenkins-infra/documentation/blob/master/ci.adoc#container-agents

--- a/full-test
+++ b/full-test
@@ -1,0 +1,1 @@
+TODO delete me

--- a/full-test
+++ b/full-test
@@ -1,1 +1,0 @@
-TODO delete me


### PR DESCRIPTION
## Retry tasks up to 6 times

- Retry up to 6 times, rather than the currently configured 3 times
- Run full tests to confirm 6 retries are sufficient

https://ci.jenkins.io/job/Tools/job/bom/job/master/1795/ had 13 tasks that reached 3 retries and at least one of those tasks failed even on the third retry.  Let's allow up to 6 retries in hopes of having all of the more than 460 tasks complete successfully within 6 retries.

This is a draft pull request that also tests that the `full-tests` instructions work for those who do not have permission to assign a label to a pull request.  Please don't merge this until the current build of the master branch has completed.  If it is merged while the current build is running, it will cancel the running build.

### Testing done

Reviewed failures in https://ci.jenkins.io/job/Tools/job/bom/job/master/1795/ and confirmed that each of the failing tasks had used 3 retries and that all of them were reporting known retry cases (like unable to resolve FilePath or channel closed exception).

### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
