### PR TITLE
Exclude a git client maintenance test

### DIFF
--- a/excludes.txt
+++ b/excludes.txt
@@ -20,3 +20,7 @@ org.jenkinsci.plugins.matrixauth.integrations.casc.ImportTest
 
 # TODO tends to run out of memory
 org.jenkinsci.plugins.pipeline.modeldefinition.TriggersTest
+
+# TODO remove exclusion when 2.375.x line is no longer being tested
+# https://github.com/jenkinsci/git-client-plugin/pull/1019 fixed the issue for 2.387.x, 2.401.x, and weekly in git client plugin 4.4.0
+org.jenkinsci.plugins.gitclient.GitClientMaintenanceTest.test_loose_objects_maintenance


### PR DESCRIPTION
## Exclude a git client maintenance test

Fails for command line git 2.41 with git client plugin releases prior to 4.4.0 because it assumes that only two files are written for a loose object.  Command line git 2.41 writes a third file for a loose object.

Git client plugin 4.4.0 requires git 2.387.3 or later, so its correction of the test does not resolve the issue for the 2.375.x BOM test.

Remove this exclusion when 2.375.x is no longer being tested.
