### PR TITLE
Revert "Bump org.jenkins-ci.plugins:ssh-credentials from 337.v395d2403ccd4 to 341.vf31377f30378 in /bom-weekly"

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -984,7 +984,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>ssh-credentials</artifactId>
-        <version>341.vf31377f30378</version>
+        <version>337.v395d2403ccd4</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Reverts jenkinsci/bom#3396

https://github.com/jenkinsci/ssh-credentials-plugin/pull/210#issuecomment-2246257901