### PR TITLE
Serialize Lockable Resources tests

### DIFF
--- a/pct.sh
+++ b/pct.sh
@@ -12,10 +12,10 @@ if [[ -n ${EXTRA_MAVEN_PROPERTIES-} ]]; then
 		PCT_D_ARGS+="-D${prop} "
 	done
 fi
-if ! [[ $PLUGINS =~ blueocean || $PLUGINS =~ pipeline-maven ]]; then
+if ! [[ $PLUGINS =~ blueocean || $PLUGINS =~ lockable-resources || $PLUGINS =~ pipeline-maven ]]; then
 	#
-	# The Blue Ocean and Pipeline Maven Integration test suites use a lot of
-	# memory and cannot handle parallelism.
+	# The Blue Ocean, Lockable Resources, and Pipeline Maven Integration
+	# test suites use a lot of memory and cannot handle parallelism.
 	#
 	PCT_D_ARGS+='-DforkCount=.75C '
 fi


### PR DESCRIPTION
More often than not when run in parallel these tests run out of memory.