### PR TITLE
Add markdown formatter plugin

### DIFF
--- a/bom-2.414.x/pom.xml
+++ b/bom-2.414.x/pom.xml
@@ -89,6 +89,11 @@
       </dependency>
       <dependency>
         <groupId>io.jenkins.plugins</groupId>
+        <artifactId>markdown-formatter</artifactId>
+        <version>95.v17a_965e696ee</version>
+      </dependency>
+      <dependency>
+        <groupId>io.jenkins.plugins</groupId>
         <artifactId>plugin-util-api</artifactId>
         <version>${plugin-util-api.version}</version>
       </dependency>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -355,6 +355,11 @@
       </dependency>
       <dependency>
         <groupId>io.jenkins.plugins</groupId>
+        <artifactId>markdown-formatter</artifactId>
+        <version>167.v8a_428ca_49f89</version>
+      </dependency>
+      <dependency>
+        <groupId>io.jenkins.plugins</groupId>
         <artifactId>mysql-api</artifactId>
         <version>8.3.0-21.v2837a_a_360d57</version>
       </dependency>

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -318,6 +318,11 @@
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
+      <artifactId>markdown-formatter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
       <artifactId>mysql-api</artifactId>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
## Add markdown formatter plugin to managed set

Proposed wider use to document Pipeline shared libraries

* https://github.com/jenkinsci/pipeline-groovy-lib-plugin/pull/117

Has 860 installations with that number increasing steadily.

https://plugins.jenkins.io/pegdown-formatter/ should be deprecated. It was last released 12 years ago.  It has a known security vulnerability.  It has no maintainer.  It has a health score of 57/100.  Still has over 1000 installations, but many of those installations could use markdown formatter.

### Testing done

Ran `PLUGINS=markdown-formatter bash local-test.sh` to confirm the plugin passes its own tests in the BOM context

I use this plugin on my installation and am very happy with its results.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
