### PR TITLE
Test jaxen 2.0.1 in core, stapler, and jelly

### DIFF
--- a/excludes.txt
+++ b/excludes.txt
@@ -15,13 +15,3 @@ org.jenkinsci.plugins.pipeline.modeldefinition.TriggersTest
 # TODO https://github.com/jenkinsci/bom/pull/6504#issuecomment-4127652429
 hudson.matrix.MatrixProjectTest#deletedLockedChildrenBuild
 hudson.matrix.MatrixProjectTest#deletedLockedParentBuild
-
-# TODO https://github.com/jenkinsci/forensics-api-plugin/pull/715
-io.jenkins.plugins.forensics.miner.AddedVersusDeletedLinesTrendChartTest
-io.jenkins.plugins.forensics.miner.CodeMetricTrendChartTest
-io.jenkins.plugins.forensics.miner.CommitStatisticsJobActionTest
-io.jenkins.plugins.forensics.miner.FilesCountSeriesBuilderTest
-io.jenkins.plugins.forensics.miner.FilesCountTrendChartTest
-io.jenkins.plugins.forensics.miner.ForensicsTableModelTest
-io.jenkins.plugins.forensics.miner.ForensicsViewModelTest
-io.jenkins.plugins.forensics.miner.RelativeCountTrendChartTest

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -14,7 +14,8 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <bom>weekly</bom>
-    <jenkins.version>2.559</jenkins.version>
+    <!-- TODO https://github.com/jenkinsci/jenkins/pull/26673 -->
+    <jenkins.version>2.560-rc38205.7b_cc260b_f6f6</jenkins.version>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>
   <dependencyManagement>


### PR DESCRIPTION
## Test jaxen 2.0.1 in core, stapler, and jelly

Refer to the jaxen changelog at:

* https://github.com/jaxen-xpath/jaxen/releases/tag/v2.0.1

Jelly pull request:

* https://github.com/jenkinsci/jelly/pull/183

Stapler pull request:

* https://github.com/jenkinsci/stapler/pull/761

Proposed for inclusion in Jenkins core with pull request:

* https://github.com/jenkinsci/jenkins/pull/26666

This incremental build was generated from core pull request:

* https://github.com/jenkinsci/jenkins/pull/26673

### Testing done

* Confirmed that forensics api tests passed locally on weekly line
* Let ci.jenkins.io run the other weekly tests

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
