### PR TITLE
Pre-heat the artifact caching proxy

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,6 +60,9 @@ stage('prep') {
       ]) {
         sh '''
         mvn -v
+        echo "Starting artifact caching proxy pre-heat"
+        mvn --no-transfer-progress dependency:go-offline
+        echo "Finished artifact caching proxy pre-heat"
         bash prep.sh
         '''
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,7 +61,7 @@ stage('prep') {
         sh '''
         mvn -v
         echo "Starting artifact caching proxy pre-heat"
-        mvn --no-transfer-progress dependency:go-offline
+        mvn -ntp dependency:go-offline
         echo "Finished artifact caching proxy pre-heat"
         bash prep.sh
         '''


### PR DESCRIPTION
## Pre-heat the artifact caching proxy

Try to detect issues with repo.jenkins-ci.org or with artifact caching proxy earlier when a failed build is less expensive.  Will not detect every issue, but is hoped to detect some issues before the parallel stage starts.

Attempt to detect artifact caching proxy failures earlier in the build process by downloading the artifacts during the prep stage.  The prep stage may not need the dependencies, but it is less expensive if the download fails early in the build process rather than failing later during plugin compatibility testing.

This is flawed because it does not account for the number of artifact caching proxy instances that may be running.  It might pre-heat only one of the caches, but hopefully that is better than nothing.

Discussed in [10 Dec 2024 Jenkins infrastructure meeting](https://community.jenkins.io/t/infrastructure-team-meeting-december-10-2024/24578)

Interested in comments from @dduportal and @basil in case this is a waste of effort or a flawed implementation.  Does not need to be merged before the weekly release, though it should be harmless, using some extra disc space on the agent that is running prep.sh.

### Testing done

Confirmed that `mvn -ntp dependency:go-offline` has expected output on my computer.

| Pre-heat? | Time | Source
| ------------- | ------------- | ---- |
| No pre-heat  | 16:30  | Another PR |
| No pre-heat  | 18:16  | flyway-api |
| No pre-heat  | 15:41  | commons-compress-api |
| No pre-heat  | 15:37  | database |
| No pre-heat  | 16:00  | byte-buddy |
| No pre-heat  | 17:19  | Apply developer label to dependency updates |
| No pre-heat  | 16:59  | ssh build agents |
| No pre-heat  | 17:15  | AWS SDK v2 |
| No pre-heat  | 18:45  | Folders |
| No pre-heat  | 19:46  | SAML |
| With pre-heat  | 23:35 | This PR build 1 |
| With pre-heat  | 17:12 | This PR build 2 |
| With pre-heat  | 18:10 | This PR build 3|
| With pre-heat  | 21:06 | This PR build 4 |
| With pre-heat  | 17:12 | This PR build 5 |
| With pre-heat  | 17:05 | This PR build 6 |
| With pre-heat  | 18:44 | This PR build 7 |
| With pre-heat  | 17:34 | This PR build 8 |
| With pre-heat  | 17:20 | This PR build 9 |
| With pre-heat  | 21:21 | This PR build 10 |
| With pre-heat  | 17:34 | This PR build 11 |

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
