### PR TITLE
Add jspecify API to the managed set

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -517,6 +517,11 @@
       </dependency>
       <dependency>
         <groupId>io.jenkins.plugins</groupId>
+        <artifactId>jspecify-api</artifactId>
+        <version>1.0.0-1.ve7231e6d0d15</version>
+      </dependency>
+      <dependency>
+        <groupId>io.jenkins.plugins</groupId>
         <artifactId>locale</artifactId>
         <version>597.v7781ce70d4cf</version>
       </dependency>

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -465,6 +465,11 @@
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
+      <artifactId>jspecify-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
       <artifactId>locale</artifactId>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
Add jspecify API to the managed set. 

Need to add in order for the latest `oras-java-api` (it'll need a little more work) to be updated because it's newest version added a dependency on jspecify. This addition [caused the problem](https://ci.jenkins.io/job/Tools/job/bom/view/change-requests/job/PR-5539/1/pipeline-overview/):

```
[ERROR] Failed to execute goal org.codehaus.gmaven:groovy-maven-plugin:2.1.1:execute (default) on project sample: Plugin dependency on io.jenkins.plugins:jspecify-api is not from dependencyManagement -> [Help 1]
```

### Testing done

* `LINE=weekly PLUGINS=jspecify-api bash local-test.sh`
* `LINE=2.516.x PLUGINS=jspecify-api bash local-test.sh`
* `LINE=2.504.x PLUGINS=jspecify-api bash local-test.sh`
* `LINE=2.492.x PLUGINS=jspecify-api bash local-test.sh`

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed