### PR TITLE
Revert "pin pipeline-model-definition to older version"

### DIFF
--- a/bom-2.528.x/pom.xml
+++ b/bom-2.528.x/pom.xml
@@ -11,7 +11,6 @@
   <properties>
     <configuration-as-code-plugin.version>2036.v0b_c2de701dcb_</configuration-as-code-plugin.version>
     <junit-plugin.version>1369.v15da_00283f06</junit-plugin.version>
-    <pipeline-model-definition-plugin.version>2.2277.v00573e73ddf1</pipeline-model-definition-plugin.version>
     <workflow-api-plugin.version>1384.vdc05a_48f535f</workflow-api-plugin.version>
   </properties>
   <dependencyManagement>
@@ -129,32 +128,6 @@
         <artifactId>workflow-api</artifactId>
         <version>${workflow-api-plugin.version}</version>
         <classifier>tests</classifier>
-      </dependency>
-      <dependency>
-        <groupId>org.jenkinsci.plugins</groupId>
-        <artifactId>pipeline-model-api</artifactId>
-        <version>${pipeline-model-definition-plugin.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jenkinsci.plugins</groupId>
-        <artifactId>pipeline-model-definition</artifactId>
-        <version>${pipeline-model-definition-plugin.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jenkinsci.plugins</groupId>
-        <artifactId>pipeline-model-definition</artifactId>
-        <version>${pipeline-model-definition-plugin.version}</version>
-        <classifier>tests</classifier>
-      </dependency>
-      <dependency>
-        <groupId>org.jenkinsci.plugins</groupId>
-        <artifactId>pipeline-model-extensions</artifactId>
-        <version>${pipeline-model-definition-plugin.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jenkinsci.plugins</groupId>
-        <artifactId>pipeline-stage-tags-metadata</artifactId>
-        <version>${pipeline-model-definition-plugin.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
## Revert "pin pipeline-model-definition to older version"

Issue fixed by the latest release.  Release includes pull request:

* https://github.com/jenkinsci/pipeline-model-definition-plugin/issues/1501

This reverts commit ad9b12aabc521a5037870f6b97a42fabd3ed5c01 from pull request:

* https://github.com/jenkinsci/bom/pull/6917

### Testing done

* Confirmed that 2.528.x line test of pipeline-model-definition passes

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
