### PR TITLE
Remove pubsub-light and sse-gateway

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -1533,11 +1533,6 @@
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>sse-gateway</artifactId>
-        <version>1.29</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>ssh-agent</artifactId>
         <version>386.v36cc0c7582f0</version>
       </dependency>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -1447,11 +1447,6 @@
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>pubsub-light</artifactId>
-        <version>1.19</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>resource-disposer</artifactId>
         <version>0.25</version>
       </dependency>

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -1281,11 +1281,6 @@
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>pubsub-light</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>reverse-proxy-auth-plugin</artifactId>
       <scope>test</scope>
     </dependency>

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -1352,11 +1352,6 @@
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>sse-gateway</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>ssh-agent</artifactId>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
## Remove pubsub-light and sse-gateway from plugin BOM

Part of Blue Ocean that has already been removed from BOM.

Amends pull request:

* https://github.com/jenkinsci/bom/pull/6322

Addresses concern from @NotMyFault in https://github.com/jenkinsci/bom/pull/6142#issuecomment-4276354182

### Testing done

* Confirmed `LINE=weekly PLUGINS=pipeline-graph-view TEST=InjectedTest bash ./local-test.sh` passes

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
