### PR TITLE
Test docker java API, git client, and git plugin pre-releases

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -21,7 +21,7 @@
     <declarative-pipeline-migration-assistant-plugin.version>1.6.5</declarative-pipeline-migration-assistant-plugin.version>
     <forensics-api.version>3.1.0</forensics-api.version>
     <github-api-plugin.version>1.321-488.v9b_c0da_9533f8</github-api-plugin.version>
-    <git-plugin.version>5.7.0</git-plugin.version>
+    <git-plugin.version>5.7.1-rc5454.fa_ee06b_847ec</git-plugin.version>
     <junit-plugin.version>1335.v6b_a_a_e18534e1</junit-plugin.version>
     <mina-sshd-api.version>2.15.0-161.vb_200831a_c15b_</mina-sshd-api.version>
     <okhttp-api-plugin.version>4.11.0-189.v976fa_d3379d6</okhttp-api-plugin.version>
@@ -1052,7 +1052,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>docker-java-api</artifactId>
-        <version>3.5.2-119.v54c784c71fa_3</version>
+        <version>3.5.3-120.v7040fa_ec0d71</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
@@ -1128,7 +1128,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>git-client</artifactId>
-        <version>6.2.0</version>
+        <version>6.2.1-rc3761.0ec8ffc3f299</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
## Test docker java API, git client, and git plugin pre-releases

Docker Java API update from 3.5.2 to 3.5.3 from pull request:

* https://github.com/jenkinsci/docker-java-api-plugin/pull/138

Bumps the netty version dependency inside the API plugin from 4.1.119 to 4.2.2 but the Jenkins netty plugin is 4.1.118.  Need to confirm that does not cause issues in plugin BOM tests.

Git plugin update from 5.7.0 to 5.8.0 includes pull request:

* https://github.com/jenkinsci/git-plugin/pull/1776

That fixes [JENKINS-75854](https://issues.jenkins.io/browse/JENKINS-75854) and adjusts the git plugin multibranch Pipeline scan to only request tags if the Discover Tags trait is associated with the scan.

Git client plugin update from 6.2.0 to 6.3.0 increases the minimum Jenkins version from 2.479.3 to 2.504.1.  Other changes are dependency updates and the replacement of Commons Lang 2 with Commons Lang 3.

### Testing done

```
PLUGINS=git,git-client,docker-plugin LINE=weekly bash ./local-test.sh
```

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
