### PR TITLE
Restore forensics-api test exclusions

### DIFF
--- a/excludes.txt
+++ b/excludes.txt
@@ -15,3 +15,14 @@ org.jenkinsci.plugins.pipeline.modeldefinition.TriggersTest
 # TODO https://github.com/jenkinsci/bom/pull/6504#issuecomment-4127652429
 hudson.matrix.MatrixProjectTest#deletedLockedChildrenBuild
 hudson.matrix.MatrixProjectTest#deletedLockedParentBuild
+
+# TODO Remove when 2.541.x support is dropped from plugin BOM
+# TODO https://github.com/jenkinsci/bom/issues/6703
+io.jenkins.plugins.forensics.miner.AddedVersusDeletedLinesTrendChartTest
+io.jenkins.plugins.forensics.miner.CodeMetricTrendChartTest
+io.jenkins.plugins.forensics.miner.CommitStatisticsJobActionTest
+io.jenkins.plugins.forensics.miner.FilesCountSeriesBuilderTest
+io.jenkins.plugins.forensics.miner.FilesCountTrendChartTest
+io.jenkins.plugins.forensics.miner.ForensicsTableModelTest
+io.jenkins.plugins.forensics.miner.ForensicsViewModelTest
+io.jenkins.plugins.forensics.miner.RelativeCountTrendChartTest


### PR DESCRIPTION
## Restore forensics API test exclusions

https://github.com/jenkinsci/bom/issues/6703 describes the problem as:

> When the test forensics-api plugin test exclusions are removed from the excludes.txt file, the tests fail on Jenkins plugin BOM lines prior to 2.555.x. Test failures can be seen with
>
> `PLUGINS=forensics-api LINE=2.528.x bash ./local-test.sh`

This partially reverts commit 38f98ab5f748a1b205bd69466ed37000779e7bdd.

Amends pull request:

* https://github.com/jenkinsci/bom/pull/6685

### Testing done

* Confirmed that the 2.541.x and 2.528.x lines fail the forensics API tests with messages like:

  ```
  [ERROR] io.jenkins.plugins.forensics.miner.RelativeCountTrendChartTest.shouldCreateWithData
  [ERROR]   Run 1: RelativeCountTrendChartTest.shouldCreateWithData:37->createChartModelConfiguration:57 NoClassDefFound Could not initialize class edu.hm.hafner.echarts.ChartModelConfiguration
  ```

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
