### PR TITLE
Revert "Bump org.jenkins-ci.plugins:credentials from 1319.v7eb_51b_3a_c97b_ to 1337.v60b_d7b_c7b_c9f in /bom-weekly"

### DIFF
--- a/bom-2.414.x/pom.xml
+++ b/bom-2.414.x/pom.xml
@@ -116,11 +116,6 @@
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>credentials</artifactId>
-        <version>1319.v7eb_51b_3a_c97b_</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>dashboard-view</artifactId>
         <version>2.495.v07e81500c3f2</version>
       </dependency>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -555,7 +555,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>credentials</artifactId>
-        <version>1337.v60b_d7b_c7b_c9f</version>
+        <version>1319.v7eb_51b_3a_c97b_</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Reverts jenkinsci/bom#2970

https://github.com/jenkinsci/credentials-plugin/pull/506#issuecomment-1974862252