### PR TITLE
Link to BOM tutorial video

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ can offer clues about unused plugin dependencies,
 though you must evaluate each carefully since it only understands Java binary dependencies
 (what is required for compilation, more or less).
 
+A [BOM tutorial video](https://www.jenkins.io/doc/developer/tutorial-improve/use-plugin-bill-of-materials/) is available in the [Jenkins developer documentation](https://www.jenkins.io/doc/developer/tutorial-improve/).
 
 ## Depending on `bom-weekly`
 


### PR DESCRIPTION
## Link to the plugin BOM tutorial video

Docs SIG members suggested that a link to the BOM tutorial video might help new plugin maintainers learn more about the plugin BOM.

### Testing done

COnfirmed the links work as expected.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
