### PR TITLE
Test 2.479.1 pre-release with ASM 9.7.1 upgrade

### DIFF
--- a/bom-2.462.x/pom.xml
+++ b/bom-2.462.x/pom.xml
@@ -26,6 +26,11 @@
       </dependency>
       <dependency>
         <groupId>io.jenkins.plugins</groupId>
+        <artifactId>analysis-model-api</artifactId>
+        <version>12.4.0</version>
+      </dependency>
+      <dependency>
+        <groupId>io.jenkins.plugins</groupId>
         <artifactId>flyway-api</artifactId>
         <version>9.22.3-151.v475c057b_07fc</version>
       </dependency>
@@ -44,6 +49,11 @@
         <groupId>io.jenkins.plugins</groupId>
         <artifactId>pipeline-graph-view</artifactId>
         <version>340.v28cecee8b_25f</version>
+      </dependency>
+      <dependency>
+        <groupId>io.jenkins.plugins</groupId>
+        <artifactId>warnings-ng</artifactId>
+        <version>11.5.0</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>

--- a/bom-2.479.x/pom.xml
+++ b/bom-2.479.x/pom.xml
@@ -18,16 +18,6 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      <dependency>
-        <groupId>io.jenkins.plugins</groupId>
-        <artifactId>analysis-model-api</artifactId>
-        <version>12.4.0</version>
-      </dependency>
-      <dependency>
-        <groupId>io.jenkins.plugins</groupId>
-        <artifactId>warnings-ng</artifactId>
-        <version>11.5.0</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 </project>

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -1180,7 +1180,7 @@
       <properties>
         <bom>2.479.x</bom>
         <!-- TODO: Replace with 2.479.1 after release of 2.479.1 -->
-        <jenkins.version>2.479</jenkins.version>
+        <jenkins.version>2.479.1-rc35406.a_347514e820d</jenkins.version>
       </properties>
     </profile>
     <profile>


### PR DESCRIPTION
## Test 2.479.1 pre-release with ASM 9.7.1 upgrade

Moves the pin of older warnings-ng and analysis-model-api from 2.479.x to 2.462.x

Intentionally running a full test to confirm that 2.479.x is in good condition.

### Testing done

Confirmed that `PLUGINS=warnings-ng,analysis-model-api bash local-test.sh` passes locally.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
