### PR TITLE
Test Jenkins weekly 2.477-rc35351.239ced05a_fca_

### DIFF
--- a/bom-2.462.x/pom.xml
+++ b/bom-2.462.x/pom.xml
@@ -23,6 +23,11 @@
       </dependency>
       <dependency>
         <groupId>io.jenkins.plugins</groupId>
+        <artifactId>analysis-model-api</artifactId>
+        <version>12.4.0</version>
+      </dependency>
+      <dependency>
+        <groupId>io.jenkins.plugins</groupId>
         <artifactId>okhttp-api</artifactId>
         <version>${okhttp-api-plugin.version}</version>
       </dependency>
@@ -31,6 +36,11 @@
         <artifactId>okhttp-api</artifactId>
         <version>${okhttp-api-plugin.version}</version>
         <classifier>tests</classifier>
+      </dependency>
+      <dependency>
+        <groupId>io.jenkins.plugins</groupId>
+        <artifactId>warnings-ng</artifactId>
+        <version>11.5.0</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -163,7 +163,7 @@
       <dependency>
         <groupId>io.jenkins.plugins</groupId>
         <artifactId>analysis-model-api</artifactId>
-        <version>12.5.0</version>
+        <version>12.4.0</version>
       </dependency>
       <dependency>
         <groupId>io.jenkins.plugins</groupId>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -463,7 +463,7 @@
       <dependency>
         <groupId>io.jenkins.plugins</groupId>
         <artifactId>warnings-ng</artifactId>
-        <version>11.6.0</version>
+        <version>11.5.0</version>
       </dependency>
       <dependency>
         <groupId>io.jenkins.plugins.mina-sshd-api</groupId>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -1014,7 +1014,8 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>script-security</artifactId>
-        <version>1361.v913100720139</version>
+        <!-- TODO: https://github.com/jenkinsci/script-security-plugin/pull/578 -->
+        <version>1364.v88f2cb_94682d</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -10,7 +10,7 @@
   <packaging>pom</packaging>
   <properties>
     <aws-java-sdk-plugin.version>1.12.767-467.vb_e93f0c614b_6</aws-java-sdk-plugin.version>
-    <blueocean-plugin.version>1.27.15-rc4520.67a_b_91263b_f9</blueocean-plugin.version>
+    <blueocean-plugin.version>1.27.14</blueocean-plugin.version>
     <branch-api-plugin.version>2.1178.v969d9eb_c728e</branch-api-plugin.version>
     <checks-api.version>2.2.1</checks-api.version>
     <cloudbees-folder-plugin.version>6.951.v5f91d88d76b_b_</cloudbees-folder-plugin.version>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -10,7 +10,7 @@
   <packaging>pom</packaging>
   <properties>
     <aws-java-sdk-plugin.version>1.12.767-467.vb_e93f0c614b_6</aws-java-sdk-plugin.version>
-    <blueocean-plugin.version>1.27.14</blueocean-plugin.version>
+    <blueocean-plugin.version>1.27.15-rc4520.67a_b_91263b_f9</blueocean-plugin.version>
     <branch-api-plugin.version>2.1178.v969d9eb_c728e</branch-api-plugin.version>
     <checks-api.version>2.2.1</checks-api.version>
     <cloudbees-folder-plugin.version>6.951.v5f91d88d76b_b_</cloudbees-folder-plugin.version>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -163,7 +163,7 @@
       <dependency>
         <groupId>io.jenkins.plugins</groupId>
         <artifactId>analysis-model-api</artifactId>
-        <version>12.4.0</version>
+        <version>12.5.0</version>
       </dependency>
       <dependency>
         <groupId>io.jenkins.plugins</groupId>

--- a/excludes.txt
+++ b/excludes.txt
@@ -23,6 +23,9 @@ hudson.matrix.AxisTest#emptyAxisValueListResultInNoConfigurations
 hudson.matrix.AxisTest#submitEmptyAxisName
 hudson.matrix.AxisTest#submitInvalidAxisName
 
+# TODO https://github.com/jenkinsci/blueocean-plugin/pull/2572
+io.jenkins.blueocean.blueocean_git_pipeline.GitReadSaveTest#testBareRepoReadWrite
+
 # TODO cryptic PCT-only errors: https://github.com/jenkinsci/bom/issues/2645#issue-1984697087
 io.jenkins.blueocean.service.embedded.PipelineApiTest#testOrganizationFolder
 

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -14,7 +14,7 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <bom>weekly</bom>
-    <jenkins.version>2.477-rc35350.7ff5a_a_a_0fdc3</jenkins.version>
+    <jenkins.version>2.477-rc35351.239ced05a_fca_</jenkins.version>
     <spotless.check.skip>false</spotless.check.skip>
     <!-- TODO JENKINS-73339 until in parent POM -->
     <jenkins-test-harness.version>2254.vcff7a_d4969e5</jenkins-test-harness.version>

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -14,7 +14,7 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <bom>weekly</bom>
-    <jenkins.version>2.476</jenkins.version>
+    <jenkins.version>2.477-rc35350.7ff5a_a_a_0fdc3</jenkins.version>
     <spotless.check.skip>false</spotless.check.skip>
     <!-- TODO JENKINS-73339 until in parent POM -->
     <jenkins-test-harness.version>2254.vcff7a_d4969e5</jenkins-test-harness.version>

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -14,7 +14,7 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <bom>weekly</bom>
-    <jenkins.version>2.477-rc35351.239ced05a_fca_</jenkins.version>
+    <jenkins.version>2.477-rc35355.2e4422a_9a_96d</jenkins.version>
     <spotless.check.skip>false</spotless.check.skip>
     <!-- TODO JENKINS-73339 until in parent POM -->
     <jenkins-test-harness.version>2254.vcff7a_d4969e5</jenkins-test-harness.version>


### PR DESCRIPTION
## Test Jenkins weekly 2.477-rc35351.239ced05a_fca_

[7ff5aaa0](https://github.com/jenkinsci/jenkins/commit/7ff5aaa0fdc337fcc6e7f02d95dd6df2721763d5) is the most recent commit included in the build.

Script security plugin test failure fix is being proposed as:

* [x] https://github.com/jenkinsci/script-security-plugin/pull/578

Blue ocean will need to be adapted to JGit 7.0.0.  Pull request being proposed is:

* [x] https://github.com/jenkinsci/blueocean-plugin/pull/2572  
* [ ] https://github.com/jenkinsci/blueocean-plugin/pull/2578 (merged but not released)

Analysis model API plugin reverted in this test pull request.  That is tracked as:

* [JENKINS-73776](https://issues.jenkins.io/browse/JENKINS-73776) - Plugin BOM tests fail with analysis model API 12.5.0

### Testing done

Ran InjectedTest with git client plugin and confirmed it passed.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
