### PR TITLE
Test core with Jetty 12.1.1 and Winstone 8.14

### DIFF
--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -14,7 +14,7 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <bom>weekly</bom>
-    <jenkins.version>2.530</jenkins.version>
+    <jenkins.version>2.531-rc37559.5767de9a_b_d74</jenkins.version>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>
   <dependencyManagement>


### PR DESCRIPTION
The core build 2.531-rc37559.5767de9a_b_d74 includes Winstone 8.14 and Jetty 12.1.1

The upgrade to Jetty 12.1.1 in plugin BOM is currently blocked by http request plugin test failures.  This is part of the investigation of Jetty 12.1.1

### Testing done

Tests are passing in core as part of:

* https://github.com/jenkinsci/jenkins/pull/10988

Upgrade is blocked in plugin BOM as part of:

* https://github.com/jenkinsci/bom/pull/5759

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
