### PR TITLE
Allow weekly release to be tested in isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,8 @@ git commit -m 'Run full tests'
 
 while keeping the PR in draft until tests pass and this file can be deleted.
 
+Similarly, the `weekly-test` label (or marker file) can be used to run tests on weekly releases in isolation.
+
 To further minimize build time, tests are run only on Linux, against Java 11, and without Docker support.
 It is unusual but possible for cross-component incompatibilities to only be visible in more specialized environments (such as Windows).
 


### PR DESCRIPTION
This PR adds a new `weekly-test` label (and corresponding marker file) that allows the weekly release to be tested in isolation (i.e., without testing other lines). This is useful to save cloud costs in case where we are testing a new weekly release or incremental build of a weekly release.

### Testing done

CI build should be sufficient.