### PR TITLE
pin go-offline to 3.9.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -79,7 +79,7 @@ stage('prep') {
       sh '''
       mvn -v
       echo "Starting artifact caching proxy pre-heat"
-      mvn -ntp dependency:go-offline
+      mvn -ntp org.apache.maven.plugins:maven-dependency-plugin:3.9.0:go-offline
       echo "Finished artifact caching proxy pre-heat"
       bash prep.sh
       '''


### PR DESCRIPTION
#6957 has failed numerous times. After some help from Claude,  it appears that when you invoke a plugin by goal-prefix on the CLI like this, Maven resolves the latest released version. It does not reliably honor the <pluginManagement> version for a direct prefix invocation.

maven-dependency-plugin 3.11.0 was released 2026-05-24. The last successful build of org.jenkins-ci:jenkins was in January 2026, when 3.9.0 was the available version, which is the pinned version in the parent POM.

Going to test to see if pinning to 3.9.0 fixes the issue or not.

### Testing done

none

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed