### PR TITLE
Migrate `renovate.json` to non-deprecated syntax

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,12 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base",
+    "config:recommended",
     ":semanticCommitsDisabled",
     "schedule:daily"
   ],
   "enabledManagers": [
-    "regex"
+    "custom.regex"
   ],
   "automerge": true,
   "customManagers": [


### PR DESCRIPTION
Migrate from deprecated syntax to non-deprecated replacements.