### PR TITLE
Revert "Bump `io.jenkins.plugins:plugin-util-api` from 3.8.0 to 4.1.0 in `/bom-weekly`"

### DIFF
--- a/bom-2.414.x/pom.xml
+++ b/bom-2.414.x/pom.xml
@@ -13,7 +13,6 @@
     <data-tables-api.version>1.13.6-5</data-tables-api.version>
     <forensics-api.version>2.3.0</forensics-api.version>
     <pipeline-model-definition-plugin.version>2.2150.v4cfd8916915c</pipeline-model-definition-plugin.version>
-    <plugin-util-api.version>3.8.0</plugin-util-api.version>
     <scm-api-plugin.version>676.v886669a_199a_a_</scm-api-plugin.version>
   </properties>
   <dependencyManagement>
@@ -76,17 +75,6 @@
         <groupId>io.jenkins.plugins</groupId>
         <artifactId>jquery3-api</artifactId>
         <version>3.7.1-1</version>
-      </dependency>
-      <dependency>
-        <groupId>io.jenkins.plugins</groupId>
-        <artifactId>plugin-util-api</artifactId>
-        <version>${plugin-util-api.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.jenkins.plugins</groupId>
-        <artifactId>plugin-util-api</artifactId>
-        <version>${plugin-util-api.version}</version>
-        <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>io.jenkins.plugins</groupId>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -26,7 +26,7 @@
     <pipeline-maven-plugin.version>1376.v18876d10ce9c</pipeline-maven-plugin.version>
     <pipeline-model-definition-plugin.version>2.2175.v76a_fff0a_2618</pipeline-model-definition-plugin.version>
     <pipeline-stage-view-plugin.version>2.34</pipeline-stage-view-plugin.version>
-    <plugin-util-api.version>4.1.0</plugin-util-api.version>
+    <plugin-util-api.version>3.8.0</plugin-util-api.version>
     <scm-api-plugin.version>683.vb_16722fb_b_80b_</scm-api-plugin.version>
     <subversion-plugin.version>2.17.3</subversion-plugin.version>
     <workflow-api-plugin.version>1291.v51fd2a_625da_7</workflow-api-plugin.version>


### PR DESCRIPTION
Reverts #2946

Breaks `io.jenkins.plugins.prism.SourceDirectoryFilterTest`