### PR TITLE
Add Build Monitor to the managed set

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -578,6 +578,11 @@
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>build-monitor-plugin</artifactId>
+        <version>1.14-925.v95b_9089a_4c7f</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>build-user-vars-plugin</artifactId>
         <version>178.v69708a_7a_dc17</version>
       </dependency>

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -495,6 +495,11 @@
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>build-monitor-plugin</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>build-user-vars-plugin</artifactId>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
This plugin recently broke due to a compatibility issue with Badge. Hopefully doing regular PCT runs will avoid this situation in the future.