### PR TITLE
Use gitlab plugin 1.8.2 in bom-2.462.x and earlier

### DIFF
--- a/bom-2.462.x/pom.xml
+++ b/bom-2.462.x/pom.xml
@@ -85,7 +85,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>gitlab-plugin</artifactId>
-        <version>1.8.1</version>
+        <version>1.8.2</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
## Use gitlab plugin 1.8.2 in bom-2.462.x and earlier

[GitLab 1.8.2 changelog](https://github.com/jenkinsci/gitlab-plugin/releases/tag/gitlab-plugin-1.8.2) describes the fix that was made for

* https://github.com/jenkinsci/gitlab-plugin/issues/1705

GitLab plugin 1.8.2 supports 2.426.x and newer.

### Testing done

Tested by users verifying plugin works in their environment Relying on ci.jenkins.io for wider testing.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
