### PR TITLE
Update `jenkins.version` to `2.528.1`

### DIFF
--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -1761,8 +1761,7 @@
       <id>2.528.x</id>
       <properties>
         <bom>2.528.x</bom>
-        <!-- TODO: Replace with 2.528.1 when released https://github.com/jenkins-infra/release/issues/762 -->
-        <jenkins.version>2.528</jenkins.version>
+        <jenkins.version>2.528.1</jenkins.version>
       </properties>
     </profile>
     <profile>


### PR DESCRIPTION
This PR updates `jenkins.version` to `2.528.1` in sample-plugin/pom.xml post LTS release.

Ref:
- https://github.com/jenkins-infra/release/issues/762

### Testing done

N/A

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
