### PR TITLE
Test JUnit plugin upgrade that adds prism-api to Jenkins war

### DIFF
--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -14,7 +14,9 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <bom>weekly</bom>
-    <jenkins.version>2.541</jenkins.version>
+    <!-- TODO: https://github.com/jenkinsci/jenkins/pull/11335 -->
+    <!-- junit plugin upgrade needs to bundle prism-api as dependency -->
+    <jenkins.version>2.542-rc37802.c626a_a_32a_09c</jenkins.version>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>
   <dependencyManagement>


### PR DESCRIPTION
## Test JUnit plugin upgrade that adds prism-api to Jenkins war

The most recent release of the JUnit plugin adds a dependency on the prism-api plugin.  That plugin needs to be added to the Jenkins war file.  This pull request is trying to assess if that addition causes surprises or issues.

Pull request:

* https://github.com/jenkinsci/jenkins/pull/11335

### Testing done

Confirmed that a few tests pass with local run.  Rely on ci.jenkins.io for full test.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
