### PR TITLE
add exclusions

### DIFF
--- a/excludes.txt
+++ b/excludes.txt
@@ -19,7 +19,7 @@ org.jenkinsci.plugins.durabletask.BourneShellScriptTest
 # TODO tends to run out of memory
 org.jenkinsci.plugins.pipeline.modeldefinition.TriggersTest
 
-# TODO times out since move to AWS. Remove after 2.462.x falls off
+# TODO https://github.com/jenkinsci/build-timeout-plugin/pull/136 times out since move to AWS. Remove after 2.462.x falls off
 hudson.plugins.build_timeout.operations.AbortAndRestartOperationTest#abortAndRestartTwice
 
 # TODO times out since move to AWS. Remove after 2.462.x falls off

--- a/excludes.txt
+++ b/excludes.txt
@@ -22,5 +22,5 @@ org.jenkinsci.plugins.pipeline.modeldefinition.TriggersTest
 # TODO https://github.com/jenkinsci/build-timeout-plugin/pull/136 times out since move to AWS. Remove after 2.462.x falls off
 hudson.plugins.build_timeout.operations.AbortAndRestartOperationTest#abortAndRestartTwice
 
-# TODO times out since move to AWS. Remove after 2.462.x falls off
+# TODO https://github.com/jenkinsci/pipeline-graph-view-plugin/pull/592 times out since move to AWS. Remove after 2.462.x falls off
 io.jenkins.plugins.pipelinegraphview.utils.PipelineStepApiTest#gh362_stepsBeforeStepBlockGetValidStatus

--- a/excludes.txt
+++ b/excludes.txt
@@ -18,3 +18,9 @@ org.jenkinsci.plugins.durabletask.BourneShellScriptTest
 
 # TODO tends to run out of memory
 org.jenkinsci.plugins.pipeline.modeldefinition.TriggersTest
+
+# TODO times out since move to AWS. Remove after 2.462.x falls off
+hudson.plugins.build_timeout.operations.AbortAndRestartOperationTest#abortAndRestartTwice
+
+# TODO times out since move to AWS. Remove after 2.462.x falls off
+io.jenkins.plugins.pipelinegraphview.utils.PipelineStepApiTest#gh362_stepsBeforeStepBlockGetValidStatus


### PR DESCRIPTION
Pulling over the exclusions added when testing 2.492.2-rc. AWS seems to be running a little slower than Azure, so these tests sometimes work and sometimes don't because their timeouts are kicking in.

### Testing done

Tested in https://github.com/jenkinsci/bom/pull/4471

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
