### PR TITLE
Include all excludes files in stash

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -94,7 +94,7 @@ stage('prep') {
       lines = [lines[0], lines[-1]] // Save resources by running PCT only on newest and oldest lines
     }
     lines.each { line ->
-      stash name: line, includes: "pct.sh,excludes.txt,target/pct.jar,target/megawar-${line}.war"
+      stash name: line, includes: "pct.sh,excludes.txt,bom-*/excludes.txt,target/pct.jar,target/megawar-${line}.war"
     }
     infra.prepareToPublishIncrementals()
   }

--- a/pct.sh
+++ b/pct.sh
@@ -25,6 +25,7 @@ if [ -f "$(pwd)/bom-${LINE}/excludes.txt" ]; then
 	# Create a temporary excludes file, remove it when the shell exits
 	EXCLUDES_FILE="$(mktemp -t excludes-${LINE}-XXX.txt)"
 	trap 'rm -f -- "$EXCLUDES_FILE"' EXIT
+	echo "Using excludes file ${EXCLUDES_FILE} for line ${LINE}"
 	cat excludes.txt bom-${LINE}/excludes.txt > "${EXCLUDES_FILE}"
 fi
 


### PR DESCRIPTION
## Include all excludes files in stash

Amends pull request:

* https://github.com/jenkinsci/bom/pull/6706

I forgot that crucial build files are stashed for each of the parallel builds.  Without the exclude files that are specific to the line, the root exclusions are the only ones that are used in the parallel builds.  

### Testing done

* Tested stash syntax with a local Pipeline job to assure that non-matching patterns did not fail the build and that the stash included the expected files.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
