### PR TITLE
Add Groovy Postbuild plugin to managed set

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -1384,6 +1384,11 @@
         <artifactId>favorite</artifactId>
         <version>2.221.v19ca_666b_62f5</version>
       </dependency>
+      <dependency>
+        <groupId>org.jvnet.hudson.plugins</groupId>
+        <artifactId>groovy-postbuild</artifactId>
+        <version>264.vf6e02a_77d5b_c</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 </project>

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -1119,6 +1119,11 @@
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jvnet.hudson.plugins</groupId>
+      <artifactId>groovy-postbuild</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <repositories>
     <repository>


### PR DESCRIPTION
## Add Groovy Postbuild plugin to managed set

Fix #3635

Plugin has over 19000 installations and is used regularly when testing new Jenkins releases.  Was affected by the badge 2.0 compatibility break and has been adapted to that change in the release that is included in bom-weekly/pom.xml.

### Testing done

Confirmed that tests pass for this plugin with:

`PLUGINS=groovy-postbuild bash local-test.sh`

Also confirmed that the tests fail with the older version of the plugin.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
