### PR TITLE
Bump `org.jenkins-ci.plugins:docker-workflow` from 592.v1001d948426c to 596.v3e6972b_46b_e2 in `/bom-weekly`

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -986,7 +986,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>docker-workflow</artifactId>
-        <version>596.v942f78663d94</version>
+        <version>596.v3e6972b_46b_e2</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -986,7 +986,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>docker-workflow</artifactId>
-        <version>595.v60cec912059b_</version>
+        <version>596.v942f78663d94</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
##  Test docker-workflow pre-release 596.v942f78663d94

The 595.v60cec912059b_ tests fail on the ci.jenkins.io agents that are used for BOM builds.  The failure message is:

> java.lang.IllegalArgumentException: No enum constant org.jenkinsci.plugins.docker.workflow.DockerTestUtil.DockerOsMode.  CANNOT CONNECT TO THE DOCKER DAEMON AT UNIX:///VAR/RUN/DOCKER.SOCK. IS THE DOCKER DAEMON RUNNING?

A pull request has been proposed to resolve the failure by skipping those tests on machines that have the docker executable available but the user does not have permission to use docker.  The pull request is:

* https://github.com/jenkinsci/docker-workflow-plugin/pull/336

This commit tests the build from the pull request

### Testing done

Ran local test successfully with

`LINE=weekly PLUGINS=docker-workflow TEST=InjectedTest bash local-test.sh`

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
