### PR TITLE
Exclude ldap and azure-vm-agents tests of configuration as code

### DIFF
--- a/excludes.txt
+++ b/excludes.txt
@@ -17,3 +17,9 @@ org.jenkinsci.plugins.pipeline.modeldefinition.TriggersTest
 
 # TODO Blue Ocean Bitbucket test fails for Wiremock mismatch: https://github.com/jenkinsci/blueocean-plugin/pull/2654
 io.jenkins.blueocean.blueocean_bitbucket_pipeline.server.BitbucketPipelineCreateRequestTest
+
+# TODO Remove when 2.504.x line is dropped https://github.com/jenkinsci/bom/pull/5751#issuecomment-3338544666
+# CasC output updated in new release but the ldap and azure-vm-agents releases with the updated test require 2.516.x or newer
+com.microsoft.azure.vmagent.test.jcasc.AdvancedConfigAsCodeTest#exportExportConfiguration
+com.microsoft.azure.vmagent.test.jcasc.BasicConfigAsCodeTest#exportBasicConfiguration
+jenkins.security.plugins.ldap.CascSecurityRealmTest#export_ldap_no_secret


### PR DESCRIPTION
## Exclude ldap and azure-vm-agents tests of configuration as code

Configuration as code plugin 1985.vdda_32d0c4ea_b_ includes the 'allow empty map' fix from pull request:

* https://github.com/jenkinsci/configuration-as-code-plugin/pull/2712

That fix needed changes in the tests of 3 plugins:

* azure-vm-agents: AdvancedConfigAsCodeTest.exportExportConfiguration and BasicConfigAsCodeTest.exportBasicConfiguration
* github-branch-source: GitHubAppCredentialsJCasCCompatibilityTest.should_support_configuration_export
* ldap: CascSecurityRealmTest.export_ldap_no_secret

All 3 of those plugins have been released with updated tests to adapt to the improved behavior of Configuration as code plugin 1985.vdda_32d0c4ea_b_, but the azure-vm-agents and ldap releases both require 2.516.x.  Exclude those tests until we drop plugin BOM support for the 2.504.x line.

Detected in tests of 2.528.1-rc by @lemeurherve in pull request:

* https://github.com/jenkinsci/bom/pull/5770

Was not detected with last week's BOM release because in order to save money we only test the weekly, oldest, and newest LTS versions when performing a plugin BOM release.  Last week, 2.504.x was not included in that test because we tested 2.492.x, 2.516.x, and weekly.  This week we dropped the 2.492.x line and added the 2.528.x line, so we will test 2.504.x, 2.528.x, and weekly.

### Testing done

None.  Rely on ci.jenkins.io

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
