### PR TITLE
Use correct bug link JENKINS-76449

### DIFF
--- a/excludes.txt
+++ b/excludes.txt
@@ -16,5 +16,5 @@ org.jenkinsci.plugins.pipeline.modeldefinition.TriggersTest
 hudson.matrix.MatrixProjectTest#deletedLockedChildrenBuild
 hudson.matrix.MatrixProjectTest#deletedLockedParentBuild
 
-# TODO https://issues.jenkins.io/browse/JENKINS-75133
+# TODO https://issues.jenkins.io/browse/JENKINS-76449
 com.cloudbees.workflow.ui.view.WorkflowStageViewActionTest#testTimezoneRespectedInStageStartTime


### PR DESCRIPTION
## Use correct bug link JENKINS-76449

https://issues.jenkins.io/browse/JENKINS-76449 describes a plugin problem with time display for the hour after midnight.

Reported by Jesse in https://github.com/jenkinsci/bom/pull/6808#issuecomment-4443951565

### Testing done

None

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
