### PR TITLE
Use git client 6.1.5 for 2.492.x line

### DIFF
--- a/bom-2.492.x/pom.xml
+++ b/bom-2.492.x/pom.xml
@@ -226,7 +226,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>git-client</artifactId>
-        <version>6.1.4</version>
+        <version>6.1.5</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
## Use git client 6.1.5 for 2.492.x line

Git client plugin tests that use GitHub to test large file support (LFS) have been failing more frequently with a 'bad credentials' message.  The failures are significantly reduced when a credential is used for the checkout.

Git LFS tests in git client plugin 6.1.5 have been adapted in the same way that tests were adapted in git client plugin 6.4.0.  If a credential is not available on the file system where the test is run, then the test will be skipped.  The credential is to the public repository https://github.com/MarkEWaite/jenkins-pipeline-utils .

The credential is not stored in the git client plugin source code because I don't want GitHub scanners to complain about a leaked security token.  I have installed the token on the agents that I use for testing so that the tests are regularly run in my environment.

I'm willing to share the credential with anyone that wants it, since it is a credential to a public repository and grants no additional permissions.

Refer to git client plugin pull requests:

* https://github.com/jenkinsci/git-client-plugin/pull/1341
* https://github.com/jenkinsci/git-client-plugin/pull/1337

### Testing done

Confirmed that the most common failing test passes locally with:

```
LINE=2.492.x PLUGINS=git-client TEST=GitClientTest#testSparseCheckoutWithCliGitLFS bash ./local-test.sh
```

Confirmed that the most common failing test runs no assertions (and is much faster) if I remove the local copy of the credential.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
