### PR TITLE
Remove run-condition test failure workaround

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -97,9 +97,6 @@ if (BRANCH_NAME == 'master' || fullTestMarkerFile || env.CHANGE_ID && pullReques
           } else if (repository == 'jacoco-plugin') {
             // TODO JENKINS-71806
             jdk = 17
-          } else if (repository == 'run-condition-plugin') {
-            // TODO JENKINS-71807
-            jdk = 17
           }
         }
         mavenEnv(jdk: jdk, nodePool: true) {


### PR DESCRIPTION
Fixes https://github.com/jenkinsci/bom/issues/2384
Closes https://github.com/jenkinsci/bom/pull/2444

Thanks to @MarkEWaite for releasing a new version of the plugin supporting Java 21 in tests, to remove the workaround here.