### PR TITLE
Remove analysis pom workaround

### DIFF
--- a/pct.sh
+++ b/pct.sh
@@ -19,28 +19,6 @@ if ! [[ $PLUGINS =~ blueocean || $PLUGINS =~ pipeline-maven ]]; then
 	#
 	PCT_D_ARGS+='-DforkCount=.75C '
 fi
-if [[ $PLUGINS =~ data-tables-api || $PLUGINS =~ echarts-api || $PLUGINS =~ prism-api ]]; then
-       #
-       # These plugins use a version of ArchUnit which triggers a
-       # requireUpperBoundDeps error with JUnit 5:
-       #
-       # +-io.jenkins.plugins:data-tables-api:1.13.8-1
-       # +-com.tngtech.archunit:archunit-junit5:1.2.0 [test]
-       # +-com.tngtech.archunit:archunit-junit5-engine:1.2.0 [test]
-       # +-com.tngtech.archunit:archunit-junit5-engine-api:1.2.0 [test]
-       # +-org.junit.platform:junit-platform-engine:1.10.0 [test] (managed)
-       #   <-- org.junit.platform:junit-platform-engine:1.10.1 [test]
-       #
-       # Since PCT will automatically resolve requireUpperBoundDeps errors by
-       # choosing the newer version, and since the newer version is not
-       # ABI-compatible with the older version, exclude this package from PCT's
-       # requireUpperBoundDeps resolution.
-       #
-       # TODO: When these plugins are fixed to not trigger a requireUpperBoundDeps
-       # error, this code should be removed.
-       #
-       PCT_D_ARGS+='-DupperBoundsExcludes=org.junit.platform:junit-platform-commons '
-fi
 
 exec java \
 	-jar target/pct.jar \


### PR DESCRIPTION
## Remove analysis pom workaround

Resolved in analysis-pom 6.17.0 that is included in:

* https://github.com/jenkinsci/data-tables-api-plugin/pull/411
* https://github.com/jenkinsci/prism-api-plugin/pull/130
* https://github.com/jenkinsci/echarts-api-plugin/pull/317
* https://github.com/jenkinsci/bootstrap5-api-plugin/pull/255

This reverts commit 92e1dbc8886baab0b867152c7a9465a74e54005b.

### Testing done

Confirmed that the command works:

```
PLUGINS=bootstrap5-api,data-tables-api,prism-api,echarts-api  bash local-test.sh
```

Rely on ci.jenkins.io to do the full testing either in this pull request or in today's test for 2.435.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
