### PR TITLE
Fix error in Jackson API exclusion

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,7 +24,7 @@ updates:
       # Jackson 2 API 2.19.0-404.vb_b_0fd2fea_e10 is harmful to Kubernetes agents
       # https://github.com/fabric8io/kubernetes-client/issues/7107
       # https://issues.jenkins.io/browse/JENKINS-75712
-      - dependency-name: "org.jenkins-ci.plugins.jackson2-api"
+      - dependency-name: "org.jenkins-ci.plugins:jackson2-api"
         versions: ["2.19.0-404.vb_b_0fd2fea_e10"]
     labels:
       # dependency updates to plugin BOM are developer relevant changes


### PR DESCRIPTION
## Fix error in Jackson 2 API dependabot exclusion

Use ":" to separate groupId and artifactId

### Testing done

Compared with the working exclusion that precedes it in the file.  Verified that dependeabot refers to Maven dependencies as groupId:artifactId by reading the log file.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
