### PR TITLE
Revert warnings-ng 11.7.0 and analysis-model-api 12.7.0

### DIFF
--- a/bom-2.452.x/pom.xml
+++ b/bom-2.452.x/pom.xml
@@ -26,11 +26,6 @@
       </dependency>
       <dependency>
         <groupId>io.jenkins.plugins</groupId>
-        <artifactId>analysis-model-api</artifactId>
-        <version>12.4.0</version>
-      </dependency>
-      <dependency>
-        <groupId>io.jenkins.plugins</groupId>
         <artifactId>custom-folder-icon</artifactId>
         <version>2.9</version>
       </dependency>
@@ -49,11 +44,6 @@
         <artifactId>plugin-util-api</artifactId>
         <version>${plugin-util-api.version}</version>
         <classifier>tests</classifier>
-      </dependency>
-      <dependency>
-        <groupId>io.jenkins.plugins</groupId>
-        <artifactId>warnings-ng</artifactId>
-        <version>11.5.0</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -163,7 +163,7 @@
       <dependency>
         <groupId>io.jenkins.plugins</groupId>
         <artifactId>analysis-model-api</artifactId>
-        <version>12.7.0</version>
+        <version>12.4.0</version>
       </dependency>
       <dependency>
         <groupId>io.jenkins.plugins</groupId>
@@ -463,7 +463,7 @@
       <dependency>
         <groupId>io.jenkins.plugins</groupId>
         <artifactId>warnings-ng</artifactId>
-        <version>11.7.0</version>
+        <version>11.5.0</version>
       </dependency>
       <dependency>
         <groupId>io.jenkins.plugins.mina-sshd-api</groupId>


### PR DESCRIPTION
## Revert warnings-ng 11.7.0 and analysis-model-api 12.7.0

Fails 7 tests in io.jenkins.plugins.analysis.warnings.steps:

* MatrixJobITest.shouldReportNoNewWarningsForSameAxisResults
* MiscIssuesRecorderITest.shouldMapSeverityFilterForFindBugs
* PackageDetectorsITest.shouldRunTwoIndependentBuildsWithTwoDifferentParsersAndCheckForCorrectPackageHandling
* ParsersITest.shouldFindAllFindBugsIssues
* ParsersITest.shouldFindAllSpotBugsIssues
* ParsersITest.shouldProvideMessagesAndDescriptionForSecurityIssuesWithSpotBugs
* RemoteApiITest.shouldReturnAggregation

Revert "Bump io.jenkins.plugins:warnings-ng from 11.5.0 to 11.7.0 in /bom-weekly (#3609)"

This reverts commit 8fce15ee8361c78e5995e807e5212bb6b937ef09.

Revert "Bump io.jenkins.plugins:analysis-model-api from 12.4.0 to 12.7.0 in /bom-weekly (#3611)"

This reverts commit 8fc54ae4ff963fd31c057bad8939d3e89fe2fe23.

### Testing done

Confirmed that the revert is sufficient in my local testing.  Also being tested with weekly-test in:

* https://github.com/jenkinsci/bom/pull/3613

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
