### PR TITLE
reactivate the cron trigger for build on Friday

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,7 @@
 properties([
   disableConcurrentBuilds(abortPrevious: true),
   buildDiscarder(logRotator(numToKeepStr: '7')),
-  // TODO: Restore build schedule after end of year break
-  // pipelineTriggers([cron('18 04 * * 5')])
+  pipelineTriggers([cron('2 15 * * 5')])
 ])
 
 if (BRANCH_NAME == 'master' && currentBuild.buildCauses*._class == ['jenkins.branch.BranchEventCause']) {


### PR DESCRIPTION
Now that the holiday break is over, reactivate the cron trigger so non-admins have the job automatically start.

For this week, I set it to 9:02am Central / 15:02 UTC.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue