### PR TITLE
Pin Mina on older lines

### DIFF
--- a/bom-2.492.x/pom.xml
+++ b/bom-2.492.x/pom.xml
@@ -8,7 +8,9 @@
   </parent>
   <artifactId>bom-2.492.x</artifactId>
   <packaging>pom</packaging>
-  <properties />
+  <properties>
+    <mina-sshd-api.version>2.14.0-143.v2b_362fc39576</mina-sshd-api.version>
+  </properties>
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -27,6 +29,26 @@
         <groupId>io.jenkins.plugins</groupId>
         <artifactId>design-library</artifactId>
         <version>355.v0f007356e15d</version>
+      </dependency>
+      <dependency>
+        <groupId>io.jenkins.plugins.mina-sshd-api</groupId>
+        <artifactId>mina-sshd-api-common</artifactId>
+        <version>${mina-sshd-api.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.jenkins.plugins.mina-sshd-api</groupId>
+        <artifactId>mina-sshd-api-core</artifactId>
+        <version>${mina-sshd-api.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.jenkins.plugins.mina-sshd-api</groupId>
+        <artifactId>mina-sshd-api-scp</artifactId>
+        <version>${mina-sshd-api.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.jenkins.plugins.mina-sshd-api</groupId>
+        <artifactId>mina-sshd-api-sftp</artifactId>
+        <version>${mina-sshd-api.version}</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Fix the build failures seen in https://ci.jenkins.io/job/Tools/job/bom/job/master/4363/ on older lines:

```
Caused by: java.io.IOException: Failed to load: Mina SSHD API :: Common (mina-sshd-api-common 2.15.0-161.vb_200831a_c15b_)
 - Update required: EDDSA API Plugin (eddsa-api 0.3.0-4.v84c6f0f4969e) to be updated to 0.3.0.1-19.vc432d923e5ee or higher
```

### Testing done

`LINE=2.492.x PLUGINS=git,workflow-basic-steps,git-parameter,pipeline-groovy-lib,docker-workflow,build-failure-analyzer TEST=InjectedTest bash local-test.sh`