### PR TITLE
Suppress `org.eclipse.mylyn.github:org.eclipse.egit.github.core`

### DIFF
--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -1216,6 +1216,13 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>pipeline-github</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <!-- TODO something funny with Maven repo -->
+        <exclusion>
+          <groupId>org.eclipse.mylyn.github</groupId>
+          <artifactId>org.eclipse.egit.github.core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Not sure what this dep of `pipeline-github` is exactly, but it prevents me from running `prep.sh` with my `~/.m2/settings.xml` configured to use the CloudBees Nexus proxy. For purposes of BOM dep testing it should be irrelevant I guess.