### PR TITLE
Revert "Block GitHub API 1.318-461 due to GitHub branch source test failures"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,8 +11,6 @@ updates:
     ignore:
       - dependency-name: "org.jenkins-ci.plugins:google-oauth-plugin"
         versions: ["1.1.1"]
-      - dependency-name: "org.jenkins-ci.plugins:github-api"
-        versions: ["1.318-461.v7a_c09c9fa_d63"]
     schedule:
       interval: "daily"
   - package-ecosystem: "github-actions"

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -18,7 +18,7 @@
     <data-tables-api.version>1.13.8-1</data-tables-api.version>
     <declarative-pipeline-migration-assistant-plugin.version>1.6.1</declarative-pipeline-migration-assistant-plugin.version>
     <forensics-api.version>2.3.0</forensics-api.version>
-    <github-api-plugin.version>1.316-451.v15738eef3414</github-api-plugin.version>
+    <github-api-plugin.version>1.318-461.v7a_c09c9fa_d63</github-api-plugin.version>
     <git-plugin.version>5.2.1</git-plugin.version>
     <junit-plugin.version>1240.vf9529b_881428</junit-plugin.version>
     <mina-sshd-api.version>2.11.0-86.v836f585d47fa_</mina-sshd-api.version>


### PR DESCRIPTION
Reverts jenkinsci/bom#2691

@MarkEWaite
https://github.com/jenkinsci/github-branch-source-plugin/pull/749 fixed the tests to no longer fail with v1.318.  
