### PR TITLE
Bump promoted-builds from 984.v90b_eb_99fc7b_4 to 992.va_00888f21b_74 in /bom-weekly

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -1440,7 +1440,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>promoted-builds</artifactId>
-        <version>984.v90b_eb_99fc7b_4</version>
+        <version>992.va_00888f21b_74</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
The promoted-builds [992.va_00888f21b_74](https://github.com/jenkinsci/promoted-builds-plugin/releases/tag/992.va_00888f21b_74) was released on April 15, dependabot doesn't seem to be creating PR due to https://github.com/dependabot/dependabot-core/issues/12096

I would like this plugin bumped for my other PR https://github.com/jenkinsci/bom/pull/4888/ where I am testing the bom-weekly all PCT passing.

Change set is [984.v90b_eb_99fc7b_4...992.va_00888f21b_74](https://github.com/jenkinsci/promoted-builds-plugin/compare/984.v90b_eb_99fc7b_4...992.va_00888f21b_74). Looks non harmful.

### Testing done

CI to pass

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue