### PR TITLE
Exclude specific test method rather than whole test

### DIFF
--- a/excludes.txt
+++ b/excludes.txt
@@ -17,7 +17,7 @@ jenkins.plugins.http_request.HttpRequestStepRoundTripTest
 org.jenkinsci.plugins.durabletask.BourneShellScriptTest
 
 # TODO https://github.com/jenkinsci/github-branch-source-plugin/pull/724
-org.jenkinsci.plugins.github_branch_source.GitHubSCMSourceTraitsTest
+org.jenkinsci.plugins.github_branch_source.GitHubSCMSourceTraitsTest#given__configuredInstance__when__uninstantiating__then__deprecatedFieldsIgnored
 
 # TODO tends to run out of memory
 org.jenkinsci.plugins.pipeline.modeldefinition.TriggersTest


### PR DESCRIPTION
Mostly just checking to see if our plugin parent POMs are finally new enough such that we can use test methods in `excludes.txt` without the dreaded `Method filter prohibited in includes|excludes|includesFile|excludesFile parameter` error from Surefire. Looks like this is true (at least for the weekly line)!

I also ran this to make sure older lines are OK:

```
LINE=2.387.x PLUGINS=blueocean-bitbucket-pipeline,blueocean-commons,blueocean-config,blueocean-core-js,blueocean-dashboard,blueocean-events,blueocean-executor-info,blueocean-github-pipeline,blueocean-git-pipeline,blueocean-i18n,blueocean-jwt,blueocean-personalization,blueocean-pipeline-api-impl,blueocean-pipeline-editor,blueocean-pipeline-scm-api,blueocean-rest,blueocean-rest-impl,blueocean-web,dark-theme,jenkins-design-language,kubernetes,kubernetes-client-api,kubernetes-credentials,workflow-job TEST=InjectedTest bash local-test.sh
```