### PR TITLE
Revert back to last week's JiraTestResultReporter

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -1203,7 +1203,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>JiraTestResultReporter</artifactId>
-        <version>372.vc7c7d897c344</version>
+        <version>340.v8ea_26d65222d</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
The latest failure:

```
15:44:47  [ERROR] Rule 1: org.apache.maven.enforcer.rules.version.RequireJavaVersion failed with message:
15:44:47  [ERROR] Detected JDK /opt/jdk-17 is version 17.0.19 which is not in the allowed range [21,).
15:44:47  [ERROR] -> [Help 1]
15:44:47  org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.6.3:enforce (display-info) on project JiraTestResultReporter:
15:44:47  Rule 1: org.apache.maven.enforcer.rules.version.RequireJavaVersion failed with message:
15:44:47  Detected JDK /opt/jdk-17 is version 17.0.19 which is not in the allowed range [21,).
15:44:47      at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2 (MojoExecutor.java:333)
15:44:47      at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute (MojoExecutor.java:316)
15:44:47      at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:212)
15:44:47      at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:174)
15:44:47      at org.apache.maven.lifecycle.internal.MojoExecutor.access$000 (MojoExecutor.java:75)
15:44:47      at org.apache.maven.lifecycle.internal.MojoExecutor$1.run (MojoExecutor.java:162)
15:44:47      at org.apache.maven.plugin.DefaultMojosExecutionStrategy.execute (DefaultMojosExecutionStrategy.java:39)
15:44:47      at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:159)
15:44:47      at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:105)
15:44:47      at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:73)
15:44:47      at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:53)
15:44:47      at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:118)
15:44:47      at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:261)
15:44:47      at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:173)
15:44:47      at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:101)
15:44:47      at org.apache.maven.cli.MavenCli.execute (MavenCli.java:919)
15:44:47      at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:285)
15:44:47      at org.apache.maven.cli.MavenCli.main (MavenCli.java:207)
15:44:47      at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
15:44:47      at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:77)
15:44:47      at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
15:44:47      at java.lang.reflect.Method.invoke (Method.java:569)
15:44:47      at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:255)
15:44:47      at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:201)
15:44:47      at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:362)
15:44:47      at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:314)
```

was added with

https://github.com/jenkinsci/JiraTestResultReporter-plugin/releases/tag/363.vdd3b_7e00de8d

in order to give more time to resolve, reverting back to the version that was in the 2026-05-29 release (`6509.v993a_c958a_e35`)

### Testing done

* `LINE=weekly PLUGINS=JiraTestResultReporter bash local-test.sh`
* `LINE=2.528.x PLUGINS=JiraTestResultReporter bash local-test.sh`

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed