### PR TITLE
Add Jobcacher S3 Storage Extension to managed set

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -589,6 +589,11 @@
       </dependency>
       <dependency>
         <groupId>io.jenkins.plugins</groupId>
+        <artifactId>s3-jobcacher-storage</artifactId>
+        <version>16.v1f404a_3a_2377</version>
+      </dependency>
+      <dependency>
+        <groupId>io.jenkins.plugins</groupId>
         <artifactId>snakeyaml-api</artifactId>
         <version>2.3-125.v4d77857a_b_402</version>
       </dependency>

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -521,6 +521,11 @@
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
+      <artifactId>s3-jobcacher-storage</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
       <artifactId>snakeyaml-api</artifactId>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
Add Jobcacher S3 Storage Extension to managed set

### Testing done

* `LINE=weekly PLUGINS=s3-jobcacher-storage bash local-test.sh`
* `LINE=2.492.x PLUGINS=s3-jobcacher-storage bash local-test.sh`
* `LINE=2.479.x PLUGINS=s3-jobcacher-storage bash local-test.sh`

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue