### PR TITLE
Revert "Bump io.jenkins.plugins:data-tables-api from 1.13.8-4 to 2.0.1-1 in /bom-weekly"

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -15,7 +15,7 @@
     <checks-api.version>2.0.2</checks-api.version>
     <cloudbees-folder-plugin.version>6.928.v7c780211d66e</cloudbees-folder-plugin.version>
     <configuration-as-code-plugin.version>1775.v810dc950b_514</configuration-as-code-plugin.version>
-    <data-tables-api.version>2.0.1-1</data-tables-api.version>
+    <data-tables-api.version>1.13.8-4</data-tables-api.version>
     <declarative-pipeline-migration-assistant-plugin.version>1.6.3</declarative-pipeline-migration-assistant-plugin.version>
     <forensics-api.version>2.4.0</forensics-api.version>
     <github-api-plugin.version>1.318-461.v7a_c09c9fa_d63</github-api-plugin.version>


### PR DESCRIPTION
Reverts jenkinsci/bom#2996

This is to fix the test failures for Lockage Resources plugin