### PR TITLE
Apply developer label to dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,11 @@ updates:
       # Should have been 1.27.0
       - dependency-name: "com.sonyericsson.jenkins.plugins.bfa:build-failure-analyzer"
         versions: ["2.27.0"]
+    labels:
+      # dependency updates to plugin BOM are developer relevant changes
+      # developer label assures CD process will release with this change
+      # https://github.com/jenkinsci/bom/issues/4092#issuecomment-2544153741
+      - "developer"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Apply developer label to dependency updates

The developer label is in the `INTERESTING_CATEGORIES` list of the GitHub action for continuous delivery.

Dependency updates to the plugin BOM are the primary purpose of the plugin BOM. It seems reasonable that they should use a label that shows the change as interesting for the continuous delivery process.

Implements the idea that I mentioned in https://github.com/jenkinsci/bom/issues/4092#issuecomment-2543889714

### Testing done

None.  Copied the labels syntax line from a plugin where it is being used successfully.  Will rely on GitHub Actions to confirm the syntax is correct.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
