### PR TITLE
Exclude forensics API test failures from Jackson 2 API packaging change

### DIFF
--- a/excludes.txt
+++ b/excludes.txt
@@ -15,3 +15,13 @@ org.jenkinsci.plugins.pipeline.modeldefinition.TriggersTest
 # TODO https://github.com/jenkinsci/bom/pull/6504#issuecomment-4127652429
 hudson.matrix.MatrixProjectTest#deletedLockedChildrenBuild
 hudson.matrix.MatrixProjectTest#deletedLockedParentBuild
+
+# TODO https://github.com/jenkinsci/forensics-api-plugin/pull/715
+io.jenkins.plugins.forensics.miner.AddedVersusDeletedLinesTrendChartTest
+io.jenkins.plugins.forensics.miner.CodeMetricTrendChartTest
+io.jenkins.plugins.forensics.miner.CommitStatisticsJobActionTest
+io.jenkins.plugins.forensics.miner.FilesCountSeriesBuilderTest
+io.jenkins.plugins.forensics.miner.FilesCountTrendChartTest
+io.jenkins.plugins.forensics.miner.ForensicsTableModelTest
+io.jenkins.plugins.forensics.miner.ForensicsViewModelTest
+io.jenkins.plugins.forensics.miner.RelativeCountTrendChartTest


### PR DESCRIPTION
## Exclude forensics API test failures from Jackson 2 API packaging change

The jackson2-api plugin and jackson3-api plugin were both bundling a copy of the jackson-annotation jar file.  That caused class loading issues as reported in:

* https://github.com/jenkinsci/jackson3-api-plugin/issues/41
* https://issues.jenkins.io/browse/JENKINS-76435
* https://issues.jenkins.io/browse/JENKINS-76437

New releases of the jackson2-api plugin and jackson3-api plugin now depend on the jackson-annotations2-api plugin.  They were released after merging pull requests:

* https://github.com/jenkinsci/jackson2-api-plugin/pull/336
* https://github.com/jenkinsci/jackson3-api-plugin/pull/42

### Testing done

* Confirmed that the tests fail with the current release of the forensics plugin
* Confirmed that the tests pass with the incremental build from pull request:
  * https://github.com/jenkinsci/forensics-api-plugin/pull/715

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
