### PR TITLE
Add calendars and cron plugins

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -258,6 +258,11 @@
       </dependency>
       <dependency>
         <groupId>io.jenkins.plugins</groupId>
+        <artifactId>calendar-view</artifactId>
+        <version>0.4.1</version>
+      </dependency>
+      <dependency>
+        <groupId>io.jenkins.plugins</groupId>
         <artifactId>checks-api</artifactId>
         <version>${checks-api.version}</version>
       </dependency>
@@ -357,6 +362,11 @@
         <groupId>io.jenkins.plugins</groupId>
         <artifactId>emoji-symbols-api</artifactId>
         <version>17.0-57.v8d44b_9a_b_d5ea_</version>
+      </dependency>
+      <dependency>
+        <groupId>io.jenkins.plugins</groupId>
+        <artifactId>extended-timer-trigger</artifactId>
+        <version>50.v1dde6750f820</version>
       </dependency>
       <dependency>
         <groupId>io.jenkins.plugins</groupId>
@@ -1031,6 +1041,11 @@
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>cron_column</artifactId>
+        <version>106.v492da_45b_051b_</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>dashboard-view</artifactId>
         <version>2.558.v96b_901978e47</version>
       </dependency>
@@ -1376,6 +1391,11 @@
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>naginator</artifactId>
         <version>1.530.vb_6d120f250b_1</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>next-executions</artifactId>
+        <version>517.vc2c2ca_1b_c808</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -248,6 +248,11 @@
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
+      <artifactId>calendar-view</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
       <artifactId>checks-api</artifactId>
       <scope>test</scope>
     </dependency>
@@ -334,6 +339,11 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>emoji-symbols-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>extended-timer-trigger</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -926,6 +936,11 @@
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>cron_column</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>dashboard-view</artifactId>
       <scope>test</scope>
     </dependency>
@@ -1215,6 +1230,11 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>naginator</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>next-executions</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Plugins

- extended-timer-trigger
- cron_column
- next-executions
- calendar-view
- parameterized-scheduler (already on bom)

Have a very tight coupling to display job execution (column, widget, calendar etc...)

I think it's worth to have them on bom to prevent API incompatibilities 

### Testing done

```
PLUGINS=extended-timer-trigger,cron_column,next-executions,calendar-view,parameterized-scheduler TEST=InjectedTest bash local-test.sh
```

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
