### PR TITLE
Avoid data-tables, echarts, and prism upper bounds error

### DIFF
--- a/pct.sh
+++ b/pct.sh
@@ -19,6 +19,28 @@ if ! [[ $PLUGINS =~ blueocean || $PLUGINS =~ pipeline-maven ]]; then
 	#
 	PCT_D_ARGS+='-DforkCount=.75C '
 fi
+if [[ $PLUGINS =~ data-tables-api || $PLUGINS =~ echarts-api || $PLUGINS =~ prism-api ]]; then
+       #
+       # These plugins use a version of ArchUnit which triggers a
+       # requireUpperBoundDeps error with JUnit 5:
+       #
+       # +-io.jenkins.plugins:data-tables-api:1.13.8-1
+       # +-com.tngtech.archunit:archunit-junit5:1.2.0 [test]
+       # +-com.tngtech.archunit:archunit-junit5-engine:1.2.0 [test]
+       # +-com.tngtech.archunit:archunit-junit5-engine-api:1.2.0 [test]
+       # +-org.junit.platform:junit-platform-engine:1.10.0 [test] (managed)
+       #   <-- org.junit.platform:junit-platform-engine:1.10.1 [test]
+       #
+       # Since PCT will automatically resolve requireUpperBoundDeps errors by
+       # choosing the newer version, and since the newer version is not
+       # ABI-compatible with the older version, exclude this package from PCT's
+       # requireUpperBoundDeps resolution.
+       #
+       # TODO: When these plugins are fixed to not trigger a requireUpperBoundDeps
+       # error, this code should be removed.
+       #
+       PCT_D_ARGS+='-DupperBoundsExcludes=org.junit.platform:junit-platform-commons '
+fi
 
 exec java \
 	-jar target/pct.jar \


### PR DESCRIPTION
## Avoid data-tables, echarts, and prism upper bounds error

@basil described it in https://github.com/jenkinsci/bom/pull/2680#issuecomment-1823115582

> analysis-pom is (incorrectly) pulling in a version of ArchUnit with a requireUpperBounds error, which analysis-pom has (also incorrectly) downgraded from an error to a warning.... Since PCT will automatically resolve requireUpperBoundDeps errors by choosing the newer version, and since the newer version is not ABI-compatible with the older version, the issue occurs.

This workaround should be removed when analysis-pom has been updated to fix the requireUpperBoundDeps error and make requireUpperBoundDeps an error instead of a warning.

### Testing done

Confirmed that `PLUGINS=echarts-api TEST=InjectedTest bash local-test.sh` passes after this change and fails before this change.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
