### PR TITLE
Revert "Bump org.jenkins-ci.plugins:cloudbees-bitbucket-branch-source from 895.v15dc41668f03 to 906.vedf430cb_4481 in /bom-weekly"

### DIFF
--- a/bom-2.452.x/pom.xml
+++ b/bom-2.452.x/pom.xml
@@ -52,11 +52,6 @@
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>cloudbees-bitbucket-branch-source</artifactId>
-        <version>895.v15dc41668f03</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>cloudbees-folder</artifactId>
         <version>${cloudbees-folder-plugin.version}</version>
       </dependency>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -619,7 +619,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>cloudbees-bitbucket-branch-source</artifactId>
-        <version>906.vedf430cb_4481</version>
+        <version>895.v15dc41668f03</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Reverts jenkinsci/bom#3911, which causes a new test failure:

```
[ERROR] io.jenkins.blueocean.blueocean_bitbucket_pipeline.cloud.BbCloudPipelineCreateRequestTest.createPipeline -- Time elapsed: 12.44 s <<< FAILURE!
com.github.tomakehurst.wiremock.client.VerificationException: 
3 requests were unmatched by any stub mapping. Shown with closest stub mappings:
 expected:<
GET
/rest/api/1.0/projects/vivektestteam/repos/pipeline-demo-test
> but was:<
GET
/rest/api/1.0/projects/vivektestteam/repos/pipeline-demo-test/branches?start=0&limit=200
>

 expected:<
GET
/rest/api/1.0/projects/%7B47cd7cf2-ca31-4c90-bc0e-4c7ef67f9dfe%7D/repos/pipeline-demo-test
> but was:<
GET
/rest/api/1.0/projects/vivektestteam/repos/pipeline-demo-test/branches?start=0&limit=200
>

 expected:<
GET
/api/2.0/repositories/%7B47cd7cf2-ca31-4c90-bc0e-4c7ef67f9dfe%7D?page=1&limit=100
> but was:<
GET
/rest/api/1.0/projects/vivektestteam/repos/pipeline-demo-test/branches?start=0&limit=200
>
        at com.github.tomakehurst.wiremock.client.VerificationException.forUnmatchedNearMisses(VerificationException.java:55)
        at com.github.tomakehurst.wiremock.WireMockServer.checkForUnmatchedRequests(WireMockServer.java:545)
        at com.github.tomakehurst.wiremock.junit.WireMockRule$1.evaluate(WireMockRule.java:70)
        at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:706)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
        at java.base/java.lang.Thread.run(Thread.java:1583)
```