### PR TITLE
Revert "Bump configuration-as-code-plugin.version from 1836.vccda_4a_122a_a_e to 1849.v3a_d20568000a_ in /bom-weekly"

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -14,7 +14,7 @@
     <branch-api-plugin.version>2.1178.v969d9eb_c728e</branch-api-plugin.version>
     <checks-api.version>2.2.0</checks-api.version>
     <cloudbees-folder-plugin.version>6.942.vb_43318a_156b_2</cloudbees-folder-plugin.version>
-    <configuration-as-code-plugin.version>1849.v3a_d20568000a_</configuration-as-code-plugin.version>
+    <configuration-as-code-plugin.version>1836.vccda_4a_122a_a_e</configuration-as-code-plugin.version>
     <data-tables-api.version>2.1.4-1</data-tables-api.version>
     <declarative-pipeline-migration-assistant-plugin.version>1.6.4</declarative-pipeline-migration-assistant-plugin.version>
     <forensics-api.version>2.5.0</forensics-api.version>


### PR DESCRIPTION
Reverts jenkinsci/bom#3492

Breaks:

- `com.cloudbees.jenkins.plugins.advisor.casc.AdvisorJCasCompatibilityTest#roundTripTest`
- `com.cloudbees.jenkins.plugins.awscredentials.ConfigurationAsCodeTest#roundTripTest`
- `hudson.plugins.active_directory.ActiveDirectoryJCasCCompatibilityTest#roundTripTest`
- `hudson.views.ViewJobFiltersConfigAsCodeTest#roundTripTest`
- `jenkins.metrics.RoundTripJCascMetricsTest#roundTripTest`
- `jenkins.plugins.git.BrowsersJCasCCompatibilityTest#roundTripTest`
- `jenkins.plugins.git.GitJCasCCompatibilityTest#roundTripTest`
- `jenkins.plugins.git.GitSCMJCasCCompatibilityTest#roundTripTest`
- `jenkins.plugins.git.GitToolJCasCCompatibilityTest#roundTripTest`
- `jenkins.plugins.git.GlobalLibraryWithLegacyJCasCCompatibilityTest#roundTripTest`
- `jenkins.plugins.git.GlobalLibraryWithModernJCasCCompatibilityTest#roundTripTest`
- `org.csanchez.jenkins.plugins.kubernetes.casc.CasCTest#roundTripTest`
- `org.csanchez.jenkins.plugins.kubernetes.casc.EnvVarCasCTest#roundTripTest`
- `org.csanchez.jenkins.plugins.kubernetes.casc.WorkspaceVolumeCasCTest#roundTripTest`
- `org.jenkinsci.plugins.docker.commons.CasCTest#roundTripTest`
- `org.jenkinsci.plugins.gitclient.JcascTest#roundTripTest`
- `org.jenkinsci.plugins.saml.SamlJCasCCompatibilityTest#roundTripTest`