### PR TITLE
Test Jenkins 2.555.2-rc38074.091b_8b_dd655d

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -92,6 +92,7 @@ stage('prep') {
 
       lines = readFile('lines.txt').split('\n')
       lines = [lines[0], lines[-1]] // Save resources by running PCT only on newest and oldest lines
+      lines = ['2.555.x', ] // Save resources by running PCT only on the exact line that changed
     }
     lines.each { line ->
       stash name: line, includes: "pct.sh,excludes.txt,bom-*/excludes.txt,target/pct.jar,target/megawar-${line}.war"

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -1703,7 +1703,7 @@
       <id>2.555.x</id>
       <properties>
         <bom>2.555.x</bom>
-        <jenkins.version>2.555.1</jenkins.version>
+        <jenkins.version>2.555.2-rc38074.091b_8b_dd655d</jenkins.version>
       </properties>
     </profile>
     <profile>


### PR DESCRIPTION
## Test Jenkins 2.555.2-rc38074.091b_8b_dd655d

Adapts the Jenkinsfile to only run one line, even though the full-test markerfile is present

Part of the 2.555.2 release checklist:

* https://github.com/jenkins-infra/release/issues/889

Includes changes from backporting pull requests:

* https://github.com/jenkinsci/jenkins/pull/26704
* https://github.com/jenkinsci/jenkins/pull/26757

DO NOT MERGE

### Testing done

* Confirmed with `LINE=2.555.x PLUGINS=git-client,git,workflow-cps TEST=InjectedTest bash ./local-test.sh`

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
