### PR TITLE
Use git client plugin 6.1.4 with 2.492.x line

### DIFF
--- a/bom-2.492.x/pom.xml
+++ b/bom-2.492.x/pom.xml
@@ -220,7 +220,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>git-client</artifactId>
-        <version>6.1.3</version>
+        <version>6.1.4</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
## Use git client plugin 6.1.4 with 2.492.x line

Need CLI git 2.51.0 support because the ci.jenkins.io agents have upgraded to command line git 2.51.0 and that needs a newer version of git client plugin with a fix for [JENKINS-76004](https://issues.jenkins.io/browse/JENKINS-76004).  Also includes fixes for [JENKINS-76026](https://issues.jenkins.io/browse/JENKINS-76026) and [SECURITY-3590](https://www.jenkins.io/security/advisory/2025-09-03/#SECURITY-3590).

### Testing done

Confirmed that tests fail without this change when the agent has git 2.51.0 installed.

Confirmed thta tests pass with this change when the agent has git 2.51.0 installed.

Test command is:

```
PLUGINS=git-client LINE=2.492.x TEST=CliGitAPIImplTest#testChangelogBounded bash ./local-test.sh
```

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
