### PR TITLE
Revert "Update dependency org.jenkins-ci.plugins:JiraTestResultReporter to v378 (#6913)"

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -1203,7 +1203,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>JiraTestResultReporter</artifactId>
-        <version>378.v2a_19e1f46c93</version>
+        <version>372.vc7c7d897c344</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
This reverts commit f4a10f6148ce2ce8be14794a536ded6b64bd5859.

Fix proposed in pull request:

* https://github.com/jenkinsci/JiraTestResultReporter-plugin/pull/288