### PR TITLE
Revert 2 plugin updates that incorrectly require Java 21

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -1464,7 +1464,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>role-strategy</artifactId>
-        <version>861.v4f04587b_b_7e9</version>
+        <version>848.va_a_ea_673cf0b_c</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -26,7 +26,7 @@
     <mina-sshd-api.version>2.17.1-187.v0341274c2905</mina-sshd-api.version>
     <okhttp-api-plugin.version>5.3.2-200.vedb_720a_cf1f8</okhttp-api-plugin.version>
     <pipeline-maven-plugin.version>1724.vfcd808f49a_0c</pipeline-maven-plugin.version>
-    <pipeline-model-definition-plugin.version>2.2289.v6f731d0a_02da_</pipeline-model-definition-plugin.version>
+    <pipeline-model-definition-plugin.version>2.2277.v00573e73ddf1</pipeline-model-definition-plugin.version>
     <pipeline-stage-view-plugin.version>2.41</pipeline-stage-view-plugin.version>
     <plugin-util-api.version>7.1341.v039f146993d9</plugin-util-api.version>
     <scm-api-plugin.version>728.vc30dcf7a_0df5</scm-api-plugin.version>


### PR DESCRIPTION
## Revert two plugin updates that incorrectly require Java 21

The Role Strategy Plugin and Pipline Model Definition Plugin both inadvertently require Java 21 to compile their most recent release.  Revert to the earlier versions in the plugin BOM so that we can release the other changes.

Pull requests submitted to fix the plugins:

* https://github.com/jenkinsci/role-strategy-plugin/pull/757
* https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/1501

Detected by plugin BOM issue:

* https://github.com/jenkinsci/bom/issues/6871

### Testing done

* None.  Earlier releases of the plugins were successfully included in the previous BOM release

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
