### PR TITLE
Pin snakeyaml-api 1.33 for Jenkins 2.387.3

### DIFF
--- a/bom-2.387.x/pom.xml
+++ b/bom-2.387.x/pom.xml
@@ -10,6 +10,7 @@
   <packaging>pom</packaging>
   <properties>
     <blueocean-plugin.version>1.27.5.1</blueocean-plugin.version>
+    <configuration-as-code-plugin.version>1670.v564dc8b_982d0</configuration-as-code-plugin.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -19,6 +20,11 @@
         <version>${project.version}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>io.jenkins</groupId>
+        <artifactId>configuration-as-code</artifactId>
+        <version>${configuration-as-code-plugin.version}</version>
       </dependency>
       <dependency>
         <groupId>io.jenkins.blueocean</groupId>
@@ -115,6 +121,11 @@
         <groupId>io.jenkins.blueocean</groupId>
         <artifactId>jenkins-design-language</artifactId>
         <version>${blueocean-plugin.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.jenkins.configuration-as-code</groupId>
+        <artifactId>test-harness</artifactId>
+        <version>${configuration-as-code-plugin.version}</version>
       </dependency>
       <dependency>
         <groupId>io.jenkins.plugins</groupId>

--- a/bom-2.387.x/pom.xml
+++ b/bom-2.387.x/pom.xml
@@ -117,6 +117,11 @@
         <version>${blueocean-plugin.version}</version>
       </dependency>
       <dependency>
+        <groupId>io.jenkins.plugins</groupId>
+        <artifactId>snakeyaml-api</artifactId>
+        <version>1.33-95.va_b_a_e3e47b_fa_4</version>
+      </dependency>
+      <dependency>
         <groupId>org.csanchez.jenkins.plugins</groupId>
         <artifactId>kubernetes</artifactId>
         <version>4007.v633279962016</version>
@@ -130,11 +135,6 @@
         <groupId>org.jenkinsci.plugins</groupId>
         <artifactId>kubernetes-credentials</artifactId>
         <version>0.10.0</version>
-      </dependency>
-      <dependency>
-        <groupId>io.jenkins.plugins</groupId>
-        <artifactId>snakeyaml-api</artifactId>
-        <version>1.33-95.va_b_a_e3e47b_fa_4</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/bom-2.387.x/pom.xml
+++ b/bom-2.387.x/pom.xml
@@ -131,6 +131,11 @@
         <artifactId>kubernetes-credentials</artifactId>
         <version>0.10.0</version>
       </dependency>
+      <dependency>
+        <groupId>io.jenkins.plugins</groupId>
+        <artifactId>snakeyaml-api</artifactId>
+        <version>1.33-95.va_b_a_e3e47b_fa_4</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 </project>


### PR DESCRIPTION
## Pin snakeyaml-api 1.33 for Jenkins 2.387.3

This pinning of the plugin version is being done to pass the 2.387.3 tests for the blue ocean plugin and the kubernetes plugin.  I think that is better than excluding the failing tests, since the failing tests would be excluded on all versions, not just one version.

This is atypical, since the snakeyaml 2.2 plugin supports Jenkins 2.387.3, but other plugins that run on 2.387.3 do not support snakeyaml 2.2.

The blue ocean plugin version 1.27.5.1 (most recent release supported with Jenkins 2.387.3) does not support snakeyaml plugin 2.2 based on [JENKINS-71966](https://issues.jenkins.io/browse/JENKINS-71966)

The kubernetes plugin version 4007.v633279962016 (most recent release supported with Jenkins 2.387.3) does not support snakeyaml plugin 2.2 based on the test results from https://github.com/jenkinsci/bom/pull/2464/checks?check_run_id=16489432297

### Testing done

Confirmed that `mvn -P2.387.x verify` passes locally

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
