### PR TITLE
Revert "Bump org.jenkins-ci.plugins:htmlpublisher from 1.35 to 1.36 in /bom-weekly"

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -757,7 +757,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>htmlpublisher</artifactId>
-        <version>1.36</version>
+        <version>1.35</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Reverts jenkinsci/bom#3379

https://github.com/jenkinsci/htmlpublisher-plugin/pull/287#issuecomment-2231902209