### PR TITLE
Further simplify scripts by removing issueId parameter

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -215,25 +215,23 @@ The scripts that are referenced are in the `release-manager-scripts` directory. 
 
 #### Friday (BOM release day)
 
-* run `./bom-lock-master.sh <issueId>` 
-  * where `<issueId>` is the issue that you created on Thursday
-  * Example: `./bom-lock-master.sh 3220` 
-* verify that job started at [ci.jenkins.io](https://ci.jenkins.io/job/Tools/job/bom/view/change-requests/)
-* run `./bom-release-issue-job-running.sh <issueId> <buildNumber>`
-  * Example: `./bom-release-issue-job-running.sh 3220 3789`
+* run `./bom-lock-master.sh` before the job runs
+  * currently, the job is [scheduled to run at 11:HH am UTC (actual 11:26am)](https://github.com/jenkinsci/bom/blob/master/Jenkinsfile#L4)
+* verify that the [branch is locked](https://github.com/jenkinsci/bom/settings/branch_protection_rules/6421306)
+* wait to verify that job started at [ci.jenkins.io](https://ci.jenkins.io/job/Tools/job/bom/view/change-requests/)
+* run `./bom-release-issue-job-running.sh <buildNumber>`
+  * Example: `./bom-release-issue-job-running.sh 1234`
 * wait for build to make it through the `prep` stage then (typically) take a 1.5-2 hr break
 * [LOOP] if there are any failures, fix until everything is successful
-* run `./bom-release-issue-add-release-comment.sh <issueId>`
-  * Example: `./bom-release-issue-add-release-comment.sh 3220`
-* run `./bom-unlock-master.sh <issueId>`
-  * Example: `./bom-unlock-master.sh 3220`
+* run `./bom-release-issue-add-release-comment.sh`
+* run `./bom-unlock-master.sh`
+* verify that the [branch is unlocked](https://github.com/jenkinsci/bom/settings/branch_protection_rules/6421306)
 * manually edit the auto-generated release notes
   * remove `<!-- Optional: add a release summary here -->`
   * remove `<details>`
   * remove `<summary>XYZ changes</summary>`
   * remove `</details>`
-* run `./bom-release-issue-close.sh <issueId>`
-  * Example: `./bom-release-issue-close.sh 3220`
+* run `./bom-release-issue-close.sh`
 
 #### Saturday/Sunday/Monday
 

--- a/release-manager-scripts/bom-lock-master.sh
+++ b/release-manager-scripts/bom-lock-master.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 
-if [[ $# -ne 1 ]]; then
-	echo "Error: This script requires exactly one argument."
-	echo "./bom-lock-master.sh <GitHub issue id>"
-	exit 1
-fi
-
 git checkout master
 git pull
 gh api \
@@ -21,6 +15,8 @@ gh api \
 	-F "restrictions=null" \
 	--silent
 
-updatedBody=$(gh issue view $1 --json body --jq ".body" | sed 's/\[\ \] Lock/[x] Lock/')
-gh issue edit $1 --body $updatedBody
+issueNumber=$(gh issue list --limit 1 --state open --label release --json number --jq=".[].number")
+
+updatedBody=$(gh issue view $issueNumber --json body --jq ".body" | sed 's/\[\ \] Lock/[x] Lock/')
+gh issue edit $issueNumber --body $updatedBody
 ./bom-get-branch-protection.sh

--- a/release-manager-scripts/bom-release-issue-add-release-comment.sh
+++ b/release-manager-scripts/bom-release-issue-add-release-comment.sh
@@ -1,12 +1,7 @@
 #!/bin/bash
 
-if [[ $# -ne 1 ]]; then
-	echo "Error: This script requires exactly one argument."
-	echo "./bom-release-issue-add-release-comment.sh <GitHub issue id>"
-	exit 1
-fi
-
 git checkout master
 git pull
 releaseName=$(gh release list --limit 1 --json isLatest,name --jq ".[].name")
-gh issue comment $1 --body "New release: [https://github.com/jenkinsci/bom/releases/tag/$releaseName](https://github.com/jenkinsci/bom/releases/tag/$releaseName)"
+issueNumber=$(gh issue list --limit 1 --state open --label release --json number --jq=".[].number")
+gh issue comment $issueNumber --body "New release: [https://github.com/jenkinsci/bom/releases/tag/$releaseName](https://github.com/jenkinsci/bom/releases/tag/$releaseName)"

--- a/release-manager-scripts/bom-release-issue-close.sh
+++ b/release-manager-scripts/bom-release-issue-close.sh
@@ -1,12 +1,7 @@
 #!/bin/bash
 
-if [[ $# -ne 1 ]]; then
-	echo "Error: This script requires exactly one argument."
-	echo "./bom-release-issue-close.sh <GitHub issue id>"
-	exit 1
-fi
-
 git checkout master
 git pull
-gh issue unpin $1
-gh issue close $1
+issueNumber=$(gh issue list --limit 1 --state open --label release --json number --jq=".[].number")
+gh issue unpin $issueNumber
+gh issue close $issueNumber

--- a/release-manager-scripts/bom-release-issue-create.sh
+++ b/release-manager-scripts/bom-release-issue-create.sh
@@ -30,4 +30,5 @@ issueNumber=$(gh api \
 	-f "assignees[]=$releaseManager" \
 	--jq ".number")
 echo $issueNumber
+gh issue edit $issueNumber --add-label "release"
 gh issue pin $issueNumber

--- a/release-manager-scripts/bom-release-issue-job-running.sh
+++ b/release-manager-scripts/bom-release-issue-job-running.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 
 if [[ $# -ne 2 ]]; then
-	echo "Error: This script requires exactly two arguments."
-	echo "./bom-release-issue-job-running.sh <GitHub issue id> <Jenkins build number>"
+	echo "Error: This script requires exactly one argument."
+	echo "./bom-release-issue-job-running.sh <Jenkins build number>"
 	exit 1
 fi
 
 git checkout master
 git pull
-updatedBody=$(gh issue view $1 --json body --jq ".body" | sed 's/\[\ \] Trigger/[x] Trigger/' | sed "s/BUILDNUMBER/$2/")
-gh issue edit $1 --body $updatedBody
+issueNumber=$(gh issue list --limit 1 --state open --label release --json number --jq=".[].number")
+updatedBody=$(gh issue view $issueNumber --json body --jq ".body" | sed 's/\[\ \] Trigger/[x] Trigger/' | sed "s/BUILDNUMBER/$1/")
+gh issue edit $issueNumber --body $updatedBody

--- a/release-manager-scripts/bom-unlock-master.sh
+++ b/release-manager-scripts/bom-unlock-master.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 
-if [[ $# -ne 1 ]]; then
-	echo "Error: This script requires exactly one argument."
-	echo "./bom-unlock-master.sh <GitHub issue id>"
-	exit 1
-fi
-
 git checkout master
 git pull
 gh api \
@@ -21,6 +15,8 @@ gh api \
 	-F "restrictions=null" \
 	--silent
 
-updatedBody=$(gh issue view $1 --json body --jq ".body" | sed 's/\[\ \] Unlock/[x] Unlock/')
-gh issue edit $1 --body $updatedBody
+issueNumber=$(gh issue list --limit 1 --state open --label release --json number --jq=".[].number")
+
+updatedBody=$(gh issue view $issueNumber --json body --jq ".body" | sed 's/\[\ \] Unlock/[x] Unlock/')
+gh issue edit $issueNumber --body $updatedBody
 ./bom-get-branch-protection.sh


### PR DESCRIPTION
After a bit more digging, I found that it wasn't necessary to pass in the GitHub issue id to some of the scripts. This should make it even easier to follow the daily (primarily Friday) task list.

The catch is the math to get the issue id is we are looking for an issue that has a `release` label (set in the create script). We need to make sure that there is never more than one open issue that has a `release` label. I did limit the return to just 1, but if there are multiple, it's going to grab the most current, even if that's not the one you want.  This probably isn't a huge deal because only one person should be doing the release, so that's why I didn't go overboard with protections.

### Testing done

Ran scripts to verify.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue