### PR TITLE
Add `aws-java-sdk2-sso` to BOM

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -758,6 +758,11 @@
         <version>${aws-java-sdk2-plugin.version}</version>
       </dependency>
       <dependency>
+        <groupId>io.jenkins.plugins.aws-java-sdk2</groupId>
+        <artifactId>aws-java-sdk2-sso</artifactId>
+        <version>${aws-java-sdk2-plugin.version}</version>
+      </dependency>
+      <dependency>
         <groupId>io.jenkins.plugins.mina-sshd-api</groupId>
         <artifactId>mina-sshd-api-common</artifactId>
         <version>${mina-sshd-api.version}</version>

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -690,6 +690,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>io.jenkins.plugins.aws-java-sdk2</groupId>
+      <artifactId>aws-java-sdk2-sso</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>io.jenkins.plugins.mina-sshd-api</groupId>
       <artifactId>mina-sshd-api-scp</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
https://github.com/jenkinsci/artifact-manager-s3-plugin/pull/635 reminded me to check https://github.com/jenkinsci/artifact-manager-s3-plugin/pull/619#discussion_r2097907514 and while https://github.com/jenkinsci/aws-java-sdk2-plugin/pull/68 was released as https://github.com/jenkinsci/aws-java-sdk2-plugin/releases/tag/2.31.45-42.va_ffb_565de208 #5055 https://github.com/jenkinsci/bom/releases/tag/4836.vdf03ded1f27c it is not usable from a BOM import yet.