### PR TITLE
Pin kubernetes plugins for 2.492.x due to kubernetes-credentials-provider

### DIFF
--- a/bom-2.492.x/pom.xml
+++ b/bom-2.492.x/pom.xml
@@ -72,6 +72,11 @@
         <version>${mina-sshd-api.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.csanchez.jenkins.plugins</groupId>
+        <artifactId>kubernetes</artifactId>
+        <version>4353.vb_47977da_9417</version>
+      </dependency>
+      <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>copyartifact</artifactId>
         <version>761.vea_2b_25523e84</version>
@@ -80,6 +85,21 @@
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>git-client</artifactId>
         <version>6.1.3</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>jackson2-api</artifactId>
+        <version>2.18.3-402.v74c4eb_f122b_2</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>kubernetes-client-api</artifactId>
+        <version>6.10.0-251.v556f5f100500</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkinsci.plugins</groupId>
+        <artifactId>kubernetes-credentials</artifactId>
+        <version>192.v4d5b_1c429d17</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
## Pin kubernetes plugins for 2.492.x due to kubernetes-credentials-provider

The kubernetes-credentials-provider had to be pinned for 2.492.x because the latest release requires 2.504.1 or newer due to its dependency on openstack-cloud plugin.

Pin the updated plugins so that the kubernetes-credentials-provider tests pass.

### Testing done

Confirmed that this fails without the change:

```
PLUGINS=kubernetes-credentials-provider TEST=KubernetesCredentialsProviderTest#credentialScope LINE=2.492.x bash ./local-test.sh
```

and passes with the change

Initially detected while evaluating:

* https://github.com/jenkinsci/bom/pull/5243

Test failure visible in CI job:

* https://ci.jenkins.io/job/Tools/job/bom/job/PR-5243/3/testReport/

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
