### PR TITLE
Pin JiraTestResultReporter to older version on older lines

### DIFF
--- a/bom-2.541.x/pom.xml
+++ b/bom-2.541.x/pom.xml
@@ -108,7 +108,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>JiraTestResultReporter</artifactId>
-        <version>372.vc7c7d897c344</version>
+        <version>340.v8ea_26d65222d</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
We would have run into the same problem that we did last week with 372. Pinning back to last week's BOM version (340) for 2.541.x so it also covers 2.528.x. The 384 version that came out this week is fine for weekly and 2.555.x.

### Testing done

* `LINE=2.541.x PLUGINS=JiraTestResultReporter bash local-test.sh`
* `LINE=2.528.x PLUGINS=JiraTestResultReporter bash local-test.sh`

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed