### PR TITLE
Exclude `RestartStageTest`

### DIFF
--- a/excludes.txt
+++ b/excludes.txt
@@ -3,6 +3,7 @@ hudson.matrix.AxisTest
 
 # TODO tends to run out of memory
 io.jenkins.blueocean.rest.impl.pipeline.PipelineNodeTest
+io.jenkins.blueocean.rest.impl.pipeline.RestartStageTest
 
 # TODO https://github.com/jenkinsci/blueocean-plugin/pull/2471
 io.jenkins.blueocean.service.embedded.PipelineApiTest


### PR DESCRIPTION
This test crashes with an out of memory error and impacted an unrelated effort in https://ci.jenkins.io/job/Tools/job/bom/job/PR-2440/17/