### PR TITLE
Exclude recently added lockable resources test

### DIFF
--- a/excludes.txt
+++ b/excludes.txt
@@ -26,3 +26,6 @@ io.jenkins.plugins.forensics.miner.FilesCountTrendChartTest
 io.jenkins.plugins.forensics.miner.ForensicsTableModelTest
 io.jenkins.plugins.forensics.miner.ForensicsViewModelTest
 io.jenkins.plugins.forensics.miner.RelativeCountTrendChartTest
+
+# TODO https://github.com/jenkinsci/lockable-resources-plugin/issues/1026
+org.jenkins.plugins.lockableresources.FreeStyleTimeoutTest#freestyleLockTimeoutCancelsQueueItem


### PR DESCRIPTION
## Exclude recently added lockable resources test

[Lockable resources issue 1026](https://github.com/jenkinsci/lockable-resources-plugin/issues/1026) notes that the FreeStyleTimeoutTest fails on Jenkins 2.532 and newer.  The test was added in the most recent release (1509.va_6b_5b_5cb_0b_40) as part of pull request:

* https://github.com/jenkinsci/lockable-resources-plugin/pull/1010

Issue has been reported to the maintainer as:

* https://github.com/jenkinsci/lockable-resources-plugin/issues/1026

### Testing done

* Confirmed that the test passes on Jenkins core versions prior to 2.532 and fails consistently on 2.532 and later

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
