### PR TITLE
Revert credentials:1305.v04f5ec1f3743

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,8 @@ updates:
     ignore:
       - dependency-name: "org.jenkins-ci.plugins:google-oauth-plugin"
         versions: ["1.1.1", "1.318.vb_39c5db_e3041"]
+      - dependency-name: "org.jenkins-ci.plugins:credentials"
+        versions: "1305.v04f5ec1f3743"
     schedule:
       interval: "daily"
   - package-ecosystem: "github-actions"

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -494,7 +494,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>credentials</artifactId>
-        <version>1305.v04f5ec1f3743</version>
+        <version>1304.v5ec13eecef46</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
## Revert the credentials 1305.x plugin inclusion in bom

- Do not update to credentials 1305.x
- Revert "Bump org.jenkins-ci.plugins:credentials in /bom-weekly (#2617)"

[1305.x changelog](https://github.com/jenkinsci/credentials-plugin/releases/tag/1305.v04f5ec1f3743) notes that a regression is being investigated as reported in https://github.com/jenkinsci/credentials-plugin/pull/490#issuecomment-1782975527

A pull request has been submitted to resolve the issue in a new release:
* https://github.com/jenkinsci/credentials-plugin/pull/492

### Testing done

No testing done.  Rely on interactive testing of upcoming releases of the credentials plugin.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
