### PR TITLE
Add Build Failure Analyzer to the managed set

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -50,6 +50,11 @@
         <version>332.va_1ee476d8f6d</version>
       </dependency>
       <dependency>
+        <groupId>com.sonyericsson.jenkins.plugins.bfa</groupId>
+        <artifactId>build-failure-analyzer</artifactId>
+        <version>2.5.2</version>
+      </dependency>
+      <dependency>
         <groupId>io.jenkins</groupId>
         <artifactId>configuration-as-code</artifactId>
         <version>${configuration-as-code-plugin.version}</version>

--- a/excludes.txt
+++ b/excludes.txt
@@ -1,3 +1,7 @@
+# TODO https://github.com/jenkinsci/build-failure-analyzer-plugin/pull/181
+com.sonyericsson.jenkins.plugins.bfa.model.FailureCauseHudsonTest#testDoCheckDescriptionViaWebForm
+com.sonyericsson.jenkins.plugins.bfa.model.FailureCauseHudsonTest#testDoCheckNameViaWebForm
+
 # TODO cryptic PCT-only errors: https://github.com/jenkinsci/bom/pull/251#issuecomment-645012427
 hudson.matrix.AxisTest#emptyAxisValueListResultInNoConfigurations
 hudson.matrix.AxisTest#submitEmptyAxisName

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -66,6 +66,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.sonyericsson.jenkins.plugins.bfa</groupId>
+      <artifactId>build-failure-analyzer</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>io.jenkins</groupId>
       <artifactId>configuration-as-code</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
Adding this to the managed set not because it is popular but rather because it is a dependency of 4 other Jenkins plugins.