### PR TITLE
Exclude some config file provider tests temporarily

### DIFF
--- a/excludes.txt
+++ b/excludes.txt
@@ -12,3 +12,8 @@ org.jenkinsci.plugins.gitclient.FilePermissionsTest
 
 # TODO tends to run out of memory
 org.jenkinsci.plugins.pipeline.modeldefinition.TriggersTest
+
+# TODO config file provider test fixes for 2.415 and later: https://github.com/jenkinsci/config-file-provider-plugin/pull/286
+org.jenkinsci.plugins.configfiles.ConfigFilesSEC1253Test
+org.jenkinsci.plugins.configfiles.folder.FolderConfigFileActionTest
+org.jenkinsci.plugins.configfiles.sec.Security2002Test


### PR DESCRIPTION
## Exclude some config file provider tests temporarily

Tests fail with Jenkins 2.415

PR https://github.com/jenkinsci/config-file-provider-plugin/pull/286

Confirmed that PR works, do not delay BOM release for test fix

### Testing done

Confirmed the pull request fixes the tests on Jenkins 2.415 and continues to run successfully on other configurations.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
