### PR TITLE
Use git client 5.0.2 in the 2.452.x and 2.462.x lines

### DIFF
--- a/bom-2.462.x/pom.xml
+++ b/bom-2.462.x/pom.xml
@@ -234,7 +234,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>git-client</artifactId>
-        <version>5.0.0</version>
+        <version>5.0.2</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>

--- a/excludes.txt
+++ b/excludes.txt
@@ -18,9 +18,3 @@ org.jenkinsci.plugins.durabletask.BourneShellScriptTest
 
 # TODO tends to run out of memory
 org.jenkinsci.plugins.pipeline.modeldefinition.TriggersTest
-
-# TODO need this to ignore for git-client 2.452.x/2.462.x
-# TODO Remove when 2.462.x and 2.452.x are no longer supported BOM lines
-# TODO Real fix is in 6.1.1 but 2.452.x and 2.462.x only supports 5.0.0
-# TODO https://github.com/jenkinsci/git-client-plugin/pull/1242
-org.jenkinsci.plugins.gitclient.GitAPITest#testListRemoteBranches


### PR DESCRIPTION
## Use git client 5.0.2 in the 2.452.x and 2.462.x lines

The git client 5.0.0 automated tests unintentionally tested a command line git behavior that changed in command line git 2.48.0.  The test is fixed in git client plugin 5.0.2 and git client plugin 6.1.1.

More details are available in:

* https://github.com/jenkinsci/git-client-plugin/pull/1242

Resolves the test failure in the plugin BOM that required the addition of a test exclusion in:

* https://github.com/jenkinsci/bom/pull/4232
* https://github.com/jenkinsci/bom/pull/4233

### Testing done

* Confirmed that the test fails before this change with:

  `PLUGINS=git-client LINE=2.462.x TEST=GitAPITest bash ./local-test.sh`

* Confirmed that the test passes after this change with:

  `PLUGINS=git-client LINE=2.462.x TEST=GitAPITest bash ./local-test.sh`

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
