### PR TITLE
Fix renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,10 +4,13 @@
     "github>jenkinsci/renovate-config",
     "schedule:daily"
   ],
-  "enabledManagers": [
-    "custom.regex"
-  ],
   "automerge": true,
+  "ignoreDeps": [
+    "io.jenkins.tools.bom:parent"
+  ],
+  "ignorePaths": [
+    "bom-*.x/pom.xml"
+  ],
   "customManagers": [
     {
       "customType": "regex",
@@ -40,7 +43,6 @@
       "matchFileNames": [
         "sample-plugin/**"
       ],
-      "automerge": true,
       "prConcurrentLimit": 10,
     },
     {
@@ -48,7 +50,6 @@
       "matchFileNames": [
         "bom-weekly/**"
       ],
-      "automerge": true,
       "prConcurrentLimit": 25,
       // dependency updates to plugin BOM are developer relevant changes
       // developer label assures CD process will release with this change
@@ -82,6 +83,5 @@
         "weekly-test"
       ]
     }
-  ],
-  "rebaseWhen": "conflicted"
+  ]
 }


### PR DESCRIPTION
Minor corrections for #6193

* Remove `enabledManagers` override
* Ignores `io.jenkins.tools.bom:parent` (local parent, can't be updated / resolved)
* Ignore updates for `bom-*.x/pom.xml`
* Remove duplications already defined in `github>jenkinsci/renovate-config`

### Testing done

Tested in https://github.com/strangelookingnerd/bom-renovate-test

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed