### PR TITLE
Properly align `workflow-job` & `workflow-cps` versions

### DIFF
--- a/bom-2.541.x/pom.xml
+++ b/bom-2.541.x/pom.xml
@@ -12,7 +12,6 @@
     <data-tables-api.version>2.3.7-1534.v539d4edf109d</data-tables-api.version>
     <forensics-api.version>3.1832.va_1179842528b_</forensics-api.version>
     <plugin-util-api.version>6.1192.v30fe6e2837ff</plugin-util-api.version>
-    <workflow-job-plugin.version>1571.vb_423c255d6d9</workflow-job-plugin.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/bom-2.555.x/pom.xml
+++ b/bom-2.555.x/pom.xml
@@ -9,7 +9,7 @@
   <artifactId>bom-2.555.x</artifactId>
   <packaging>pom</packaging>
   <properties>
-    <workflow-job-plugin.version>1571.vb_423c255d6d9</workflow-job-plugin.version>
+    <workflow-job-plugin.version>1571.1580.v18e46842c125</workflow-job-plugin.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -31,7 +31,7 @@
     <scm-api-plugin.version>728.vc30dcf7a_0df5</scm-api-plugin.version>
     <subversion-plugin.version>1303.vcfd9679fb_c12</subversion-plugin.version>
     <workflow-api-plugin.version>1413.v2ff1a_5e720fa_</workflow-api-plugin.version>
-    <workflow-cps-plugin.version>4303.v8fa_2a_581f0a_6</workflow-cps-plugin.version>
+    <workflow-cps-plugin.version>4315.va_e456c4e7f4f</workflow-cps-plugin.version>
     <workflow-job-plugin.version>1581.ve4b_d0db_fcb_b_b_</workflow-job-plugin.version>
     <workflow-multibranch-plugin.version>821.vc3b_4ea_780798</workflow-multibranch-plugin.version>
     <workflow-step-api-plugin.version>724.v538c2362b_dfb_</workflow-step-api-plugin.version>


### PR DESCRIPTION
Following up #6742 to reflect the status of https://github.com/jenkinsci/workflow-job-plugin/pull/757 + https://github.com/jenkinsci/workflow-job-plugin/pull/758 + https://github.com/jenkinsci/workflow-cps-plugin/pull/1769.