### PR TITLE
Test 3: verify ACP 1.0 + cleaned up repo.jenkins-ci.org

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -90,10 +90,6 @@ if (BRANCH_NAME == 'master' || fullTestMarkerFile || weeklyTestMarkerFile || env
       return
     }
     pluginsByRepository.each { repository, plugins ->
-      if (repository == 'pam-auth-plugin' || repository == 'sse-gateway-plugin') {
-        // TODO https://github.com/jenkins-infra/helpdesk/issues/4021
-        return
-      }
       branches["pct-$repository-$line"] = {
         def jdk = line == 'weekly' ? 21 : 11
         mavenEnv(jdk: jdk, nodePool: true) {

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ BOMs older than the two prior LTS releases will generally be retired in order to
 ## Releasing
 
 You can cut a release using [JEP-229](https://jenkins.io/jep/229).
-To save resources, `master` is built only on demand, so use **Re-run checks**  in https://github.com/jenkinsci/bom/commits/master if you wish to start.
+To save resources, `master` is built only on demand, so use **Re-run checks** in https://github.com/jenkinsci/bom/commits/master if you wish to start.
 If that build passes, a release should be published automatically when PRs matching certain label patterns are merged.
 For the common case that only lots of `dependencies` PRs have been merged,
 the release can be triggered manually from the **Actions** tab after a `master` build has succeeded.


### PR DESCRIPTION
Same as https://github.com/jenkinsci/bom/pull/3078

The goal is to validate that https://github.com/jenkins-infra/helpdesk/issues/4021 is no longer a problem.

Do NOT merge this PR. It should be closed once the checks have been validated.