### PR TITLE
Check git client 6.1.1 test fix for CLI git 2.48.0

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -957,7 +957,9 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>git-client</artifactId>
-        <version>6.1.1-rc3667.8f7cddc42e9e</version>
+        <!-- master branch after adapting test for CLI git 2.48.0 -->
+        <!-- https://github.com/jenkinsci/git-client-plugin/commit/8d5f9c37c25ece914f7d968efda9bdf36ad74aab -->
+        <version>6.1.1-rc3667.8d5f9c37c25e</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -959,7 +959,11 @@
         <artifactId>git-client</artifactId>
         <!-- master branch after adapting test for CLI git 2.48.0 -->
         <!-- https://github.com/jenkinsci/git-client-plugin/commit/8d5f9c37c25ece914f7d968efda9bdf36ad74aab -->
-        <version>6.1.1-rc3667.8d5f9c37c25e</version>
+        <!-- <version>6.1.1-rc3667.8d5f9c37c25e</version> -->
+        <!-- stable-6.1 branch after adapting test for CLI git 2.48.0 -->
+        <!-- https://github.com/jenkinsci/git-client-plugin/compare/stable-6.1 -->
+        <!-- https://github.com/jenkinsci/git-client-plugin/commit/dc6719e47df4a18f8b7bdf1a6ff1a454bcd8d520 -->
+        <version>6.1.1-rc3628.dc6719e47df4</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -957,7 +957,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>git-client</artifactId>
-        <version>6.1.1-rc3670.65a_d746a_b_706</version>
+        <version>6.1.1-rc3667.8f7cddc42e9e</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -957,13 +957,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>git-client</artifactId>
-        <!-- master branch after adapting test for CLI git 2.48.0 -->
-        <!-- https://github.com/jenkinsci/git-client-plugin/commit/8d5f9c37c25ece914f7d968efda9bdf36ad74aab -->
-        <!-- <version>6.1.1-rc3667.8d5f9c37c25e</version> -->
-        <!-- stable-6.1 branch after adapting test for CLI git 2.48.0 -->
-        <!-- https://github.com/jenkinsci/git-client-plugin/compare/stable-6.1 -->
-        <!-- https://github.com/jenkinsci/git-client-plugin/commit/dc6719e47df4a18f8b7bdf1a6ff1a454bcd8d520 -->
-        <version>6.1.1-rc3628.dc6719e47df4</version>
+        <version>6.1.1</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -957,7 +957,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>git-client</artifactId>
-        <version>6.1.0</version>
+        <version>6.1.1-rc3670.65a_d746a_b_706</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
## Check git client 6.1.1 test fix for CLI git 2.48.0

Work in progress.  Do not merge.  Running weekly test to confirm that the test fix in git client 6.1.1 is enough to fix the 3 tests that are failing with CLI git 2.48.0.

CLI git 2.48.0 changes a behavior that one of the git client tests unintentionally relied upon.  The git client plugin test has been updated in the pull request and confirmed that it is passing with CLI git 2.48.0.

### Testing done

Checked the plugin tests in the plugin repository.  Checked that the git client plugin tests pass locally for me in BOM.  Rely on ci.jenkins.io to test the rest of BOM.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
