### PR TITLE
Test git plugin pre-release build

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -962,7 +962,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>git-client</artifactId>
-        <version>6.1.1-rc3643.ff37e600016d</version>
+        <version>6.1.0</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -20,7 +20,7 @@
     <declarative-pipeline-migration-assistant-plugin.version>1.6.4</declarative-pipeline-migration-assistant-plugin.version>
     <forensics-api.version>2.6.0</forensics-api.version>
     <github-api-plugin.version>1.321-478.vc9ce627ce001</github-api-plugin.version>
-    <git-plugin.version>5.6.0</git-plugin.version>
+    <git-plugin.version>5.6.1-rc5357.7a_4955e76288</git-plugin.version>
     <junit-plugin.version>1309.v0078b_fecd6ed</junit-plugin.version>
     <mina-sshd-api.version>2.14.0-133.vcc091215a_358</mina-sshd-api.version>
     <okhttp-api-plugin.version>4.11.0-181.v1de5b_83857df</okhttp-api-plugin.version>
@@ -962,7 +962,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>git-client</artifactId>
-        <version>6.1.0</version>
+        <version>6.1.1-rc3643.ff37e600016d</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
## Test git plugin pre-release builds

Git plugin 5.6.1-rc5357.7a_4955e76288 adds credentials to the GitClient object before decorating the object with settings from extensions.  A plugin that adds a deocrator will now be able to adjust the credentials if needed.

* https://github.com/jenkinsci/git-plugin/pull/1687

Jira issue for the change of ordering of GitClient decoration is:

* https://issues.jenkins.io/browse/JENKINS-73677

## Rejected changes

The pre-release git client plugin fails the warnings-ng tests with a null pointer exception.  Those changes have been removed from this pull request in commit d4df16889f4087e8217c0a8eee3b5861775a6d71

### Testing done

Checked that a few plugins that depend on the git plugin are passing their automated tests in the BOM context.

```
PLUGINS=github-branch-source,cloudbees-bitbucket-branch-source,,mailer TEST=InjectedTest bash local-test.sh
```

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
