### PR TITLE
Add CloudBees CD to the managed set

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -684,6 +684,11 @@
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>electricflow</artifactId>
+        <version>1.1.37</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>email-ext</artifactId>
         <version>1814.v404722f34263</version>
       </dependency>

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -570,6 +570,11 @@
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>electricflow</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>email-ext</artifactId>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
While this plugin is neither installed widely nor a dependency of many other plugins, it is important to CloudBees, so why not test it regularly here.