### PR TITLE
Remove sbt plugin test exclusion

### DIFF
--- a/excludes.txt
+++ b/excludes.txt
@@ -23,8 +23,3 @@ io.jenkins.blueocean.blueocean_bitbucket_pipeline.server.BitbucketPipelineCreate
 com.microsoft.azure.vmagent.test.jcasc.AdvancedConfigAsCodeTest#exportExportConfiguration
 com.microsoft.azure.vmagent.test.jcasc.BasicConfigAsCodeTest#exportBasicConfiguration
 jenkins.security.plugins.ldap.CascSecurityRealmTest#export_ldap_no_secret
-
-# TODO Remove when https://github.com/jenkins-infra/crawler/pull/165 is merged and tool installer list is updated
-# https://updates.jenkins.io/updates/org.jvnet.hudson.plugins.SbtPluginBuilder.SbtInstaller.json must contain valid entries before tests will pass
-org.jvnet.hudson.plugins.SbtPluginBuilderTest#testFreestyle
-org.jvnet.hudson.plugins.SbtPluginBuilderTest#testPipeline


### PR DESCRIPTION
## Remove sbt plugin test exclusion

Tool installer data is correct at https://updates.jenkins.io/updates/org.jvnet.hudson.plugins.SbtPluginBuilder.SbtInstaller.json

Reverts the change that was made in pull request:

* https://github.com/jenkinsci/bom/pull/6225

Issue for sbt plugin was reported in Jira:

* https://issues.jenkins.io/browse/JENKINS-76355

Help desk issue reported as:

* https://github.com/jenkins-infra/helpdesk/issues/4957

Crawler issue reported as:

* https://github.com/jenkins-infra/crawler/issues/166

### Testing done

* Confirmed that sbt-plugin tests pass from the plugin repository

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
