### PR TITLE
Test git client 6.1.3 incremental

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -1093,7 +1093,11 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>git-client</artifactId>
-        <version>6.1.2</version>
+        <!-- TODO: test in 6.1.2 fails with Apache Mina SSHD 2.15.0 -->
+        <!-- 6.1.3-rc3691.d370da_2808ef is the incremental before the assertion is disabled (fails) -->
+        <!-- TODO: assertion disabled in 6.1.3 incremental -->
+        <!-- 6.1.3-rc3692.0c73d1414381 is the incremental after the assertion is disabled (passes) -->
+        <version>6.1.3-rc3692.0c73d1414381</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
## Test git client 6.1.3 incremental

Test in git client 6.1.2 fails with Apache Mina SSHD 2.15.0.

https://github.com/jenkinsci/git-client-plugin/pull/1274 improves the tests on the git client master branch so that the plugin is ready for JGit 7.2.0 and its requirement for Apache Mina SSHD 2.15.0.

Test assertion is disabled on the git client 6.1.3 branch so that it will pass the test with both Apache Mina SSHD 2.14.x and with Apache Mina SSHD 2.15.0.

### Testing done

Confirmed git client plugin tests in plugin BOM fail on the weekly line
before the assertion is disabled.  Confirmed that with the changes in
the incremental in this pull request, the git client plugin tests pass
in plugin BOM on the weekly line.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
