### PR TITLE
Use Jenkins 2.426.1 as baseline for bom-2.426.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ PLUGINS=structs,mailer TEST=InjectedTest bash local-test.sh
 optionally also passing either
 
 ```
-LINE=2.414.x
+LINE=2.426.x
 ```
 
 or

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -931,8 +931,7 @@
       <id>2.426.x</id>
       <properties>
         <bom>2.426.x</bom>
-        <!-- TODO: Revise to 2.426.1 when release is available -->
-        <jenkins.version>2.426</jenkins.version>
+        <jenkins.version>2.426.1</jenkins.version>
       </properties>
     </profile>
     <profile>


### PR DESCRIPTION
## Use Jenkins 2.426.1 as baseline for bom-2.426.x

Now that 2.426.1 has been released, ready to switch from weekly to the LTS version.

### Testing done

Vertified that the example test from README passes

```bash
LINE=2.426.x PLUGINS=structs,mailer TEST=InjectedTest bash local-test.sh
```

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
