### PR TITLE
Revert opentelemetry-api v1.54.1.102.v276c93ee966d

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -507,7 +507,7 @@
       <dependency>
         <groupId>io.jenkins.plugins</groupId>
         <artifactId>opentelemetry-api</artifactId>
-        <version>1.54.1.102.v276c93ee966d</version>
+        <version>1.49.0.99.vd48c9e6c4fa_b_</version>
       </dependency>
       <dependency>
         <groupId>io.jenkins.plugins</groupId>


### PR DESCRIPTION
## Revert opentelemetry-api v1.54.1.102.v276c93ee966d

Issue reported to opentelemetry-api plugin:

* https://github.com/jenkinsci/opentelemetry-api-plugin/issues/116

Test failures when running the plugin BOM tests from pull request:

* https://github.com/jenkinsci/bom/pull/6484

Failures include:

```
java.lang.AbstractMethodError: Receiver class io.opentelemetry.sdk.logs.ExtendedSdkLogRecordBuilder does not define or inherit an implementation of the resolved method 'abstract io.opentelemetry.api.incubator.logs.ExtendedLogRecordBuilder setAttribute(io.opentelemetry.api.common.AttributeKey, java.lang.Object)' of interface io.opentelemetry.api.incubator.logs.ExtendedLogRecordBuilder.
	at io.opentelemetry.api.incubator.logs.ExtendedLogRecordBuilder.lambda$setAllAttributes$0(ExtendedLogRecordBuilder.java:89)
	at io.opentelemetry.api.internal.ImmutableKeyValuePairs.forEach(ImmutableKeyValuePairs.java:94)
	at io.opentelemetry.api.incubator.logs.ExtendedLogRecordBuilder.setAllAttributes(ExtendedLogRecordBuilder.java:88)
	at io.opentelemetry.api.incubator.logs.ExtendedLogRecordBuilder.setAllAttributes(ExtendedLogRecordBuilder.java:21)
	at io.jenkins.plugins.opentelemetry.init.OtelJulHandler.publish(OtelJulHandler.java:121)
	at java.logging/java.util.logging.Logger.log(Logger.java:983)
	at java.logging/java.util.logging.Logger.doLog(Logger.java:1010)
	at java.logging/java.util.logging.Logger.log(Logger.java:1055)
	at io.jenkins.plugins.opentelemetry.api.ReconfigurableOpenTelemetry.configure(ReconfigurableOpenTelemetry.java:218)
	at io.jenkins.plugins.opentelemetry.JenkinsOpenTelemetryPluginConfiguration.configureOpenTelemetrySdk(JenkinsOpenTelemetryPluginConfiguration.java:285)
	at io.jenkins.plugins.opentelemetry.JenkinsOpenTelemetryPluginConfigurationIntegrationTest.logStorageRetrieverInitializedWhenLogsExporterIsConfigured(JenkinsOpenTelemetryPluginConfigurationIntegrationTest.java:95)
	Suppressed: java.lang.AbstractMethodError: Receiver class io.opentelemetry.sdk.logs.ExtendedSdkLogRecordBuilder does not define or inherit an implementation of the resolved method 'abstract io.opentelemetry.api.incubator.logs.ExtendedLogRecordBuilder setAttribute(io.opentelemetry.api.common.AttributeKey, java.lang.Object)' of interface io.opentelemetry.api.incubator.logs.ExtendedLogRecordBuilder.
		at io.opentelemetry.api.incubator.logs.ExtendedLogRecordBuilder.lambda$setAllAttributes$0(ExtendedLogRecordBuilder.java:89)
		at io.opentelemetry.api.internal.ImmutableKeyValuePairs.forEach(ImmutableKeyValuePairs.java:94)
		at io.opentelemetry.api.incubator.logs.ExtendedLogRecordBuilder.setAllAttributes(ExtendedLogRecordBuilder.java:88)
		at io.opentelemetry.api.incubator.logs.ExtendedLogRecordBuilder.setAllAttributes(ExtendedLogRecordBuilder.java:21)
		at io.jenkins.plugins.opentelemetry.init.OtelJulHandler.publish(OtelJulHandler.java:121)
		at java.logging/java.util.logging.Logger.log(Logger.java:983)
		at java.logging/java.util.logging.Logger.doLog(Logger.java:1010)
		at java.logging/java.util.logging.Logger.log(Logger.java:1033)
		at hudson.lifecycle.Lifecycle.onStatusUpdate(Lifecycle.java:310)
		at jenkins.model.Jenkins.cleanUp(Jenkins.java:3625)
		at org.jvnet.hudson.test.JenkinsRule._stopJenkins(JenkinsRule.java:575)
		at org.jvnet.hudson.test.JenkinsRule.after(JenkinsRule.java:523)
		at org.jvnet.hudson.test.junit.jupiter.JenkinsExtension.afterEach(JenkinsExtension.java:26)
		at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
		at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
```

Compilation failure when trying to use opentelemetry-api
v1.54.1.102.v276c93ee966d with latest opentelemetry plugin source code
results in error:

```
[INFO] -------------------------------------------------------------
[ERROR] COMPILATION ERROR :
[INFO] -------------------------------------------------------------
[ERROR] /home/mwaite/hub/plugins/opentelemetry-plugin/src/main/java/io/jenkins/plugins/opentelemetry/init/JvmMonitoringInitializer.java:[55,25] no suitable method found for registerObservers(io.jenkins.plugins.opentelemetry.api.ReconfigurableOpenTelemetry)
    method io.opentelemetry.instrumentation.runtimemetrics.java8.GarbageCollector.registerObservers(io.opentelemetry.api.OpenTelemetry,boolean) is not applicable
      (actual and formal argument lists differ in length)
    method io.opentelemetry.instrumentation.runtimemetrics.java8.GarbageCollector.registerObservers(io.opentelemetry.api.OpenTelemetry,java.util.List<java.lang.management.GarbageCollectorMXBean>,java.util.function.Function<javax.management.Notification,com.sun.management.GarbageCollectionNotificationInfo>,boolean) is not applicable
      (actual and formal argument lists differ in length)
[ERROR] /home/mwaite/hub/plugins/opentelemetry-plugin/src/main/java/io/jenkins/plugins/opentelemetry/opentelemetry/GlobalOpenTelemetrySdk.java:[88,68] method create in class io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties cannot be applied to given types;
  required: java.util.Map<java.lang.String,java.lang.String>,io.opentelemetry.common.ComponentLoader
  found:    java.util.Map<java.lang.String,java.lang.String>
  reason: actual and formal argument lists differ in length
[INFO] 2 errors
[INFO] -------------------------------------------------------------
```

This reverts commit 3f4442c353012ed2f3d831c28b6388092f0ccf9f.

### Testing done

Confirmed that tests fail without this change and pass with the change.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
