### PR TITLE
Remove unnecessary exclusion

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,6 @@ updates:
   - package-ecosystem: "maven"
     open-pull-requests-limit: 25
     directory: "/bom-weekly"
-    ignore:
-      - dependency-name: "org.jenkins-ci.plugins:google-oauth-plugin"
-        versions: ["1.1.1"]
     schedule:
       interval: "daily"
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
`google-oauth-plugin` apparently passed a PR build with the `full-test` label last night, so this exclusion is no longer needed.