### PR TITLE
Test parameterized trigger optional dependency update

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -19,7 +19,7 @@
     <declarative-pipeline-migration-assistant-plugin.version>1.6.3</declarative-pipeline-migration-assistant-plugin.version>
     <forensics-api.version>2.4.0</forensics-api.version>
     <github-api-plugin.version>1.318-461.v7a_c09c9fa_d63</github-api-plugin.version>
-    <git-plugin.version>5.2.1</git-plugin.version>
+    <git-plugin.version>5.2.2-rc5238.7552457b_12a_c</git-plugin.version>
     <junit-plugin.version>1265.v65b_14fa_f12f0</junit-plugin.version>
     <mina-sshd-api.version>2.12.1-101.v85b_e08b_780dd</mina-sshd-api.version>
     <okhttp-api-plugin.version>4.11.0-172.vda_da_1feeb_c6e</okhttp-api-plugin.version>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -853,7 +853,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>parameterized-trigger</artifactId>
-        <version>787.v665fcf2a_830b_</version>
+        <version>799.v197a_83a_103a_9</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
## Test parameterized trigger optional dependency update

The parameterized trigger plugin has an optional dependency on promoted builds plugin 3.11.  The git plugin also declares an optional dependency on the promoted builds plugin 3.11.  Attempts to update that optional dependency in the git plugin have failed.  This is an attempt to upgrade the dependency in the promoted builds plugin first, in hopes that will eventually allow the dependency to be updated in the git plugin.

Tests the plugin built from:

* https://github.com/jenkinsci/parameterized-trigger-plugin/pull/378

### Testing done

Passes `LINE=weekly PLUGINS=parameterized-trigger bash local-test.sh`

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
