### PR TITLE
Revert "chore(deps): bump io.jenkins.plugins:eddsa-api from 0.3.0-13.v7cb_69ed68f00 to 0.3.0.1-16.vcb_4a_98a_3531c in /bom-weekly"

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -347,7 +347,7 @@
       <dependency>
         <groupId>io.jenkins.plugins</groupId>
         <artifactId>eddsa-api</artifactId>
-        <version>0.3.0.1-16.vcb_4a_98a_3531c</version>
+        <version>0.3.0-13.v7cb_69ed68f00</version>
       </dependency>
       <dependency>
         <groupId>io.jenkins.plugins</groupId>


### PR DESCRIPTION
Reverts jenkinsci/bom#4737

```

java.lang.IllegalStateException: Could not find a valid Docker environment. Please see logs and check configuration
	at org.testcontainers.dockerclient.DockerClientProviderStrategy.lambda$getFirstValidStrategy$7(DockerClientProviderStrategy.java:274)
	at java.base/java.util.Optional.orElseThrow(Optional.java:403)
	at org.testcontainers.dockerclient.DockerClientProviderStrategy.getFirstValidStrategy(DockerClientProviderStrategy.java:265)
	at org.testcontainers.DockerClientFactory.getOrInitializeStrategy(DockerClientFactory.java:154)
	at org.testcontainers.DockerClientFactory.client(DockerClientFactory.java:196)
	at org.testcontainers.DockerClientFactory$1.getDockerClient(DockerClientFactory.java:108)
	at com.github.dockerjava.api.DockerClientDelegate.authConfig(DockerClientDelegate.java:109)
	at org.testcontainers.containers.GenericContainer.start(GenericContainer.java:321)
	at org.testcontainers.containers.GenericContainer.starting(GenericContainer.java:1082)
	at org.testcontainers.containers.FailureDetectingExternalResource$1.evaluate(FailureDetectingExternalResource.java:28)
```