### PR TITLE
Add `cvs`, `junit-realtime-test-reporter`, and `view-job-filters` to the managed set

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -84,6 +84,9 @@ stage('prep') {
 if (BRANCH_NAME == 'master' || fullTestMarkerFile || env.CHANGE_ID && pullRequest.labels.contains('full-test')) {
   branches = [failFast: false]
   lines.each {line ->
+    if (line != 'weekly') {
+      return
+    }
     pluginsByRepository.each { repository, plugins ->
       branches["pct-$repository-$line"] = {
         def jdk = line == 'weekly' ? 21 : 11

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -464,6 +464,12 @@
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>cvs</artifactId>
+        <!-- TODO https://github.com/jenkinsci/cvs-plugin/pull/87 -->
+        <version>2.20-rc444.7b_3b_2d526eee</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>dashboard-view</artifactId>
         <version>2.495.v07e81500c3f2</version>
       </dependency>
@@ -599,6 +605,11 @@
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>junit-attachments</artifactId>
         <version>167.vf1d139e316b_3</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>junit-realtime-test-reporter</artifactId>
+        <version>129.vd45a_61b_e3a_c8</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
@@ -796,6 +807,11 @@
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>variant</artifactId>
         <version>59.vf075fe829ccb</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>view-job-filters</artifactId>
+        <version>369.ve0513a_a_f5524</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -386,6 +386,11 @@
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>cvs</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>dashboard-view</artifactId>
       <scope>test</scope>
     </dependency>
@@ -509,6 +514,11 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>junit-attachments</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>junit-realtime-test-reporter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -680,6 +690,11 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>variant</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>view-job-filters</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Demonstrating that these three plugins are all ready for BOM inclusion pending merge/release of various open PRs.