### PR TITLE
Revert ssh-credentials 342.x

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -984,7 +984,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>ssh-credentials</artifactId>
-        <version>342.ve5a_f1db_5a_132</version>
+        <version>337.v395d2403ccd4</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
## Revert ssh-credentials 342.x

Plugin loading fails in several BOM tests, including:

* `LINE=2.440.x PLUGINS=git-server TEST=InjectedTest bash local-test.sh`

The [test report](https://ci.jenkins.io/job/Tools/job/bom/view/change-requests/job/PR-3374/10/testReport/) lists the other plugins with failures as:

* workflow-basic-steps with 2.440.x
* git with 2.440.x and 2.452.x
* pipeline-model-definition with 2.452.x
* docker-workflow with 2.440.x and 2.452.x
* blueocean plugin with 2.440.x and 2.452.x

This reverts commit 63a641801d8ba672d62f5bc0004de72bf60e045c.

### Testing done

`LINE=2.440.x PLUGINS=git-server TEST=InjectedTest bash local-test.sh` passes with this change

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
