### PR TITLE
Ignore google-oauth-plugin 1.318.vb_39c5db_e3041

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     directory: "/bom-weekly"
     ignore:
       - dependency-name: "org.jenkins-ci.plugins:google-oauth-plugin"
-        versions: "1.1.1"
+        versions: ["1.1.1", "1.318.vb_39c5db_e3041"]
     schedule:
       interval: "daily"
   - package-ecosystem: "github-actions"

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -606,7 +606,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>google-oauth-plugin</artifactId>
-        <version>1.318.vb_39c5db_e3041</version>
+        <version>1.0.11</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
## Ignore google-oauth-plugin 1.318.vb_39c5db_e3041

Fails test in the google-storage-plugin with the same failure message as is seen with 1.1.1.

Command that fails is:

```bash
LINE=weekly PLUGINS=google-storage-plugin TEST=ClientFactoryTest bash local-test.sh
```

Dependabot version ignore syntax is described in [their documentation](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#ignore).

See earlier pull requests that are related, including:

* #2563 - first upgraded to 1.1.1
* #2564 - first detected the issue in google-oauth-plugin 1.1.1
* #2567 - first revert
* #2572
* #2580 - update to 1.318.x
* 

### Testing done

Confirmed that tests fail with 1.318.vb_39c5db_e3041 and that they passed with previous versions of the google-oauth-plugin.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
