### PR TITLE
Test git plugin upgrade of promoted builds dependency

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -776,6 +776,11 @@
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>job-dsl</artifactId>
+        <version>1.87</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>jsch</artifactId>
         <version>0.2.16-86.v42e010d9484b_</version>
       </dependency>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -19,7 +19,7 @@
     <declarative-pipeline-migration-assistant-plugin.version>1.6.3</declarative-pipeline-migration-assistant-plugin.version>
     <forensics-api.version>2.4.0</forensics-api.version>
     <github-api-plugin.version>1.318-461.v7a_c09c9fa_d63</github-api-plugin.version>
-    <git-plugin.version>5.2.1</git-plugin.version>
+    <git-plugin.version>5.2.2-rc5230.8d618a_2c8118</git-plugin.version>
     <junit-plugin.version>1265.v65b_14fa_f12f0</junit-plugin.version>
     <mina-sshd-api.version>2.12.1-101.v85b_e08b_780dd</mina-sshd-api.version>
     <okhttp-api-plugin.version>4.11.0-172.vda_da_1feeb_c6e</okhttp-api-plugin.version>
@@ -681,7 +681,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>git-client</artifactId>
-        <version>4.7.0</version>
+        <version>4.7.1-rc3564.39d253b_d0eff</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -912,6 +912,11 @@
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>promoted-builds</artifactId>
+        <version>945.v597f5c6a_d3fd</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>pubsub-light</artifactId>
         <version>1.18</version>
       </dependency>

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -46,6 +46,10 @@
       <artifactId>jsch</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>promoted-builds</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-step-api</artifactId>
     </dependency>

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -43,6 +43,10 @@
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>job-dsl</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>jsch</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
## Test git plugin upgrade of promoted builds dependency

Previous attempts to upgrade the optional promoted builds dependency in the git plugin caused failures in the plugin bill of materials.  Let's try a more recent version of the promoted builds plugin that removes the dependency on the project-inheritance plugin.

Also tests git client plugin upgrade to require Jenkins 2.426.3 or newer

Evaluates two pending pull requests:

* https://github.com/jenkinsci/git-client-plugin/pull/1129
* https://github.com/jenkinsci/git-plugin/pull/1581

Possible thanks to pull request:

* https://github.com/jenkinsci/promoted-builds-plugin/pull/272

### Testing done

Confirmed that `PLUGINS=git,git-client bash local-test.sh` passes

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
