### PR TITLE
Revert "Bump jakarta.servlet:jakarta.servlet-api from 4.0.4 to 5.0.0 in /sample-plugin"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,10 @@ updates:
       interval: "daily"
     ignore:
       # EE 10+ is not yet supported
+      # EE 9 is inherited from parent pom now
+      # EE 4 needs to remain in older lines of sample-plugin until those lines are retired
       - dependency-name: "jakarta.servlet:jakarta.servlet-api"
-        versions: [">=6.0.0"]
+        versions: [">=5.0.0"]
   - package-ecosystem: "maven"
     open-pull-requests-limit: 25
     directory: "/bom-weekly"

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -1212,7 +1212,7 @@
           <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
-            <version>5.0.0</version>
+            <version>4.0.4</version>
           </dependency>
         </dependencies>
       </dependencyManagement>
@@ -1231,7 +1231,7 @@
           <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
-            <version>5.0.0</version>
+            <version>4.0.4</version>
           </dependency>
         </dependencies>
       </dependencyManagement>


### PR DESCRIPTION
Reverts jenkinsci/bom#3685

Jakarta servlet API 4.0.4 is needed in these parts of the sample plugin so that the older lines continue to compile.