### PR TITLE
Schedule next week's BOM release for late Thursday Denver time

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 // Do not trigger build regularly on change requests as it costs a lot
 String cronTrigger = ''
 if(env.BRANCH_NAME == "master") {
-  cronTrigger = '00 11 * * 5'
+  cronTrigger = '59 23 * * 4' // Thursday evening in Denver, Colorado, USA (almost midnight UTC)
 }
 
 properties([


### PR DESCRIPTION
## Schedule next week's BOM release for late Thursday Denver time

That is a low use time for ci.jenkins.io and is an easier time for me to watch the job as the release lead for the week.

Do not merge while the current release build is running.

### Testing done

Checked the cron expression with Google Gemini.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
