### PR TITLE
Revert "Add flyway api plugin"

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -239,11 +239,6 @@
       </dependency>
       <dependency>
         <groupId>io.jenkins.plugins</groupId>
-        <artifactId>flyway-api</artifactId>
-        <version>9.22.3-51.vd80b_c1ea_8040</version>
-      </dependency>
-      <dependency>
-        <groupId>io.jenkins.plugins</groupId>
         <artifactId>font-awesome-api</artifactId>
         <version>6.5.1-2</version>
       </dependency>

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -223,11 +223,6 @@
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
-      <artifactId>flyway-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.jenkins.plugins</groupId>
       <artifactId>font-awesome-api</artifactId>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
Reverts jenkinsci/bom#2902 because the tests in the plugin require access to a Docker daemon and we don't run the plugin BOM tests with access to a docker daemon.

@jonesbusy would you be willing to investigate alternatives to allow the tests of the flyway-api plugin to be run from the Jenkins plugin bill of materials?  They fail when I run them with the command:

```bash
$ PLUGINS=flyway-api  bash local-test.sh
```