### PR TITLE
Bump configuration as code from 1738.v2d8b_a_b_8a_54b_1 to 1746.vf1673cfe690a

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -14,7 +14,7 @@
     <branch-api-plugin.version>2.1135.v8de8e7899051</branch-api-plugin.version>
     <checks-api.version>2.0.2</checks-api.version>
     <cloudbees-folder-plugin.version>6.858.v898218f3609d</cloudbees-folder-plugin.version>
-    <configuration-as-code-plugin.version>1738.v2d8b_a_b_8a_54b_1</configuration-as-code-plugin.version>
+    <configuration-as-code-plugin.version>1746.vf1673cfe690a</configuration-as-code-plugin.version>
     <data-tables-api.version>1.13.8-1</data-tables-api.version>
     <declarative-pipeline-migration-assistant-plugin.version>1.6.1</declarative-pipeline-migration-assistant-plugin.version>
     <forensics-api.version>2.3.0</forensics-api.version>


### PR DESCRIPTION
Bump configuration as code from 1738.v2d8b_a_b_8a_54b_1 to 1746.vf1673cfe690a

https://github.com/jenkinsci/configuration-as-code-plugin/releases/tag/1746.vf1673cfe690a reports the changelog as:

🚀 New features and improvements

* JENKINS-64816 - support for node monitors in CasC (#2392) @mawinter69

📝 Documentation updates

* Fix javadoc warnings (#2415) @MarkEWaite
* Improve git plugin and git client plugin examples (#2414) @MarkEWaite

👻 Maintenance

* Downgrade windows to Java 11 for CI (#2418) @timja
* Test with Java 21 (#2384) @MarkEWaite

📦 Dependency updates

* Update dependency org.jenkins-ci.plugins:azure-keyvault to v233 (#2413) @renovate
* Update dependency io.jenkins.tools.bom:bom-2.414.x to v2582 (#2412) @renovate
* Update dependency com.puppycrawl.tools:checkstyle to v10.12.5 (#2411) @renovate

Still not clear to me why dependabot incorrectly reports in its log file that

> Latest version is 1738.v2d8b_a_b_8a_54b_1

The maven-metadata.xml file correctly includes 1746.vf1673cfe690a

<!-- Please describe your pull request here. -->

### Testing done

Confirmed that `PLUGINS=configuration-as-code bash local-test.sh` passes

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
