### PR TITLE
chore(Jenkinsfile) disable cron trigger outside the `master` branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,13 +1,13 @@
 // Do not trigger build regularly on change requests as it costs a lot
-def pipelineTriggers = []
+String cronTrigger = ''
 if(env.BRANCH_NAME == "master") {
-   pipelineTriggers << cron('45 07 * * 5')
+   cronTrigger = '45 07 * * 5'
 }
 
 properties([
   disableConcurrentBuilds(abortPrevious: true),
   buildDiscarder(logRotator(numToKeepStr: '7')),
-  pipelineTriggers(pipelineTriggers)
+  pipelineTriggers([cron(cronTrigger)])
 ])
 
 if (env.BRANCH_NAME == 'master' && currentBuild.buildCauses*._class == ['jenkins.branch.BranchEventCause']) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,10 +1,16 @@
+// Do not trigger build regularly on change requests as it costs a lot
+def pipelineTriggers = []
+if(env.BRANCH_NAME == "master") {
+   pipelineTriggers << cron('45 07 * * 5')
+}
+
 properties([
   disableConcurrentBuilds(abortPrevious: true),
   buildDiscarder(logRotator(numToKeepStr: '7')),
-  pipelineTriggers([cron('45 07 * * 5')])
+  pipelineTriggers(pipelineTriggers)
 ])
 
-if (BRANCH_NAME == 'master' && currentBuild.buildCauses*._class == ['jenkins.branch.BranchEventCause']) {
+if (env.BRANCH_NAME == 'master' && currentBuild.buildCauses*._class == ['jenkins.branch.BranchEventCause']) {
   currentBuild.result = 'NOT_BUILT'
   error 'No longer running builds on response to master branch pushes. If you wish to cut a release, use “Re-run checks” from this failing check in https://github.com/jenkinsci/bom/commits/master'
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 // Do not trigger build regularly on change requests as it costs a lot
 String cronTrigger = ''
 if(env.BRANCH_NAME == "master") {
-   cronTrigger = '45 07 * * 5'
+  cronTrigger = '45 07 * * 5'
 }
 
 properties([


### PR DESCRIPTION
As per https://github.com/jenkins-infra/helpdesk/issues/4600, we are having budget issues.

It looks like we are rebuilding regularly PRs with the current pipeline trigger syntax, which generates a LOT of costs since builds are retried many times.

Note: once merged we have to update all PRs to ensure that:
- Their Jenkinsfile is up to date
- Their pipeline trigger is updated by parsing the up to date trigger

<img width="940" alt="Capture d’écran 2025-03-20 à 14 29 19" src="https://github.com/user-attachments/assets/af3b79bd-aabe-44e2-93a2-eda35695ee12" />
