### PR TITLE
Revert "Passing options to sample plugin build"

### DIFF
--- a/local-test.sh
+++ b/local-test.sh
@@ -9,11 +9,7 @@ cd "$(dirname "$0")"
 LATEST_LINE=weekly
 : "${LINE:=$LATEST_LINE}"
 
-if [[ -n ${SAMPLE_PLUGIN_OPTS} ]]; then
-	SAMPLE_PLUGIN_OPTS+=' -Dtest=InjectedTest'
-else
-	SAMPLE_PLUGIN_OPTS='-Dtest=InjectedTest'
-fi
+SAMPLE_PLUGIN_OPTS=-Dtest=InjectedTest
 if [[ $LINE != "${LATEST_LINE}" ]]; then
 	SAMPLE_PLUGIN_OPTS+=" -P${LINE}"
 fi


### PR DESCRIPTION
Reverts jenkinsci/bom#2940

```
$ PLUGINS=prism-api TEST=io.jenkins.plugins.prism.SourceDirectoryFilterTest bash local-test.sh
++ dirname local-test.sh
+ cd .
+ LATEST_LINE=weekly
+ : weekly
local-test.sh: line 12: SAMPLE_PLUGIN_OPTS: unbound variable
```