### PR TITLE
pin pipeline-model-definition to older version

### DIFF
--- a/bom-2.528.x/pom.xml
+++ b/bom-2.528.x/pom.xml
@@ -11,6 +11,7 @@
   <properties>
     <configuration-as-code-plugin.version>2036.v0b_c2de701dcb_</configuration-as-code-plugin.version>
     <junit-plugin.version>1369.v15da_00283f06</junit-plugin.version>
+    <pipeline-model-definition-plugin.version>2.2277.v00573e73ddf1</pipeline-model-definition-plugin.version>
     <workflow-api-plugin.version>1384.vdc05a_48f535f</workflow-api-plugin.version>
   </properties>
   <dependencyManagement>
@@ -128,6 +129,32 @@
         <artifactId>workflow-api</artifactId>
         <version>${workflow-api-plugin.version}</version>
         <classifier>tests</classifier>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkinsci.plugins</groupId>
+        <artifactId>pipeline-model-api</artifactId>
+        <version>${pipeline-model-definition-plugin.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkinsci.plugins</groupId>
+        <artifactId>pipeline-model-definition</artifactId>
+        <version>${pipeline-model-definition-plugin.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkinsci.plugins</groupId>
+        <artifactId>pipeline-model-definition</artifactId>
+        <version>${pipeline-model-definition-plugin.version}</version>
+        <classifier>tests</classifier>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkinsci.plugins</groupId>
+        <artifactId>pipeline-model-extensions</artifactId>
+        <version>${pipeline-model-definition-plugin.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkinsci.plugins</groupId>
+        <artifactId>pipeline-stage-tags-metadata</artifactId>
+        <version>${pipeline-model-definition-plugin.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
pipeline-model-definition 2.2289 moved to plugin-pom 6.2185, which enables the banObsoleteDependencyOverrides enforcer rule referenced via the deprecated org.apache.maven.plugins.enforcer API; under maven-enforcer 3.6.2 in PCT it fails with ClassNotFoundException before any test runs. 2.2277 (plugin-pom 5.27) builds cleanly.

Both versions share core baseline 2.504, so this is a build-tooling hold-back, not a core-compatibility one; drop once a fixed pmd release is available.

### Testing done

* `LINE=2.528.x PLUGINS=pipeline-model-definition bash local-test.sh`

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
