### PR TITLE
Add `mock-slave`

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -1302,6 +1302,11 @@
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>mock-slave</artifactId>
+        <version>217.v67c790ca_a_c31</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>msbuild</artifactId>
         <version>1.41</version>
       </dependency>

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -1144,6 +1144,11 @@
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>mock-slave</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>msbuild</artifactId>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
While this plugin is mainly used for interactive testing, on occasion it is useful for automated tests (https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/372 is one example), and then it becomes necessary to manage its version (https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/613).