### PR TITLE
Use `RealJenkinsRule` when possible in sample plugin tests

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -128,7 +128,7 @@
       <dependency>
         <groupId>io.jenkins.plugins</groupId>
         <artifactId>artifactory-client-api</artifactId>
-        <version>2.21.2-166.v56e395cd41e0</version>
+        <version>2.19.0-158.ve20b_86b_a_d36a_</version>
       </dependency>
       <dependency>
         <groupId>io.jenkins.plugins</groupId>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -128,7 +128,7 @@
       <dependency>
         <groupId>io.jenkins.plugins</groupId>
         <artifactId>artifactory-client-api</artifactId>
-        <version>2.19.0-158.ve20b_86b_a_d36a_</version>
+        <version>2.21.2-166.v56e395cd41e0</version>
       </dependency>
       <dependency>
         <groupId>io.jenkins.plugins</groupId>

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -673,6 +673,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>4.3.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.6wind.jenkins</groupId>
       <artifactId>lockable-resources</artifactId>
       <scope>test</scope>

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -673,14 +673,14 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.awaitility</groupId>
-      <artifactId>awaitility</artifactId>
-      <version>4.3.0</version>
+      <groupId>org.6wind.jenkins</groupId>
+      <artifactId>lockable-resources</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.6wind.jenkins</groupId>
-      <artifactId>lockable-resources</artifactId>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>4.3.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/sample-plugin/src/test/java/io/jenkins/tools/bom/sample/DeclarativePipelineTest.java
+++ b/sample-plugin/src/test/java/io/jenkins/tools/bom/sample/DeclarativePipelineTest.java
@@ -3,35 +3,36 @@ package io.jenkins.tools.bom.sample;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
-import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
-import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.RealJenkinsRule;
 
 public class DeclarativePipelineTest {
-    @ClassRule
-    public static BuildWatcher buildWatcher = new BuildWatcher();
 
     @Rule
-    public JenkinsRule r = new JenkinsRule();
+    public RealJenkinsRule r = new RealJenkinsRule();
 
     @Test
-    public void smokes() throws Exception {
-        final WorkflowRun run = runPipeline(m(
-                "pipeline {",
-                "  agent none",
-                "  stages {",
-                "    stage('Example') {",
-                "      steps {",
-                "        example(x: 'foobar')",
-                "      }",
-                "    }",
-                "  }",
-                "}"));
+    public void smokes() throws Throwable {
+        r.then(r -> {
+            final WorkflowRun run = runPipeline(
+                    r,
+                    m(
+                            "pipeline {",
+                            "  agent none",
+                            "  stages {",
+                            "    stage('Example') {",
+                            "      steps {",
+                            "        example(x: 'foobar')",
+                            "      }",
+                            "    }",
+                            "  }",
+                            "}"));
 
-        r.assertBuildStatusSuccess(run);
-        r.assertLogContains("Ran on foobar!", run);
+            r.assertBuildStatusSuccess(run);
+            r.assertLogContains("Ran on foobar!", run);
+        });
     }
 
     /**
@@ -40,7 +41,7 @@ public class DeclarativePipelineTest {
      * @param definition the pipeline job definition
      * @return the started job
      */
-    private WorkflowRun runPipeline(String definition) throws Exception {
+    private static WorkflowRun runPipeline(JenkinsRule r, String definition) throws Exception {
         final WorkflowJob project = r.createProject(WorkflowJob.class, "example");
         project.setDefinition(new CpsFlowDefinition(definition, true));
         final WorkflowRun workflowRun = project.scheduleBuild2(0).waitForStart();

--- a/sample-plugin/src/test/java/io/jenkins/tools/bom/sample/DeclarativePipelineTest.java
+++ b/sample-plugin/src/test/java/io/jenkins/tools/bom/sample/DeclarativePipelineTest.java
@@ -16,19 +16,18 @@ public class DeclarativePipelineTest {
     @Test
     public void smokes() throws Throwable {
         r.then(r -> {
-            final WorkflowRun run = runPipeline(
-                    r,
-                    m(
-                            "pipeline {",
-                            "  agent none",
-                            "  stages {",
-                            "    stage('Example') {",
-                            "      steps {",
-                            "        example(x: 'foobar')",
-                            "      }",
-                            "    }",
-                            "  }",
-                            "}"));
+            final WorkflowRun run = runPipeline(r, """
+                    pipeline {
+                      agent none
+                      stages {
+                        stage('Example') {
+                          steps {
+                            example(x: 'foobar')
+                          }
+                        }
+                      }
+                    }
+                    """);
 
             r.assertBuildStatusSuccess(run);
             r.assertLogContains("Ran on foobar!", run);
@@ -47,15 +46,5 @@ public class DeclarativePipelineTest {
         final WorkflowRun workflowRun = project.scheduleBuild2(0).waitForStart();
         r.waitForCompletion(workflowRun);
         return workflowRun;
-    }
-
-    /**
-     * Approximates a multiline string in Java.
-     *
-     * @param lines the lines to concatenate with a newline separator
-     * @return the concatenated multiline string
-     */
-    private static String m(String... lines) {
-        return String.join("\n", lines);
     }
 }

--- a/sample-plugin/src/test/java/io/jenkins/tools/bom/sample/ExampleStepTest.java
+++ b/sample-plugin/src/test/java/io/jenkins/tools/bom/sample/ExampleStepTest.java
@@ -1,42 +1,26 @@
 package io.jenkins.tools.bom.sample;
 
-import static org.junit.Assert.*;
-
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
-import org.jenkinsci.plugins.workflow.cps.SnippetizerTester;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
-import org.jenkinsci.plugins.workflow.steps.StepConfigTester;
-import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
-import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
-import org.jvnet.hudson.test.BuildWatcher;
-import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.RealJenkinsRule;
 
 public class ExampleStepTest {
 
-    @ClassRule
-    public static BuildWatcher buildWatcher = new BuildWatcher();
-
     @Rule
-    public JenkinsRule r = new JenkinsRule();
+    public RealJenkinsRule r = new RealJenkinsRule();
 
     @Test
-    public void smokes() throws Exception {
-        WorkflowJob p = r.createProject(WorkflowJob.class);
-        p.setDefinition(new CpsFlowDefinition(
-                "node {example(x: 'some value')}; semaphore 'wait'; echo 'more stuff too'", true));
-        WorkflowRun b = p.scheduleBuild2(0).waitForStart();
-        SemaphoreStep.waitForStart("wait/1", b);
-        SemaphoreStep.success("wait/1", null);
-        r.assertBuildStatusSuccess(r.waitForCompletion(b));
-        r.assertLogContains("Ran on some value!", b);
-        r.assertLogContains("more stuff too", b);
-        ExampleStep s = new ExampleStep();
-        s.x = "sample";
-        ExampleStep s2 = new StepConfigTester(r).configRoundTrip(s);
-        assertEquals("sample", s2.x);
-        new SnippetizerTester(r).assertRoundTrip(s2, "example x: 'sample'");
+    public void smokes() throws Throwable {
+        r.then(r -> {
+            WorkflowJob p = r.createProject(WorkflowJob.class);
+            p.setDefinition(new CpsFlowDefinition("node {example(x: 'some value')}; echo 'more stuff too'", true));
+            WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+            r.assertBuildStatusSuccess(r.waitForCompletion(b));
+            r.assertLogContains("Ran on some value!", b);
+            r.assertLogContains("more stuff too", b);
+        });
     }
 }

--- a/sample-plugin/src/test/java/io/jenkins/tools/bom/sample/ExampleStepTest.java
+++ b/sample-plugin/src/test/java/io/jenkins/tools/bom/sample/ExampleStepTest.java
@@ -1,10 +1,16 @@
 package io.jenkins.tools.bom.sample;
 
+import static org.junit.Assert.assertEquals;
+
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.cps.SnippetizerTester;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.steps.StepConfigTester;
+import org.jenkinsci.plugins.workflow.support.steps.input.InputAction;
 import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.RealJenkinsRule;
 
 public class ExampleStepTest {
@@ -12,15 +18,34 @@ public class ExampleStepTest {
     @Rule
     public RealJenkinsRule r = new RealJenkinsRule();
 
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
     @Test
     public void smokes() throws Throwable {
         r.then(r -> {
             WorkflowJob p = r.createProject(WorkflowJob.class);
-            p.setDefinition(new CpsFlowDefinition("node {example(x: 'some value')}; echo 'more stuff too'", true));
+            p.setDefinition(new CpsFlowDefinition(
+                    "node {example(x: 'some value')}; input 'wait'; echo 'more stuff too'", true));
             WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+            while (true) {
+                InputAction ia = b.getAction(InputAction.class);
+                if (ia != null && ia.isWaitingForInput()) break;
+                Thread.sleep(100);
+            }
+            b.getAction(InputAction.class).getExecutions().get(0).doProceedEmpty();
             r.assertBuildStatusSuccess(r.waitForCompletion(b));
             r.assertLogContains("Ran on some value!", b);
             r.assertLogContains("more stuff too", b);
         });
+    }
+
+    @Test
+    public void configRoundTrip() throws Exception {
+        ExampleStep s = new ExampleStep();
+        s.x = "sample";
+        ExampleStep s2 = new StepConfigTester(j).configRoundTrip(s);
+        assertEquals("sample", s2.x);
+        new SnippetizerTester(j).assertRoundTrip(s2, "example x: 'sample'");
     }
 }

--- a/sample-plugin/src/test/java/io/jenkins/tools/bom/sample/ExampleStepTest.java
+++ b/sample-plugin/src/test/java/io/jenkins/tools/bom/sample/ExampleStepTest.java
@@ -1,5 +1,6 @@
 package io.jenkins.tools.bom.sample;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
 
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
@@ -10,7 +11,7 @@ import org.jenkinsci.plugins.workflow.steps.StepConfigTester;
 import org.jenkinsci.plugins.workflow.support.steps.input.InputAction;
 import org.junit.Rule;
 import org.junit.Test;
-import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.JenkinsSessionRule;
 import org.jvnet.hudson.test.RealJenkinsRule;
 
 public class ExampleStepTest {
@@ -19,7 +20,7 @@ public class ExampleStepTest {
     public RealJenkinsRule r = new RealJenkinsRule();
 
     @Rule
-    public JenkinsRule j = new JenkinsRule();
+    public JenkinsSessionRule sessions = new JenkinsSessionRule();
 
     @Test
     public void smokes() throws Throwable {
@@ -28,11 +29,10 @@ public class ExampleStepTest {
             p.setDefinition(new CpsFlowDefinition(
                     "node {example(x: 'some value')}; input 'wait'; echo 'more stuff too'", true));
             WorkflowRun b = p.scheduleBuild2(0).waitForStart();
-            while (true) {
+            await().until(() -> {
                 InputAction ia = b.getAction(InputAction.class);
-                if (ia != null && ia.isWaitingForInput()) break;
-                Thread.sleep(100);
-            }
+                return ia != null && ia.isWaitingForInput();
+            });
             b.getAction(InputAction.class).getExecutions().get(0).doProceedEmpty();
             r.assertBuildStatusSuccess(r.waitForCompletion(b));
             r.assertLogContains("Ran on some value!", b);
@@ -41,11 +41,13 @@ public class ExampleStepTest {
     }
 
     @Test
-    public void configRoundTrip() throws Exception {
-        ExampleStep s = new ExampleStep();
-        s.x = "sample";
-        ExampleStep s2 = new StepConfigTester(j).configRoundTrip(s);
-        assertEquals("sample", s2.x);
-        new SnippetizerTester(j).assertRoundTrip(s2, "example x: 'sample'");
+    public void configRoundTrip() throws Throwable {
+        sessions.then(j -> {
+            ExampleStep s = new ExampleStep();
+            s.x = "sample";
+            ExampleStep s2 = new StepConfigTester(j).configRoundTrip(s);
+            assertEquals("sample", s2.x);
+            new SnippetizerTester(j).assertRoundTrip(s2, "example x: 'sample'");
+        });
     }
 }


### PR DESCRIPTION
Replace JenkinsRule with RealJenkinsRule in DeclarativePipelineTest and ExampleStepTest to run tests against a real Jenkins controller.

### Testing done

CI

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
