### PR TITLE
Revert 'Update pipeline-stage-view-plugin.version to v2.40'

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -26,7 +26,7 @@
     <okhttp-api-plugin.version>5.3.2-200.vedb_720a_cf1f8</okhttp-api-plugin.version>
     <pipeline-maven-plugin.version>1672.v1b_d4c0435b_20</pipeline-maven-plugin.version>
     <pipeline-model-definition-plugin.version>2.2277.v00573e73ddf1</pipeline-model-definition-plugin.version>
-    <pipeline-stage-view-plugin.version>2.40</pipeline-stage-view-plugin.version>
+    <pipeline-stage-view-plugin.version>2.39</pipeline-stage-view-plugin.version>
     <plugin-util-api.version>7.1320.v684dd26fca_19</plugin-util-api.version>
     <scm-api-plugin.version>728.vc30dcf7a_0df5</scm-api-plugin.version>
     <subversion-plugin.version>1303.vcfd9679fb_c12</subversion-plugin.version>


### PR DESCRIPTION
## Revert 'Update pipeline-stage-view-plugin.version to v2.40'

Release 2.40 fails a test with newer Jenkins versions.  The failure can be seen with the command:

```
  mvn clean verify \
      -Djenkins.version=2.541.3 \
      -Dtest=com.cloudbees.workflow.ui.view.WorkflowStageViewActionTest#testTimezoneRespectedInStageStartTime
```

Issue shared with plugin maintainers in comment: https://github.com/jenkinsci/pipeline-stage-view-plugin/pull/398#issuecomment-4264285354

Reported as plugin issue:

* https://issues.jenkins.io/browse/JENKINS-76440

This reverts commit af6baf391d66d4056bbe854adc5d7efa95521da3 from pull request:

* https://github.com/jenkinsci/bom/pull/6652

### Testing done

* Confirmed with git bisect that this is the commit that introduced the failing test
* Confirmed with local execution in the plugin repository that the test fails on newer Jenkins core releases

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
