### PR TITLE
Ignore Groovy monorepo updates in Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,7 +6,9 @@
   ],
   "automerge": true,
   "ignoreDeps": [
-    "io.jenkins.tools.bom:parent"
+    "io.jenkins.tools.bom:parent",
+    "org.codehaus.groovy:groovy-all",
+    "org.apache.groovy:groovy-all"
   ],
   "ignorePaths": [
     "bom-*.x/pom.xml"


### PR DESCRIPTION
The `groovy-all` dependency in `sample-plugin` is intentionally pinned at `2.4.21`. Add both the `org.codehaus.groovy` and `org.apache.groovy` coordinates to ignoreDeps so Renovate stops proposing the v2.5.23 and v3 (which migrates the groupId to `org.apache.groovy`) monorepo updates.

### Testing done

None.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed