### PR TITLE
Only test newest and oldest lines to reduce costs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -94,6 +94,7 @@ stage('prep') {
       pluginsByRepository = parsePlugins(plugins)
 
       lines = readFile('lines.txt').split('\n')
+      lines = [lines[0], lines[-1]] // Save resources by running PCT only on newest and oldest lines
       withCredentials([string(credentialsId: 'launchable-jenkins-bom', variable: 'LAUNCHABLE_TOKEN')]) {
         lines.each { line ->
           def commitHashes = readFile "commit-hashes-${line}.txt"


### PR DESCRIPTION
## Only test newest and oldest lines to reduce costs

Tests rarely detect issues on lines other than the newest and the oldest lines.  Accept the risk that some cases might be missed in the middle lines in order to reduce the BOM release cost.

Fixes #2695 

### Testing done

None.  Rely on ci.jenkins.io to test the change.  Copied from an earlier commit.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
