### PR TITLE
Do not set the JTH War file

### DIFF
--- a/pct.sh
+++ b/pct.sh
@@ -28,7 +28,6 @@ exec java \
 	--working-dir "$(pwd)/target/pct-work" \
 	$PCT_D_ARGS \
 	${PCT_OPTS-} \
-	-Djth.jenkins-war.path="$(pwd)/target/megawar-$LINE.war" \
 	-Dsurefire.excludesFile="$(pwd)/excludes.txt"
 
 # produces: **/target/surefire-reports/TEST-*.xml


### PR DESCRIPTION
as mentioned in [the upstream PR](https://github.com/jenkinsci/plugin-compat-tester/pull/470#issuecomment-1448789132) that attempted to do this unconditionally this is broken by design.

The JTH and tests assume that the classpath is correctly setup however it is not, as demonstrated by https://github.com/jenkinsci/bom/pull/3218/commits/d9dba5ae443044ff6a3a6a4a8f2533b678a94c9d

According to Jenkins there is a plugin installed (trilead-api) because it is in the megawar, however its classess are not in the flat classpath used by JenkinsRule and thus breakage ensues.

There are also issues where a plugin is present that is incompatible with a mode of running for the test - e.g. a system property is set when running JTH to test a mode of running for a plugin (e.g. FIPS) and the plugin itself is incompatable with that mode (which causes a BootFailure).

ref: https://github.com/jenkinsci/plugin-compat-tester/pull/470#issuecomment-1448789132
fixes: #3231

<!-- Please describe your pull request here. -->

### Testing done

This commit has been run in a [full build](https://github.com/jenkinsci/bom/pull/3218) where failures occured with eddsa-api / trilead-api and mina-api plugins and a [weekly build](https://github.com/jenkinsci/bom/pull/3230) of just the eddsa-api plugin.
In both cases all plugins passed after introducing this change.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
