### PR TITLE
Revert "chore(deps): bump io.jenkins.plugins:echarts-api from 5.6.0-2 to 5.6.0-3 in /bom-weekly"

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -342,7 +342,7 @@
       <dependency>
         <groupId>io.jenkins.plugins</groupId>
         <artifactId>echarts-api</artifactId>
-        <version>5.6.0-3</version>
+        <version>5.6.0-2</version>
       </dependency>
       <dependency>
         <groupId>io.jenkins.plugins</groupId>


### PR DESCRIPTION
Reverts jenkinsci/bom#4878

https://github.com/jenkinsci/echarts-api-plugin/pull/387#issuecomment-2798877228