### PR TITLE
Revert checks-api from 2.0.1 to 2.0.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -88,7 +88,10 @@ if (BRANCH_NAME == 'master' || fullTestMarkerFile || env.CHANGE_ID && pullReques
       branches["pct-$repository-$line"] = {
         def jdk = line == 'weekly' ? 21 : 11
         if (jdk == 21) {
-          if (repository == 'jacoco-plugin') {
+          if (repository == 'checks-api-plugin') {
+            // TODO JENKINS-71804
+            jdk = 17
+          } else if (repository == 'jacoco-plugin') {
             // TODO JENKINS-71806
             jdk = 17
           }

--- a/bom-2.414.x/pom.xml
+++ b/bom-2.414.x/pom.xml
@@ -27,6 +27,15 @@
         <artifactId>theme-manager</artifactId>
         <version>211.vef2a_42c645a_b_</version>
       </dependency>
+      <!-- TODO Remove when config-file-provider test failure is fixed
+           by credentials-binding plugin
+           https://github.com/jenkinsci/bom/issues/2513
+      -->
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>credentials-binding</artifactId>
+        <version>631.v861c06d062b_4</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 </project>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -12,7 +12,7 @@
     <aws-java-sdk-plugin.version>1.12.529-406.vdeff15e5817d</aws-java-sdk-plugin.version>
     <blueocean-plugin.version>1.27.7</blueocean-plugin.version>
     <branch-api-plugin.version>2.1128.v717130d4f816</branch-api-plugin.version>
-    <checks-api.version>2.0.1</checks-api.version>
+    <checks-api.version>2.0.0</checks-api.version>
     <cloudbees-folder-plugin.version>6.848.ve3b_fd7839a_81</cloudbees-folder-plugin.version>
     <configuration-as-code-plugin.version>1700.v6f448841296e</configuration-as-code-plugin.version>
     <data-tables-api.version>1.13.5-1</data-tables-api.version>


### PR DESCRIPTION
## Revert checks-api from 2.0.1 to 2.0.0

https://github.com/jenkinsci/bom/issues/2484 describes the unexpected addition of commons-text-api as a new dependency for many consumers of the plugin bill of materials.

Rather than having more and more plugins adding dependencies on the commons-text-api or the commons-lang3-api plugin, let's keep the checks-api dependency at 2.0.0 instead of 2.0.1.

https://github.com/jenkinsci/checks-api-plugin/issues/233 is the issue reported to the checks-api plugin.  Once that issue is resolved, we should be able to use more recent checks-api plugin versions.

Dependency updates that had to add commons-text-api included:

* https://github.com/jenkinsci/bitbucket-kubernetes-credentials-plugin/pull/133
* https://github.com/jenkinsci/elastic-axis-plugin/pull/309
* https://github.com/jenkinsci/nodelabelparameter-plugin/pull/265
* https://github.com/jenkinsci/testng-plugin-plugin/pull/244

This reverts commit 729dfb26e76a7babd2cf503ce5bfb233b572d32f.

### Testing done

PLUGINS=checks-api bash local-tests.sh passes

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
