### PR TITLE
Switches off xtrace flag for shell scripts

### DIFF
--- a/local-test.sh
+++ b/local-test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euxo pipefail
+set -euo pipefail
 
 cd "$(dirname "$0")"
 
@@ -22,7 +22,7 @@ else
 	EXTRA_MAVEN_PROPERTIES=
 fi
 
-if [[ "${DOCKERIZED-}" == "true" ]]; then
+if [[ ${DOCKERIZED-} == "true" ]]; then
 	docker volume inspect m2repo || docker volume create m2repo
 	docker run \
 		-v ~/.m2:/var/maven/.m2 \

--- a/pct.sh
+++ b/pct.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-set -euxo pipefail
+
+set -euo pipefail
+
 cd "$(dirname "$0")"
 
 # expects: excludes.txt, target/megawar-$LINE.war, target/pct.jar, $PLUGINS, $LINE

--- a/prep-megawar.sh
+++ b/prep-megawar.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-set -euxo pipefail
+
+set -euo pipefail
+
 cd "$(dirname "${0}")"
 
 # expects: $LINE

--- a/prep-pct.sh
+++ b/prep-pct.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-set -euxo pipefail
+
+set -euo pipefail
+
 cd "$(dirname "${0}")"
 
 # Tracked by .github/renovate.json

--- a/prep.sh
+++ b/prep.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-set -euxo pipefail
+
+set -euo pipefail
+
 cd "$(dirname "${0}")"
 
 mvn clean install ${SAMPLE_PLUGIN_OPTS:-}


### PR DESCRIPTION
`xtrace` flag outputs the script what is helpful for debugging only. Having this flag enabled adds noise to the console.

### Testing done

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```