### PR TITLE
Revert "Bump org.jenkins-ci.plugins:google-oauth-plugin from 1.0.11 to 1.1.1 in /bom-weekly"

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -606,7 +606,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>google-oauth-plugin</artifactId>
-        <version>1.1.1</version>
+        <version>1.0.11</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Reverts jenkinsci/bom#2563 because the updated google oath plugin causes test failures in the google storage plugin and the google compute engine plugin.  Needs more investigation and likely needs a new release of the google oauth plugin