### PR TITLE
Test revert of warnings-ng 11.7.0 and analysis-model-api 12.7.0

### DIFF
--- a/bom-2.452.x/pom.xml
+++ b/bom-2.452.x/pom.xml
@@ -51,11 +51,6 @@
         <classifier>tests</classifier>
       </dependency>
       <dependency>
-        <groupId>io.jenkins.plugins</groupId>
-        <artifactId>warnings-ng</artifactId>
-        <version>11.5.0</version>
-      </dependency>
-      <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>cloudbees-folder</artifactId>
         <version>${cloudbees-folder-plugin.version}</version>

--- a/bom-2.452.x/pom.xml
+++ b/bom-2.452.x/pom.xml
@@ -26,11 +26,6 @@
       </dependency>
       <dependency>
         <groupId>io.jenkins.plugins</groupId>
-        <artifactId>analysis-model-api</artifactId>
-        <version>12.4.0</version>
-      </dependency>
-      <dependency>
-        <groupId>io.jenkins.plugins</groupId>
         <artifactId>custom-folder-icon</artifactId>
         <version>2.9</version>
       </dependency>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -463,7 +463,7 @@
       <dependency>
         <groupId>io.jenkins.plugins</groupId>
         <artifactId>warnings-ng</artifactId>
-        <version>11.7.0</version>
+        <version>11.5.0</version>
       </dependency>
       <dependency>
         <groupId>io.jenkins.plugins.mina-sshd-api</groupId>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -163,7 +163,7 @@
       <dependency>
         <groupId>io.jenkins.plugins</groupId>
         <artifactId>analysis-model-api</artifactId>
-        <version>12.7.0</version>
+        <version>12.4.0</version>
       </dependency>
       <dependency>
         <groupId>io.jenkins.plugins</groupId>

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -14,7 +14,7 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <bom>weekly</bom>
-    <jenkins.version>2.477</jenkins.version>
+    <jenkins.version>2.478-rc35376.57d8fa_0b_72c0</jenkins.version>
     <spotless.check.skip>false</spotless.check.skip>
     <!-- TODO JENKINS-73339 until in parent POM -->
     <jenkins-test-harness.version>2254.vcff7a_d4969e5</jenkins-test-harness.version>

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -14,7 +14,7 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <bom>weekly</bom>
-    <jenkins.version>2.478-rc35376.57d8fa_0b_72c0</jenkins.version>
+    <jenkins.version>2.477</jenkins.version>
     <spotless.check.skip>false</spotless.check.skip>
     <!-- TODO JENKINS-73339 until in parent POM -->
     <jenkins-test-harness.version>2254.vcff7a_d4969e5</jenkins-test-harness.version>


### PR DESCRIPTION
## Test revert of warnings-ng 11.7.0 and analysis-model-api 12.7.0

Run weekly-test after removing pull requests:

* #3609
* #3611

### Testing done

Confirmed that 7 tests fail in my local configuration without this revert.  Same 7 tests fail on ci.jenkins.io without this revert.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
