### PR TITLE
Pin `copyartifact` on older lines

### DIFF
--- a/bom-2.479.x/pom.xml
+++ b/bom-2.479.x/pom.xml
@@ -39,6 +39,11 @@
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>copyartifact</artifactId>
+        <version>757.v05365583a_455</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>htmlpublisher</artifactId>
         <version>1.36</version>
       </dependency>


### PR DESCRIPTION
Amends #4155. Without this PR, testing `org.jenkinsci.plugins.pipeline_model_definition.InjectedTest` fails on 2.479.x and earlier with:

```
java.lang.AssertionError: While testing pipeline-model-definition, copyartifact failed to start
	at org.jvnet.hudson.test.PluginAutomaticTestBuilder$OtherTests.testPluginActive(PluginAutomaticTestBuilder.java:102)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at junit.framework.TestCase.runTest(TestCase.java:177)
	at junit.framework.TestCase.runBare(TestCase.java:142)
	at junit.framework.TestResult$1.protect(TestResult.java:122)
	at junit.framework.TestResult.runProtected(TestResult.java:142)
	at junit.framework.TestResult.run(TestResult.java:125)
	at junit.framework.TestCase.run(TestCase.java:130)
	at junit.framework.TestSuite.runTest(TestSuite.java:241)
	at junit.framework.TestSuite.run(TestSuite.java:236)
	at org.jvnet.hudson.test.junit.GroupedTest.runGroupedTests(GroupedTest.java:67)
	at org.jvnet.hudson.test.JellyTestSuiteBuilder$JellyTestSuite.doTests(JellyTestSuiteBuilder.java:139)
	at org.jvnet.hudson.test.JellyTestSuiteBuilder$JellyTestSuite$2.call(JellyTestSuiteBuilder.java:148)
	at org.jvnet.hudson.test.HudsonTestCase$WebClient$5.run(HudsonTestCase.java:1728)
	at org.jvnet.hudson.test.ClosureExecuterAction.doIndex(ClosureExecuterAction.java:52)
	at java.base/java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:732)
	at org.kohsuke.stapler.Function$MethodFunction.invoke(Function.java:484)
	at org.kohsuke.stapler.Function$InstanceFunction.invoke(Function.java:497)
	at org.kohsuke.stapler.Function.bindAndInvoke(Function.java:218)
	at org.kohsuke.stapler.Function.bindAndInvokeAndServeResponse(Function.java:140)
	at org.kohsuke.stapler.IndexDispatcher.dispatch(IndexDispatcher.java:31)
	at org.kohsuke.stapler.Stapler.tryInvoke(Stapler.java:800)
	at org.kohsuke.stapler.Stapler.invoke(Stapler.java:938)
	at org.kohsuke.stapler.MetaClass$10.dispatch(MetaClass.java:590)
	at org.kohsuke.stapler.Stapler.tryInvoke(Stapler.java:800)
	at org.kohsuke.stapler.Stapler.invoke(Stapler.java:938)
	at org.kohsuke.stapler.Stapler.invoke(Stapler.java:721)
	at org.kohsuke.stapler.Stapler.service(Stapler.java:253)
	at jakarta.servlet.http.HttpServlet.service(HttpServlet.java:587)
	at org.eclipse.jetty.ee9.servlet.ServletHolder.handle(ServletHolder.java:765)
	at org.eclipse.jetty.ee9.servlet.ServletHandler$ChainEnd.doFilter(ServletHandler.java:1668)
	at hudson.util.PluginServletFilter$1.doFilter(PluginServletFilter.java:204)
	at io.jenkins.servlet.FilterChainWrapper$2.doFilter(FilterChainWrapper.java:53)
	at jenkins.metrics.impl.MetricsFilter.doFilter(MetricsFilter.java:125)
	at io.jenkins.servlet.FilterWrapper$1.doFilter(FilterWrapper.java:42)
	at hudson.util.PluginServletFilter$1.doFilter(PluginServletFilter.java:201)
	at jenkins.util.HttpServletFilter$1.doFilter(HttpServletFilter.java:77)
	at hudson.util.PluginServletFilter$1.doFilter(PluginServletFilter.java:201)
	at hudson.util.PluginServletFilter.doFilter(PluginServletFilter.java:207)
	at org.eclipse.jetty.ee9.servlet.FilterHolder.doFilter(FilterHolder.java:202)
	at org.eclipse.jetty.ee9.servlet.ServletHandler$Chain.doFilter(ServletHandler.java:1638)
	at jenkins.ErrorAttributeFilter.doFilter(ErrorAttributeFilter.java:29)
	at org.eclipse.jetty.ee9.servlet.FilterHolder.doFilter(FilterHolder.java:202)
	at org.eclipse.jetty.ee9.servlet.ServletHandler$Chain.doFilter(ServletHandler.java:1638)
	at hudson.security.csrf.CrumbFilter.doFilter(CrumbFilter.java:160)
	at org.eclipse.jetty.ee9.servlet.FilterHolder.doFilter(FilterHolder.java:202)
	at org.eclipse.jetty.ee9.servlet.ServletHandler$Chain.doFilter(ServletHandler.java:1638)
	at hudson.security.ChainedServletFilter2$1.doFilter(ChainedServletFilter2.java:94)
	at hudson.security.ChainedServletFilter2.doFilter(ChainedServletFilter2.java:111)
	at hudson.security.HudsonFilter.doFilter(HudsonFilter.java:173)
	at org.eclipse.jetty.ee9.servlet.FilterHolder.doFilter(FilterHolder.java:202)
	at org.eclipse.jetty.ee9.servlet.ServletHandler$Chain.doFilter(ServletHandler.java:1638)
	at org.kohsuke.stapler.UncaughtExceptionFilter.doFilter(UncaughtExceptionFilter.java:26)
	at org.eclipse.jetty.ee9.servlet.FilterHolder.doFilter(FilterHolder.java:202)
	at org.eclipse.jetty.ee9.servlet.ServletHandler$Chain.doFilter(ServletHandler.java:1638)
	at hudson.util.CharacterEncodingFilter.doFilter(CharacterEncodingFilter.java:86)
	at org.eclipse.jetty.ee9.servlet.FilterHolder.doFilter(FilterHolder.java:202)
	at org.eclipse.jetty.ee9.servlet.ServletHandler$Chain.doFilter(ServletHandler.java:1638)
	at org.kohsuke.stapler.DiagnosticThreadNameFilter.doFilter(DiagnosticThreadNameFilter.java:31)
	at org.eclipse.jetty.ee9.servlet.FilterHolder.doFilter(FilterHolder.java:202)
	at org.eclipse.jetty.ee9.servlet.ServletHandler$Chain.doFilter(ServletHandler.java:1638)
	at jenkins.security.SuspiciousRequestFilter.doFilter(SuspiciousRequestFilter.java:38)
	at org.eclipse.jetty.ee9.servlet.FilterHolder.doFilter(FilterHolder.java:202)
	at org.eclipse.jetty.ee9.servlet.ServletHandler$Chain.doFilter(ServletHandler.java:1638)
	at org.eclipse.jetty.ee9.servlet.ServletHandler.doHandle(ServletHandler.java:526)
	at org.eclipse.jetty.ee9.nested.ScopedHandler.handle(ScopedHandler.java:127)
	at org.eclipse.jetty.ee9.security.SecurityHandler.handle(SecurityHandler.java:574)
	at org.eclipse.jetty.ee9.nested.HandlerWrapper.handle(HandlerWrapper.java:124)
	at org.eclipse.jetty.ee9.nested.ScopedHandler.nextHandle(ScopedHandler.java:197)
	at org.eclipse.jetty.ee9.nested.SessionHandler.doHandle(SessionHandler.java:606)
	at org.eclipse.jetty.ee9.nested.ScopedHandler.nextHandle(ScopedHandler.java:195)
	at org.eclipse.jetty.ee9.nested.ContextHandler.doHandle(ContextHandler.java:1034)
	at org.eclipse.jetty.ee9.nested.ScopedHandler.nextScope(ScopedHandler.java:164)
	at org.eclipse.jetty.ee9.servlet.ServletHandler.doScope(ServletHandler.java:483)
	at org.eclipse.jetty.ee9.nested.ScopedHandler.nextScope(ScopedHandler.java:162)
	at org.eclipse.jetty.ee9.nested.SessionHandler.doScope(SessionHandler.java:583)
	at org.eclipse.jetty.ee9.nested.ScopedHandler.nextScope(ScopedHandler.java:162)
	at org.eclipse.jetty.ee9.nested.ContextHandler.doScope(ContextHandler.java:955)
	at org.eclipse.jetty.ee9.nested.ScopedHandler.handle(ScopedHandler.java:125)
	at org.eclipse.jetty.ee9.nested.ContextHandler.handle(ContextHandler.java:1693)
	at org.eclipse.jetty.ee9.nested.HttpChannel$RequestDispatchable.dispatch(HttpChannel.java:1576)
	at org.eclipse.jetty.ee9.nested.HttpChannel.dispatch(HttpChannel.java:738)
	at org.eclipse.jetty.ee9.nested.HttpChannel.handle(HttpChannel.java:511)
	at org.eclipse.jetty.ee9.nested.ContextHandler$CoreContextHandler$CoreToNestedHandler.handle(ContextHandler.java:2832)
	at org.eclipse.jetty.server.handler.ContextHandler.handle(ContextHandler.java:858)
	at org.eclipse.jetty.server.handler.gzip.GzipHandler.handle(GzipHandler.java:597)
	at org.eclipse.jetty.server.Server.handle(Server.java:181)
	at org.eclipse.jetty.server.internal.HttpChannelState$HandlerInvoker.run(HttpChannelState.java:648)
	at org.eclipse.jetty.server.internal.HttpConnection.onFillable(HttpConnection.java:403)
	at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:322)
	at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:99)
	at org.eclipse.jetty.io.SelectableChannelEndPoint$1.run(SelectableChannelEndPoint.java:53)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:979)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.doRunJob(QueuedThreadPool.java:1209)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:1164)
	at java.base/java.lang.Thread.run(Thread.java:840)
Caused by: java.io.IOException: Failed to load: Copy Artifact Plugin (copyartifact 761.vea_2b_25523e84)
 - Update required: Matrix Project Plugin (matrix-project 832.va_66e270d2946) to be updated to 839.vff91cd7e3a_b_2 or higher
	at hudson.PluginWrapper.resolvePluginDependencies(PluginWrapper.java:992)
	at hudson.PluginManager$2$1$1.run(PluginManager.java:581)
	at org.jvnet.hudson.reactor.TaskGraphBuilder$TaskImpl.run(TaskGraphBuilder.java:177)
	at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:305)
	at jenkins.model.Jenkins$5.runTask(Jenkins.java:1195)
	at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:221)
	at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:120)
	at jenkins.security.ImpersonatingExecutorService$1.run(ImpersonatingExecutorService.java:68)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	... 1 more
```