### PR TITLE
Revert declarative pipeline 2.2188.x upgrade

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,16 @@ updates:
   - package-ecosystem: "maven"
     open-pull-requests-limit: 25
     directory: "/bom-weekly"
+    ignore:
+      # TODO: Remove exclusion when https://github.com/jenkinsci/bom/issues/3106 is fixed
+      - dependency-name: "org.jenkinsci.plugins:pipeline-model-api"
+        versions: ["2.2188.v26e255fd2984"]
+      - dependency-name: "org.jenkinsci.plugins:pipeline-model-definition"
+        versions: ["2.2188.v26e255fd2984"]
+      - dependency-name: "org.jenkinsci.plugins:pipeline-model-extensions"
+        versions: ["2.2188.v26e255fd2984"]
+      - dependency-name: "org.jenkinsci.plugins:pipeline-stage-tags-metadata"
+        versions: ["2.2188.v26e255fd2984"]
     schedule:
       interval: "daily"
   - package-ecosystem: "github-actions"

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -24,7 +24,7 @@
     <mina-sshd-api.version>2.12.1-101.v85b_e08b_780dd</mina-sshd-api.version>
     <okhttp-api-plugin.version>4.11.0-172.vda_da_1feeb_c6e</okhttp-api-plugin.version>
     <pipeline-maven-plugin.version>1396.veb_f07b_2fc1d8</pipeline-maven-plugin.version>
-    <pipeline-model-definition-plugin.version>2.2188.v26e255fd2984</pipeline-model-definition-plugin.version>
+    <pipeline-model-definition-plugin.version>2.2184.v0b_358b_953e69</pipeline-model-definition-plugin.version>
     <pipeline-stage-view-plugin.version>2.34</pipeline-stage-view-plugin.version>
     <plugin-util-api.version>4.1.0</plugin-util-api.version>
     <scm-api-plugin.version>689.v237b_6d3a_ef7f</scm-api-plugin.version>


### PR DESCRIPTION
## Revert declarative Pipeline 2.2188.x

The ssh-agent plugin tests fail with the new release of declarative Pipeline while they were passing before that new release.

Block upgrades to declarative Pipeline 2.2188.v26e255fd2984 by dependabot (with the caveat that I'm not confident I've used the correct syntax for the dependabot exclusion).

### Testing done

Confirmed that the ssh-agent test fails with declarative Pipeline 2.2188.v26e255fd2984 and that it passes with declarative Pipeline 2.2184.v0b_358b_953e69.

```
LINE=WEEKLY PLUGINS=ssh-agent bash local-test.sh
```

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
