### PR TITLE
Update release lead calendar

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,18 +6,18 @@ For people potentially working on the BOM itself, not just consuming it.
 
 | Release Date | Lead                 |
 | ------------ | -------------------- |
-| 2025-04-04   | Basil Crow           |
-| 2025-04-11   | Basil Crow           |
 | 2025-04-18   | Adrien Lecharpentier |
 | 2025-04-25   | Adrien Lecharpentier |
 | 2025-05-02   | Darin Pope           |
 | 2025-05-09   | Darin Pope           |
 | 2025-05-16   | Kris Stern           |
 | 2025-05-23   | Kris Stern           |
-| 2025-05-30   | Bruno Verachten      |
-| 2025-06-06   | Bruno Verachten      |
-| 2025-06-13   | Mark Waite           |
-| 2025-06-20   | Mark Waite           |
+| 2025-05-30   | Mark Waite           |
+| 2025-06-06   | Mark Waite           |
+| 2025-06-13   | Basil Crow           |
+| 2025-06-20   | Basil Crow           |
+| 2025-06-27   | Bruno Verachten      |
+| 2025-07-04   | Bruno Verachten      |
 
 ## Updating a plugin
 


### PR DESCRIPTION
## Update release lead calendar

Move Bruno Verachten's assignment as release lead to be later so that Bruno covers the BOM release instead of Basil on 4 Jul 2025.  That day is a public holiday for Basil in the U.S.

Avoids the week of Establishment Day (1 Jul 2025) in Hong Kong for Kris Stern.

Avoids Labour Day (1 May 2025), Victory in Europe Day (8 May 2025), and Bastille Day (14 Jul 2025) in France for Bruno Verachten.

Avoids Memorial Day (26 May 2025) in the U.S. for Mark Waite.

Alternative proposals are welcomed.

### Testing done

Reviewed public holiday calendars for release leads and tried to find a reasonable compromise for all release leads.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
