### PR TITLE
Revert custom-folder-icon 2.11 update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,8 @@ updates:
     ignore:
       - dependency-name: "org.jenkins-ci.plugins:script-security"
         versions: ["1310.vf24a_dfce068b"]
+      - dependency-name: "io.jenkins.plugins:custom-folder-icon"
+        versions: ["2.11"]
     schedule:
       interval: "daily"
   - package-ecosystem: "github-actions"

--- a/bom-2.414.x/pom.xml
+++ b/bom-2.414.x/pom.xml
@@ -25,11 +25,6 @@
       </dependency>
       <dependency>
         <groupId>io.jenkins.plugins</groupId>
-        <artifactId>custom-folder-icon</artifactId>
-        <version>2.10</version>
-      </dependency>
-      <dependency>
-        <groupId>io.jenkins.plugins</groupId>
         <artifactId>dark-theme</artifactId>
         <version>336.v02165cd8c2ee</version>
       </dependency>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -199,7 +199,7 @@
       <dependency>
         <groupId>io.jenkins.plugins</groupId>
         <artifactId>custom-folder-icon</artifactId>
-        <version>2.11</version>
+        <version>2.10</version>
       </dependency>
       <dependency>
         <groupId>io.jenkins.plugins</groupId>


### PR DESCRIPTION
## Revert custom-folder-icon 2.11 update

- Revert "Bump io.jenkins.plugins:custom-folder-icon from 2.10 to 2.11 in /bom-weekly (#2793)"
- Exclude custom-folder-icon 2.11 from dependabot updates

### Testing done

Confirmed that the test passes with custom-folder-icon 2.10 and that it fails with custom-folder-con 2.11

```
LINE=2.426.x PLUGINS=custom-folder-icon TEST=JobDSLConfigurationTest bash local-test.sh
```

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
