### PR TITLE
Add dockerhub-notification to managed set

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -529,7 +529,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>dockerhub-notification</artifactId>
-        <version>2.7.1-rc187.7fc53a_ca_6193</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -528,6 +528,11 @@
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>dockerhub-notification</artifactId>
+        <version>2.7.1-rc187.7fc53a_ca_6193</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>durable-task</artifactId>
         <version>523.va_a_22cf15d5e0</version>
       </dependency>

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -431,6 +431,11 @@
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>dockerhub-notification</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>email-ext</artifactId>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
## Add `dockerhub-notification` to the managed set

Draft pull request preparing to fix

*  #2439

Test latest incremental build of dockerhub-notification plugin.  Once a release of the plugin is available with the latest changes from the master branch and this pull request is passing all tests, this pull request will be marked as ready for review.

### Testing done

Ran automated tests of the dockerhub-notification plugin in its repository with the fixes from:

* https://github.com/jenkinsci/dockerhub-notification-plugin/pull/44

Ran plugin bom tests of the google-storage plugin and the google-compute-engine plugins and confirmed that they are now passing.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
