### PR TITLE
Synchronizing `jjwt-api` with `oidc-provider`

### DIFF
--- a/bom-2.528.x/pom.xml
+++ b/bom-2.528.x/pom.xml
@@ -59,6 +59,11 @@
       </dependency>
       <dependency>
         <groupId>io.jenkins.plugins</groupId>
+        <artifactId>oidc-provider</artifactId>
+        <version>206.210.v1d53c0295b_2f</version>
+      </dependency>
+      <dependency>
+        <groupId>io.jenkins.plugins</groupId>
         <artifactId>pipeline-graph-view</artifactId>
         <version>661.v6003f4542123</version>
       </dependency>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -491,7 +491,7 @@
       <dependency>
         <groupId>io.jenkins.plugins</groupId>
         <artifactId>oidc-provider</artifactId>
-        <version>206.v0a_5b_09149886</version>
+        <version>210.va_069ffe119cb_</version>
       </dependency>
       <dependency>
         <groupId>io.jenkins.plugins</groupId>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -491,7 +491,7 @@
       <dependency>
         <groupId>io.jenkins.plugins</groupId>
         <artifactId>oidc-provider</artifactId>
-        <version>210.va_069ffe119cb_</version>
+        <version>206.208.vf215c51351cf</version>
       </dependency>
       <dependency>
         <groupId>io.jenkins.plugins</groupId>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -421,7 +421,7 @@
       <dependency>
         <groupId>io.jenkins.plugins</groupId>
         <artifactId>jjwt-api</artifactId>
-        <version>0.11.5-120.v0268cf544b_89</version>
+        <version>0.13.0-139.vb_dc6c7b_b_1ea_9</version>
       </dependency>
       <dependency>
         <groupId>io.jenkins.plugins</groupId>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -421,7 +421,7 @@
       <dependency>
         <groupId>io.jenkins.plugins</groupId>
         <artifactId>jjwt-api</artifactId>
-        <version>0.13.0-139.vb_dc6c7b_b_1ea_9</version>
+        <version>0.13.0-141.vd58b_a_9592b_6c</version>
       </dependency>
       <dependency>
         <groupId>io.jenkins.plugins</groupId>
@@ -491,7 +491,7 @@
       <dependency>
         <groupId>io.jenkins.plugins</groupId>
         <artifactId>oidc-provider</artifactId>
-        <version>206.208.vf215c51351cf</version>
+        <version>212.v7657c4d7b_29f</version>
       </dependency>
       <dependency>
         <groupId>io.jenkins.plugins</groupId>


### PR DESCRIPTION
https://github.com/jenkinsci/jjwt-api-plugin/pull/124 expected to be incompatible, so starting by checking the scope of test failures.