### PR TITLE
Revert config file provider test exclusion

### DIFF
--- a/excludes.txt
+++ b/excludes.txt
@@ -12,8 +12,3 @@ org.jenkinsci.plugins.gitclient.FilePermissionsTest
 
 # TODO tends to run out of memory
 org.jenkinsci.plugins.pipeline.modeldefinition.TriggersTest
-
-# TODO config file provider test fixes for 2.415 and later: https://github.com/jenkinsci/config-file-provider-plugin/pull/286
-org.jenkinsci.plugins.configfiles.ConfigFilesSEC1253Test
-org.jenkinsci.plugins.configfiles.folder.FolderConfigFileActionTest
-org.jenkinsci.plugins.configfiles.sec.Security2002Test


### PR DESCRIPTION
## Revert config file provider test exclusion

Fixed issue https://github.com/jenkinsci/bom/issues/2274 with pull request https://github.com/jenkinsci/bom/pull/2276

https://github.com/jenkinsci/config-file-provider-plugin/pull/286 fixed it thanks to @mawinter69 and @rsandell.

This reverts commit 8fe50be609c02d45168d025c0b188320d001ead0.

### Testing done

Tested plugin pull request before its release.

### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
