### PR TITLE
When variable DOCKERIZED was set to 'false' then 'docker' section was executed

### DIFF
--- a/local-test.sh
+++ b/local-test.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
+
 set -euxo pipefail
+
 cd "$(dirname "$0")"
 
 # expects: $PLUGINS, optionally $TEST, $LINE
@@ -20,7 +22,7 @@ else
 	EXTRA_MAVEN_PROPERTIES=
 fi
 
-if [[ -n ${DOCKERIZED-} ]]; then
+if [[ "${DOCKERIZED-}" == "true" ]]; then
 	docker volume inspect m2repo || docker volume create m2repo
 	docker run \
 		-v ~/.m2:/var/maven/.m2 \


### PR DESCRIPTION
### Testing done

`local-test.sh` script works fine when `DOCKERIZED` variable was undefined or set to `true` but not when set to `false`

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
