### PR TITLE
Reduce Maven memory usage even more

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,1 +1,1 @@
--Xmx512m
+-Xmx512m -XX:+TieredCompilation -XX:TieredStopAtLevel=1


### PR DESCRIPTION
In #2440 I am still seeing some failures of `ExampleStepTest` due to lack of memory, but curiously enough only on the oldest BOM line. This PR attempts to reduce memory usage even more by adopting some JVM flags (already used in `pipeline-model-definition`) that disable the C2 compiler and its (couple hundred MB) of code cache.

### Testing done

I have been running with these flags in #2440 and while they haven't totally fixed the problem, they haven't made it any worse.