### PR TITLE
Add appropriate labels from Renovate PRs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,8 +3,9 @@
   "extends": ["config:base", ":semanticCommitsDisabled", "schedule:daily"],
   "enabledManagers": ["regex"],
   "automerge": true,
-  "regexManagers": [
+  "customManagers": [
     {
+      "customType": "regex",
       "fileMatch": ["prep-pct.sh"],
       "matchStrings": ["pct_version=(?<currentValue>.*?)\\n"],
       "depNameTemplate": "org.jenkins-ci.tests:plugins-compat-tester-cli",
@@ -12,6 +13,7 @@
       "registryUrlTemplate": "https://repo.jenkins-ci.org/releases/"
     },
     {
+      "customType": "regex",
       "fileMatch": ["sample-plugin/pom.xml"],
       "matchStrings": [
         "\\n\\s{4}<jenkins\\.version>(?<currentValue>.*?)<\\\/jenkins\\.version>\\n"
@@ -21,6 +23,15 @@
       "registryUrlTemplate": "https://repo.jenkins-ci.org/releases/"
     }
   ],
-  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "matchDepNames": ["org.jenkins-ci.tests:plugins-compat-tester-cli"],
+      "labels": ["dependencies", "full-test"]
+    },
+    {
+      "matchDepNames": ["org.jenkins-ci.main:jenkins-war"],
+      "labels": ["dependencies", "weekly-test"]
+    }
+  ],
   "rebaseWhen": "conflicted"
 }

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -14,7 +14,7 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <bom>weekly</bom>
-    <jenkins.version>2.431</jenkins.version>
+    <jenkins.version>2.430</jenkins.version>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>
   <dependencyManagement>


### PR DESCRIPTION
This PR adds the `full-test` label whenever PCT is updated and the `weekly-test` label whenever the weekly release is updated to ensure that we run the appropriate amount of testing on these (infrequent) PRs. While I was here, I also migrated the syntax from the deprecated `regexManagers` to its non-deprecated replacement `customManagers`.

### Testing done

I intentionally downgraded the weekly release in this PR. Once this is merged, I'll trigger Renovate to update the weekly again and ensure the PR has the right labels.