### PR TITLE
Pin htmlpublisher 1.36 for older lines

### DIFF
--- a/bom-2.479.x/pom.xml
+++ b/bom-2.479.x/pom.xml
@@ -27,6 +27,11 @@
         <artifactId>warnings-ng</artifactId>
         <version>11.5.0</version>
       </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>htmlpublisher</artifactId>
+        <version>1.36</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 </project>


### PR DESCRIPTION
## Pin htmlpublisher 1.36 for older lines

Prevent test failure in the declarative Pipeline plugin when it attempts to load htmlpublisher 1.37 on Jenkins 2.479.x and earlier.

Tests fail with the commands:

```
$ LINE=2.479.x PLUGINS=pipeline-model-definition TEST=InjectedTest bash local-test.sh
$ LINE=2.462.x PLUGINS=pipeline-model-definition TEST=InjectedTest bash local-test.sh
$ LINE=2.452.x PLUGINS=pipeline-model-definition TEST=InjectedTest bash local-test.sh
```

Failure message is:

```
> Failed to load: HTML Publisher plugin (htmlpublisher 1.37)
>  - Update required: Matrix Project Plugin (matrix-project 832.va_66e270d2946) 
>    to be updated to 838.v4d7b_7b_f9b_d4b_ or higher
```

The matrix project release 839.vff91cd7e3a_b_2 is already defined in those older release lines but that definition does not seem to be honored by the pipeline-model-definition test configuration.

### Testing done

Confirmed that the failure cases all pass with this change.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
