### PR TITLE
Bump unique-id from 2.113.va_25f74db_66a_b_ to 2.117.v7a_81333a_584b_ in /bom-weekly

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -1607,7 +1607,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>unique-id</artifactId>
-        <version>2.113.va_25f74db_66a_b_</version>
+        <version>2.117.v7a_81333a_584b_</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Due to https://github.com/dependabot/dependabot-core/issues/12096 dependabot is not creating bump PRs. The release happened 4 days ago in unique-id plugin for [2.117.v7a_81333a_584b_](https://github.com/jenkinsci/unique-id-plugin/releases/tag/2.117.v7a_81333a_584b_)

I would like this update for my other PR https://github.com/jenkinsci/bom/pull/4888

Change set: [2.113.va_25f74db_66a_b_...2.117.v7a_81333a_584b_](https://github.com/jenkinsci/unique-id-plugin/compare/2.113.va_25f74db_66a_b_...2.117.v7a_81333a_584b_)

### Testing done

CI to pass

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
