### PR TITLE
Revert "Bump script-security to 1310.vf24a_dfce068b_"

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -874,7 +874,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>script-security</artifactId>
-        <version>1310.vf24a_dfce068b_</version>
+        <version>1305.v487433146192</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Test failure can be seen with script security 1310.vf24a_dfce068b_:

LINE=2.426.x PLUGINS=script-security TEST=ScriptApprovalLoadingTest bash local-test.sh

Test does not fail with script security 1305.v487433146192

Failure assumed to be a result of script security pull request:

* https://github.com/jenkinsci/script-security-plugin/pull/552

Reverts pull request:

* https://github.com/jenkinsci/bom/pull/2796

This reverts commit f02d56c4ac3b99b576444157031f5de3041dfbfa.
