### PR TITLE
Use JDK 21 on 2.555.x line

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -108,7 +108,7 @@ if (BRANCH_NAME == 'master' || fullTestMarkerFile || weeklyTestMarkerFile || env
     }
     pluginsByRepository.each { repository, plugins ->
       branches["pct-$repository-$line"] = {
-        def jdk = line == 'weekly' ? 21 : 17
+        def jdk = line == 'weekly' || line == '2.555.x' ? 21 : 17
         mavenEnv(jdk: jdk) {
           unstash line
           withEnv([


### PR DESCRIPTION
## Use JDK 21 on 2.555.x line

We only test the weekly line and the oldest line when we run full tests, so we did not need to use the correct JDK for the 2.555.x line yet.  Eventually, 2.555.x will be tested and we'll want it to run with Java 21, since it does not support Java 17.

### Testing done

Confirmed that a simple test passes with 2.555.x line using Java 21

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
