### PR TITLE
Exclude memory-hogging Blue Ocean test

### DIFF
--- a/excludes.txt
+++ b/excludes.txt
@@ -1,6 +1,9 @@
 # TODO cryptic PCT-only errors: https://github.com/jenkinsci/bom/pull/251#issuecomment-645012427
 hudson.matrix.AxisTest
 
+# TODO tends to run out of memory
+io.jenkins.blueocean.rest.impl.pipeline.PipelineNodeTest
+
 # TODO https://github.com/jenkinsci/blueocean-plugin/pull/2471
 io.jenkins.blueocean.service.embedded.PipelineApiTest
 


### PR DESCRIPTION
I've seen this test crash a number of times due to out-of-memory errors on our agents, even after multiple re-runs. Since the point of having this plugin in the test suite is to ensure basic Java compatibility rather than to run every single test, exclude the test to keep the rest of the suite stable.