### PR TITLE
Pin ssh-credentials for 2.452.x

### DIFF
--- a/bom-2.452.x/pom.xml
+++ b/bom-2.452.x/pom.xml
@@ -98,6 +98,11 @@
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>ssh-credentials</artifactId>
+        <version>343.v884f71d78167</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>subversion</artifactId>
         <version>${subversion-plugin.version}</version>
       </dependency>


### PR DESCRIPTION
When adding some other plugins, I kept hitting the following issue:

```
Caused by: java.io.IOException: Failed to load: SSH Credentials Plugin (ssh-credentials 349.vb_8b_6b_9709f5b_)
- Update required: Trilead API Plugin (trilead-api 2.142.v748523a_76693) to be updated to 2.147.vb_73cc728a_32e or higher
```
for the following plugins only for the `2.452.x` line:

* build-failure-analyzer
* docker-workflow
* git-parameter
* git
* git-server
* workflow-basic-steps
* pipeline-model-definition
* jenkins-design-language

This was probably introduced with #4028.

Pinning to the previous version just for 2.452.x to see if it resolves.

### Testing done

2.452.x LINE tests for a few of the plugins that were failing before the pin, i.e.:

`LINE=2.452.x PLUGINS=build-failure-analyzer bash local-test.sh`

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue