### PR TITLE
Exclude failing test testTimezoneRespectedInStageStartTime

### DIFF
--- a/excludes.txt
+++ b/excludes.txt
@@ -15,3 +15,6 @@ org.jenkinsci.plugins.pipeline.modeldefinition.TriggersTest
 # TODO https://github.com/jenkinsci/bom/pull/6504#issuecomment-4127652429
 hudson.matrix.MatrixProjectTest#deletedLockedChildrenBuild
 hudson.matrix.MatrixProjectTest#deletedLockedParentBuild
+
+# TODO https://issues.jenkins.io/browse/JENKINS-75133
+com.cloudbees.workflow.ui.view.WorkflowStageViewActionTest#testTimezoneRespectedInStageStartTime


### PR DESCRIPTION
## Exclude failing test testTimezoneRespectedInStageStartTime

The test fails because there is a bug in the plugin.  The bug in the plugin is that it reports the time as 24:xx during the one hour after midnight.  The test correctly asserts that it should report that time as 00:xx.

The plugin bug has been reported as

* https://issues.jenkins.io/browse/JENKINS-76449

Test has failed in other pull requests like:

* https://github.com/jenkinsci/bom/pull/6745
* https://github.com/jenkinsci/bom/pull/6807

### Testing done

* Confirmed test was excluded by `LINE=weekly PLUGINS=pipeline-stage-view TEST=WorkflowStageViewActionTest bash ./local-test.sh`

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
