### PR TITLE
Remove unnecessary workaround

### DIFF
--- a/sample-plugin/check.groovy
+++ b/sample-plugin/check.groovy
@@ -45,9 +45,6 @@ project.artifacts.each { art ->
   if (plugin == null) {
     return
   }
-  if (plugin == 'instance-identity') {
-    return // JEP-230
-  }
   for (String intermediate : art.dependencyTrail.drop(1).dropRight(1).collect {stripAllButGA(it)}) {
     def intermediateArt = artifactMap[intermediate]
     if (intermediateArt == null) {


### PR DESCRIPTION
This workaround was only needed when this repository supported core versions prior to the Instance Identity split. This repository now has an oldest supported line of 2.387.x which is after the split, so this workaround is no longer needed. The CI build should be sufficient to test this code path.