### PR TITLE
Exclude dependency updates to google-oauth-plugin 1.1.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,9 @@ updates:
   - package-ecosystem: "maven"
     open-pull-requests-limit: 25
     directory: "/bom-weekly"
+    ignore:
+      - dependency-name: "google-oauth-plugin"
+        versions: "1.1.1"
     schedule:
       interval: "daily"
   - package-ecosystem: "github-actions"

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -606,7 +606,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>google-oauth-plugin</artifactId>
-        <version>1.1.1</version>
+        <version>1.0.11</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
## Exclude dependency updates to google-oauth-plugin 1.1.1

Plugin breaks tests of other plugins

Rework is in progress.

https://github.com/jenkinsci/bom/pull/2563 updated the google oauth plugin to 1.1.1 and broke tests in google-storage-plugin and the google-compute-engine-plugin.

https://github.com/jenkinsci/bom/pull/2567 reverted it again

https://github.com/jenkinsci/bom/pull/2572 incremented it again

Let's stop the pattern of new commit followed by a revert

### Testing done

No testing done.  Dependency exclusions need to be tested by dependabot.

###xSubmitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
