### PR TITLE
Revert ssh-credentials that made trilead-api optional

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -939,7 +939,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>ssh-credentials</artifactId>
-        <version>326.v7fcb_a_ef6194b_</version>
+        <version>322.v124df57ed808</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
https://github.com/jenkinsci/ssh-credentials-plugin/pull/199 makes the trilead-api optional.  Likely needs some tuning to allow plugin compatibility tests to pass.

This reverts commit 3fb57483e33efe2da05418c4cd671ee0f39f0f20.

@olamy can you investigate the two failures?  I can duplicate the failures in the plugin bom repository with:

```
$ PLUGINS=subversion TEST=CompareAgainstBaselineCallableTest bash local-test.sh
```

```
$ LINE=weekly PLUGINS=mina-sshd-api-core  bash local-test.sh
```