### PR TITLE
Check the modernise build time trend page pull request

### DIFF
--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -14,7 +14,7 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <bom>weekly</bom>
-    <jenkins.version>2.468</jenkins.version>
+    <jenkins.version>2.468-rc35126.1487e023e8b_3</jenkins.version>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>
   <dependencyManagement>


### PR DESCRIPTION
## Check the modernise build time trend page pull request

[PR-9465](https://github.com/jenkinsci/jenkins/pull/9465) improves the build time trend page by adding a "time since" column and an explicit icon that links to the console output.  It also hides the agent column for Pipeline jobs and allows the table to be resized.

Check that those very nice improvements do not break any of the tests in the plugin bill of materials.

### Testing done

Confirmed that `mvn clean verify` passes locally.  Rely on ci.jenkins.io to run the tests with this incremental build.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
