### PR TITLE
Test Apache Ant 1.10.17 upgrade

### DIFF
--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -14,7 +14,7 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <bom>weekly</bom>
-    <jenkins.version>2.558</jenkins.version>
+    <jenkins.version>2.559-rc38167.55023596127d</jenkins.version>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>
   <dependencyManagement>


### PR DESCRIPTION
## Test Apache Ant 1.10.17 upgrade

The upgrade to Apache Ant 1.10.16 showed no issue in plugin BOM, but had an issue on Windows automated tests.  Test here before allowing the upgrade in Jenkins weekly.

### Testing done

Testing on multiple Windows computers and already tested on ci.jenkins.io in Jenkins core.

* https://github.com/jenkinsci/jenkins/pull/26611

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
