### PR TITLE
Depend on 2.414.1 rather than 2.414

### DIFF
--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -894,7 +894,7 @@
       <id>2.414.x</id>
       <properties>
         <bom>2.414.x</bom>
-        <jenkins.version>2.414</jenkins.version>
+        <jenkins.version>2.414.1</jenkins.version>
       </properties>
     </profile>
     <profile>


### PR DESCRIPTION
## Depend on Jenkins 2.414.1 instead of 2.414

Jenkins LTS 2.414.1 has releaed

### Testing done

None.  Relying on ci run of full-test

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
