### PR TITLE
Pin kubernetes-credentials-provider and blueocean for 2.479.x

### DIFF
--- a/bom-2.479.x/pom.xml
+++ b/bom-2.479.x/pom.xml
@@ -18,6 +18,11 @@
         <scope>import</scope>
       </dependency>
       <dependency>
+        <groupId>com.cloudbees.jenkins.plugins</groupId>
+        <artifactId>kubernetes-credentials-provider</artifactId>
+        <version>1.276.v99a_de03cb_076</version>
+      </dependency>
+      <dependency>
         <groupId>io.jenkins.blueocean</groupId>
         <artifactId>blueocean-parent</artifactId>
         <version>1.27.19</version>
@@ -61,11 +66,6 @@
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>javadoc</artifactId>
         <version>280.v050b_5c849f69</version>
-      </dependency>
-      <dependency>
-        <groupId>com.cloudbees.jenkins.plugins</groupId>
-        <artifactId>kubernetes-credentials-provider</artifactId>
-        <version>1.276.v99a_de03cb_076</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>

--- a/bom-2.479.x/pom.xml
+++ b/bom-2.479.x/pom.xml
@@ -63,7 +63,7 @@
         <version>280.v050b_5c849f69</version>
       </dependency>
       <dependency>
-        <groupId>org.jenkins-ci.plugins</groupId>
+        <groupId>com.cloudbees.jenkins.plugins</groupId>
         <artifactId>kubernetes-credentials-provider</artifactId>
         <version>1.276.v99a_de03cb_076</version>
       </dependency>

--- a/bom-2.479.x/pom.xml
+++ b/bom-2.479.x/pom.xml
@@ -62,6 +62,11 @@
         <artifactId>pipeline-utility-steps</artifactId>
         <version>2.18.0</version>
       </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>kubernetes-credentials-provider</artifactId>
+        <version>1.276.v99a_de03cb_076</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 </project>

--- a/bom-2.479.x/pom.xml
+++ b/bom-2.479.x/pom.xml
@@ -18,6 +18,11 @@
         <scope>import</scope>
       </dependency>
       <dependency>
+        <groupId>io.jenkins.blueocean</groupId>
+        <artifactId>blueocean-parent</artifactId>
+        <version>1.27.19</version>
+      </dependency>
+      <dependency>
         <groupId>io.jenkins.plugins</groupId>
         <artifactId>analysis-model-api</artifactId>
         <version>12.4.0</version>
@@ -59,13 +64,13 @@
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>pipeline-utility-steps</artifactId>
-        <version>2.18.0</version>
+        <artifactId>kubernetes-credentials-provider</artifactId>
+        <version>1.276.v99a_de03cb_076</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>kubernetes-credentials-provider</artifactId>
-        <version>1.276.v99a_de03cb_076</version>
+        <artifactId>pipeline-utility-steps</artifactId>
+        <version>2.18.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -1674,14 +1674,14 @@
         <version>2.1.1</version>
         <dependencies>
           <dependency>
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-all</artifactId>
-            <version>2.4.21</version>
-          </dependency>
-          <dependency>
             <groupId>com.cloudbees.jenkins.plugins</groupId>
             <artifactId>kubernetes-credentials-provider</artifactId>
             <version>1.276.v99a_de03cb_076</version>
+          </dependency>
+          <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-all</artifactId>
+            <version>2.4.21</version>
           </dependency>
         </dependencies>
         <executions>

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -1677,6 +1677,7 @@
             <groupId>com.cloudbees.jenkins.plugins</groupId>
             <artifactId>kubernetes-credentials-provider</artifactId>
             <version>1.276.v99a_de03cb_076</version>
+            <scope>test</scope>
           </dependency>
           <dependency>
             <groupId>org.codehaus.groovy</groupId>

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -1674,12 +1674,6 @@
         <version>2.1.1</version>
         <dependencies>
           <dependency>
-            <groupId>com.cloudbees.jenkins.plugins</groupId>
-            <artifactId>kubernetes-credentials-provider</artifactId>
-            <version>1.276.v99a_de03cb_076</version>
-            <scope>test</scope>
-          </dependency>
-          <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
             <version>2.4.21</version>

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -1678,6 +1678,11 @@
             <artifactId>groovy-all</artifactId>
             <version>2.4.21</version>
           </dependency>
+          <dependency>
+            <groupId>com.cloudbees.jenkins.plugins</groupId>
+            <artifactId>kubernetes-credentials-provider</artifactId>
+            <version>1.276.v99a_de03cb_076</version>
+          </dependency>
         </dependencies>
         <executions>
           <execution>


### PR DESCRIPTION
### Description
Encountering issues with weekly release. Attempting to resolve by pinning pin-kubernetes-credentials-provider and blueocean to 2.792.x. 

<!-- Please describe your pull request here. -->

<!-- ### Testing done -->

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
