### PR TITLE
Drop support for migrating from `branch-api` 1.x to 2.x

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -13,9 +13,11 @@
     <aws-java-sdk2-plugin.version>2.30.28-26.v649b_8df2f988</aws-java-sdk2-plugin.version>
     <gcp-java-sdk-plugin.version>26.23.0-31.va_efec42c4f8c</gcp-java-sdk-plugin.version>
     <blueocean-plugin.version>1.27.17</blueocean-plugin.version>
-    <branch-api-plugin.version>2.1214.v3f652804588d</branch-api-plugin.version>
+    <!-- TODO https://github.com/jenkinsci/branch-api-plugin/pull/507 -->
+    <branch-api-plugin.version>2.1216.v0ec74b_47f9c3</branch-api-plugin.version>
     <checks-api.version>367.v18b_7f530e54a_</checks-api.version>
-    <cloudbees-folder-plugin.version>6.999.v42253c105443</cloudbees-folder-plugin.version>
+    <!-- TODO https://github.com/jenkinsci/cloudbees-folder-plugin/pull/480 -->
+    <cloudbees-folder-plugin.version>6.1000.v6f94d92154df</cloudbees-folder-plugin.version>
     <configuration-as-code-plugin.version>1953.v148f87d74b_1e</configuration-as-code-plugin.version>
     <data-tables-api.version>2.2.2-1</data-tables-api.version>
     <declarative-pipeline-migration-assistant-plugin.version>1.6.5</declarative-pipeline-migration-assistant-plugin.version>


### PR DESCRIPTION
https://github.com/jenkinsci/branch-api-plugin/pull/507
https://github.com/jenkinsci/cloudbees-folder-plugin/pull/480
