### PR TITLE
Downgrade `jackson2-api`

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -1154,7 +1154,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>jackson2-api</artifactId>
-        <version>2.18.3-402.v74c4eb_f122b_2</version>
+        <version>2.17.0-389.va_5c7e45cd806</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Breaks

```
javaposse.jobdsl.plugin.actions.GeneratedConfigFilesBuildActionSpec
javaposse.jobdsl.plugin.actions.GeneratedJobsBuildActionSpec
javaposse.jobdsl.plugin.actions.GeneratedUserContentsBuildActionSpec
javaposse.jobdsl.plugin.actions.GeneratedViewsActionSpec
javaposse.jobdsl.plugin.actions.GeneratedViewsBuildActionSpec
javaposse.jobdsl.plugin.JenkinsJobManagementSpec
```

as seen in https://ci.jenkins.io/job/Tools/job/bom/job/PR-4663/3/