### PR TITLE
Revert "chore(deps): bump org.jenkins-ci.plugins:htmlpublisher from 1.37 to 424.va_e57f1253461 in /bom-weekly"

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -1144,7 +1144,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>htmlpublisher</artifactId>
-        <version>424.va_e57f1253461</version>
+        <version>1.37</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Reverts jenkinsci/bom#4593 because of [this error](https://ci.jenkins.io/job/Tools/job/bom/job/master/4118/testReport/junit/org.jenkinsci.plugins.pipeline_model_definition/InjectedTest/pct_pipeline_model_definition_plugin_2_492_x___testPluginActive/).