### PR TITLE
Pin htmlpublisher 1.35 for 2.426.x

### DIFF
--- a/bom-2.426.x/pom.xml
+++ b/bom-2.426.x/pom.xml
@@ -60,6 +60,11 @@
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>htmlpublisher</artifactId>
+        <version>1.35</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>mailer</artifactId>
         <version>470.vc91f60c5d8e2</version>
       </dependency>


### PR DESCRIPTION
## Pin htmlpublisher 1.35 for 2.426.x

Do not want to diagnose strange failure on a line that we will drop next week.

The strange failure happens only on the 2.426.x line where even though matrix project plugin 822.824.v14451b_c0fd42 is specified in the 2.426.x pom.xml file, still the declarative Pipeline plugin InjectedTest.pluginActive fails with the message:

```
SEVERE: Failed Loading plugin Copy Artifact Plugin v749.vfb_dca_a_9b_6549 (copyartifact)
java.io.IOException: Failed to load: Copy Artifact Plugin (copyartifact 749.vfb_dca_a_9b_6549)
 - Update required: Matrix Project Plugin (matrix-project 789.v57a_725b_63c79) to be updated to 822.824.v14451b_c0fd42 or higher
        at hudson.PluginWrapper.resolvePluginDependencies(PluginWrapper.java:988)
        at hudson.PluginManager$2$1$1.run(PluginManager.java:550)
        at org.jvnet.hudson.reactor.TaskGraphBuilder$TaskImpl.run(TaskGraphBuilder.java:177)
        at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:305)
        at jenkins.model.Jenkins$5.runTask(Jenkins.java:1170)
        at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:221)
        at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:120)
        at jenkins.security.ImpersonatingExecutorService$1.run(ImpersonatingExecutorService.java:68)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
        at java.base/java.lang.Thread.run(Thread.java:1583)

Jul 19, 2024 9:09:23 AM jenkins.InitReactorRunner$1 onTaskFailed
SEVERE: Failed Loading plugin Git plugin v5.2.2 (git)
java.io.IOException: Failed to load: Git plugin (git 5.2.2)
 - Update required: Matrix Project Plugin (matrix-project 789.v57a_725b_63c79) to be updated to 822.824.v14451b_c0fd42 or higher
        at hudson.PluginWrapper.resolvePluginDependencies(PluginWrapper.java:988)
        at hudson.PluginManager$2$1$1.run(PluginManager.java:550)
        at org.jvnet.hudson.reactor.TaskGraphBuilder$TaskImpl.run(TaskGraphBuilder.java:177)
        at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:305)
        at jenkins.model.Jenkins$5.runTask(Jenkins.java:1170)
        at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:221)
        at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:120)
        at jenkins.security.ImpersonatingExecutorService$1.run(ImpersonatingExecutorService.java:68)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
        at java.base/java.lang.Thread.run(Thread.java:1583)

Jul 19, 2024 9:09:23 AM jenkins.InitReactorRunner$1 onTaskFailed
SEVERE: Failed Loading plugin HTML Publisher plugin v1.36 (htmlpublisher)
java.io.IOException: Failed to load: HTML Publisher plugin (htmlpublisher 1.36)
 - Update required: Matrix Project Plugin (matrix-project 789.v57a_725b_63c79) to be updated to 818.v7eb_e657db_924 or higher
        at hudson.PluginWrapper.resolvePluginDependencies(PluginWrapper.java:988)
        at hudson.PluginManager$2$1$1.run(PluginManager.java:550)
        at org.jvnet.hudson.reactor.TaskGraphBuilder$TaskImpl.run(TaskGraphBuilder.java:177)
        at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:305)
        at jenkins.model.Jenkins$5.runTask(Jenkins.java:1170)
        at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:221)
        at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:120)
        at jenkins.security.ImpersonatingExecutorService$1.run(ImpersonatingExecutorService.java:68)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
        at java.base/java.lang.Thread.run(Thread.java:1583)
```

### Testing done

Ran the command:

```
git clean -xffd
LINE=2.426.x PLUGINS=pipeline-model-definition TEST=InjectedTest bash local-test.sh
```

before this change and confirmed that I see the test failure on RHEL 8, Ubuntu 22.04, and Debian testing.

Ran the same command after this change on the same machines and confirmed that the test passes.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
