### PR TITLE
Pipeline replay can sometimes avoid a rebuild to update GitHub checks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,6 +164,15 @@ If that build passes, a release should be published automatically when PRs match
 For the common case that only lots of `dependencies` PRs have been merged,
 the release can be triggered manually from the **Actions** tab after a `master` build has succeeded.
 
+If a `master` build succeeds but does not notify GitHub of the success, the release process will not run.
+In one case where that happened, we were able to replay the Pipeline on the `master` branch to show the failing test was passing.
+The Pipeline replay was:
+
+```
+publishChecks(name: 'pct-blueocean-plugin-weekly')
+echo 'OK'
+```
+
 ## Incrementals
 
 This repository is integrated with “Incrementals” [JEP-305](https://jenkins.io/jep/305):


### PR DESCRIPTION
## Pipeline replay can sometimes avoid a rebuild to update GitHub checks

The GitHub checks were somehow notified by an outdated failing build after the succeeding build.  That prevented a release.  Describe the workaround that Damien Duportal applied while Mark Waite and Adrien Lecharpentier were watching.  

### Testing done

Mark and Adrien reviewed the Pipeline replay while Damien was launching it.  We confirmed that it worked as expected and the plugin BOM release was able to complete.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
