### PR TITLE
Block JiraTestResultReporter 378.x line in Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -68,6 +68,12 @@
     },
     {
       "matchDepNames": [
+        "org.jenkins-ci.plugins:JiraTestResultReporter"
+      ],
+      "allowedVersions": "!/^378\\./" // skip 378.x line, see PR #6918
+    },
+    {
+      "matchDepNames": [
         "org.jenkins-ci.tests:plugins-compat-tester-cli"
       ],
       "labels": [


### PR DESCRIPTION
Renovate kept recreating the closed PR #6918 because automerge is enabled and a matching PR was automerged previously. Add an allowedVersions rule to skip the 378.x line while still allowing future updates.

### Testing done

none

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed