### PR TITLE
Let Maven and the JVM define memory usage based on cgroup or host

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,1 +1,1 @@
--Xmx512m -XX:+TieredCompilation -XX:TieredStopAtLevel=1
+-XX:+TieredCompilation -XX:TieredStopAtLevel=1


### PR DESCRIPTION
Nowadays, the JVM is able to determine the amount of memory when running in a container (if a limit is applied).

Since the infra provides 12 Gb of memory to each pod agents, it is worth using it.

As I can see in my attempts in #4667 , looks like the agents are using way more memory and less CPUs. That ought to be proved right in a real life bom build.

<img width="1857" alt="Capture d’écran 2025-03-09 à 21 05 05" src="https://github.com/user-attachments/assets/dd9d539b-ddd6-49bb-a85a-8761aa8f0921" />
<img width="1854" alt="Capture d’écran 2025-03-09 à 21 05 16" src="https://github.com/user-attachments/assets/a43dd83b-28e7-4dd0-821e-b0d6c46f29d3" />
