### PR TITLE
Block update to ssh-credentials plugin 326.v7fcb_a_ef6194b_

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
   - package-ecosystem: "maven"
     open-pull-requests-limit: 25
     directory: "/bom-weekly"
+    ignore:
+      # Remove when https://github.com/jenkinsci/subversion-plugin/pull/284 is released
+      - dependency-name: "org.jenkins-ci.plugins:ssh-credentials"
+        versions: ["326.v7fcb_a_ef6194b_"]
     schedule:
       interval: "daily"
   - package-ecosystem: "github-actions"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,8 @@ updates:
     open-pull-requests-limit: 25
     directory: "/bom-weekly"
     ignore:
-      # Remove when https://github.com/jenkinsci/subversion-plugin/pull/284 is released
+      # Remove when https://github.com/jenkinsci/subversion-plugin/pull/284 is released and mina-sshd-api-core test failure is resolved
+      # https://github.com/jenkinsci/bom/pull/3049 has more details
       - dependency-name: "org.jenkins-ci.plugins:ssh-credentials"
         versions: ["326.v7fcb_a_ef6194b_"]
     schedule:


### PR DESCRIPTION
## Block update to ssh-credentials plugin 326.v7fcb_a_ef6194b_

https://github.com/jenkinsci/ssh-credentials-plugin/pull/199 makes the trilead-api plugin an optional dependency of the ssh-credentials plugin.  That exposed a latent issue in the subversion plugin that is resolved in 

* https://github.com/jenkinsci/subversion-plugin/pull/284

https://github.com/jenkinsci/bom/issues/3050 describes the details of the test failures in the plugin bill of mateerials.  The failing tests can be seen with the commands:

```bash
PLUGINS=subversion TEST=CompareAgainstBaselineCallableTest bash local-test.sh
PLUGINS=mina-sshd-api-core LINE=weekly bash local-test.sh
```

### Testing done

Confirmed that the incremental build of the subversion plugin resolves the subversion plugin test failure.  The subversion plugin does not resolve the apache-mina-sshd-core test failure.  That is being investigated by Olivier Lamy.

Copied this section from an earlier pull request that was used to block a specific version.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
```
