### PR TITLE
Test git plugin 5.2.2-rc5199 (dependency updates)

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -19,7 +19,7 @@
     <declarative-pipeline-migration-assistant-plugin.version>1.6.1</declarative-pipeline-migration-assistant-plugin.version>
     <forensics-api.version>2.3.0</forensics-api.version>
     <github-api-plugin.version>1.318-461.v7a_c09c9fa_d63</github-api-plugin.version>
-    <git-plugin.version>5.2.1</git-plugin.version>
+    <git-plugin.version>5.2.2-rc5199.9999da_372d5a_</git-plugin.version>
     <junit-plugin.version>1252.vfc2e5efa_294f</junit-plugin.version>
     <mina-sshd-api.version>2.11.0-86.v836f585d47fa_</mina-sshd-api.version>
     <okhttp-api-plugin.version>4.11.0-157.v6852a_a_fa_ec11</okhttp-api-plugin.version>


### PR DESCRIPTION
Updates the promoted builds plugin, an optional dependency, from 3.11 to
945.v597f5c6a_d3fd.  Run the weekly tests to see if there are issues in
compatibillity testing with the new version of the promoted builds plugin.
