### PR TITLE
Add jackson-annotations2-api plugin

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -26,7 +26,7 @@
     <okhttp-api-plugin.version>5.3.2-200.vedb_720a_cf1f8</okhttp-api-plugin.version>
     <pipeline-maven-plugin.version>1672.v1b_d4c0435b_20</pipeline-maven-plugin.version>
     <pipeline-model-definition-plugin.version>2.2277.v00573e73ddf1</pipeline-model-definition-plugin.version>
-    <pipeline-stage-view-plugin.version>2.40</pipeline-stage-view-plugin.version>
+    <pipeline-stage-view-plugin.version>2.39</pipeline-stage-view-plugin.version>
     <plugin-util-api.version>7.1320.v684dd26fca_19</plugin-util-api.version>
     <scm-api-plugin.version>728.vc30dcf7a_0df5</scm-api-plugin.version>
     <subversion-plugin.version>1303.vcfd9679fb_c12</subversion-plugin.version>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -369,6 +369,11 @@
       </dependency>
       <dependency>
         <groupId>io.jenkins.plugins</groupId>
+        <artifactId>jackson-annotations2-api</artifactId>
+        <version>2.21-7.v4777a_f3a_a_d47</version>
+      </dependency>
+      <dependency>
+        <groupId>io.jenkins.plugins</groupId>
         <artifactId>jackson3-api</artifactId>
         <version>3.1.2-71.v0a_23916945fe</version>
       </dependency>

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -333,6 +333,11 @@
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
+      <artifactId>jackson-annotations2-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
       <artifactId>jackson3-api</artifactId>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
## Add jackson-annotations2-api plugin

A class loading conflict for Jackson Annotations 2 causes Bitbucket Branch Source scan failure and causes Gitea plugin failures.  Refer to issues:

* https://github.com/jenkinsci/jackson3-api-plugin/issues/41
* https://issues.jenkins.io/browse/JENKINS-76435
* https://issues.jenkins.io/browse/JENKINS-76437

The Jackson Annotations 2 jar was bundled in both the Jackson 2 API plugin and the Jackson 3 API plugin.

This creates a new API plugin that will be used by those two plugins.

Plugin pull requests to consume the new API plugin include:

* https://github.com/jenkinsci/jackson2-api-plugin/pull/336
* https://github.com/jenkinsci/jackson3-api-plugin/pull/42

This pull request will probably be required before the most recent release of the Jackson 3 API plugin can be included in the plugin BOM.

### Testing done

* Confirmed that `PLUGINS=jackson-annotations2-api bash ./local-test.sh` passes

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
