### PR TITLE
Revert versioncolumn 319.x upgrade

### DIFF
--- a/bom-2.462.x/pom.xml
+++ b/bom-2.462.x/pom.xml
@@ -360,11 +360,6 @@
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>versioncolumn</artifactId>
-        <version>243.vda_c20eea_a_8a_f</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>ws-cleanup</artifactId>
         <version>0.47</version>
       </dependency>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -1436,7 +1436,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>versioncolumn</artifactId>
-        <version>319.v052e2d416b_23</version>
+        <version>243.vda_c20eea_a_8a_f</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
## Revert versioncolumn 319.x upgrade

Test failures reported during BOM release, including:

* hudson.plugin.versioncolumn.VersionMonitorTest.testMonitor_VersionIsNull_NotIgnored
* hudson.plugin.versioncolumn.VersionMonitorTest.testMonitor_DifferentVersion_NotIgnored

This reverts commit 942ab4a543cf2aa5032cccd4b199e28243548483.

### Testing done

Confirmed that I see the test failure locally before this change and that the test passes after this change.  Command line to run the test is:

```
PLUGINS=versioncolumn LINE=weekly TEST=VersionMonitorTest bash ./local-test.sh
```

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
