### PR TITLE
Pin previous credentials-binding release for LTS profiles

### DIFF
--- a/bom-2.414.x/pom.xml
+++ b/bom-2.414.x/pom.xml
@@ -27,6 +27,15 @@
         <artifactId>theme-manager</artifactId>
         <version>211.vef2a_42c645a_b_</version>
       </dependency>
+      <!-- TODO Remove when config-file-provider test failure is fixed
+           by credentials-binding plugin
+           https://github.com/jenkinsci/bom/issues/2513
+      -->
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>credentials-binding</artifactId>
+        <version>631.v861c06d062b_4</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 </project>


### PR DESCRIPTION
## Pin previous credentials-binding release for LTS profiles

The most recent release of the credentials-binding plugin adds masking for base64 credentials.  That's a nice improvement.  Unfortunately, it causes one of the config-file-provider tests to fail.

Adapt older bom profiles to "Bump credentials-binding (#2509)" by retaining the current version of the credentials binding plugin on the weekly release and pinning the previous credentials binding plugin release on the LTS releases.  

Could exclude the test failure on all releases, but it seemed better to be able to detect test failures from the weekly release even if we can't yet test the new version with the LTS releases.  

This partially reverts commit bab8257f69b4411d683a420b106d8361fae5d0cf.

### Testing done

Confirmed that the failing config-file-provider tests now pass.  Used the build.sh script like this to bisect with `git bisect run`:

```bash
#!/bin/bash

git clean -xffd
# mvn -am -pl war,bom -Pquick-build clean install
# mvn -pl war -Dhost=0.0.0.0 jetty:run

logfile=logfile-$(date --rfc-3339=seconds | sed 's, ,-,g')

git log -n 1 > ../$logfile

export LINE=2.414.x
export PLUGINS=config-file-provider
export TEST=MavenSettingsConfigTest
bash local-test.sh >> ../$logfile 2>&1 
```

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
