### PR TITLE
Test gitlab API 6.2.0 coordinated update

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -427,12 +427,12 @@
       <dependency>
         <groupId>io.jenkins.plugins</groupId>
         <artifactId>gitlab-api</artifactId>
-        <version>5.8.1-106.vef1de800710e</version>
+        <version>6.2.0-129.v770352b_103a_6</version>
       </dependency>
       <dependency>
         <groupId>io.jenkins.plugins</groupId>
         <artifactId>gitlab-branch-source</artifactId>
-        <version>724.v6e30226050b_3</version>
+        <version>734.v0de96a_c7d739</version>
       </dependency>
       <dependency>
         <groupId>io.jenkins.plugins</groupId>
@@ -1194,12 +1194,12 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>gitlab-logo</artifactId>
-        <version>221.v4041f5e65573</version>
+        <version>230.v55939e9c183d</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>gitlab-oauth</artifactId>
-        <version>1.23</version>
+        <version>1.24-rc666.3643a_b_77dd6f</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
## Test gitlab API 6.2.0 coordinated update

Rather than create a compatibility layer for the breaking changes between GitLab API 5.8 and 6.x, we're planning a coordinated release of the API plugin and the three plugins that depend on it.  Users will need to upgrade the API plugin and the dependent plugins at the same time.

Tests the following 4 pull requests:

* https://github.com/jenkinsci/gitlab-api-plugin/pull/121
* https://github.com/jenkinsci/gitlab-branch-source-plugin/pull/517
* https://github.com/jenkinsci/gitlab-logo-plugin/pull/133
* https://github.com/jenkinsci/gitlab-oauth-plugin/pull/201

### Testing done

* Confirmed the 6.2.0 API upgrade works in each of the pull requests
* Confirmed this set of changes pass their own tests locally on the weekly line

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
