### PR TITLE
Disable weekly build during 2 week end of year shutdown

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,8 @@
 properties([
   disableConcurrentBuilds(abortPrevious: true),
   buildDiscarder(logRotator(numToKeepStr: '7')),
-  pipelineTriggers([cron('18 03 * * 6')])
+  // TODO: Restore build schedule after end of year break
+  // pipelineTriggers([cron('18 04 * * 5')])
 ])
 
 if (BRANCH_NAME == 'master' && currentBuild.buildCauses*._class == ['jenkins.branch.BranchEventCause']) {


### PR DESCRIPTION
## Disable weekly build during 2 week end of year shutdown

Jenkins infra team will be off for the next two weeks.  Let's not release plugin BOM during those two weeks.

### Testing done

None.  Rely on ci.jenkins.io to test.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
