### PR TITLE
chore(Jenkinsfile): Maven cache improvements

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,6 +4,8 @@ if(env.BRANCH_NAME == "master") {
   cronTrigger = '53 22 * * 5'
 }
 
+env.MAVEN_NTP = true
+
 properties([
   disableConcurrentBuilds(abortPrevious: true),
   buildDiscarder(logRotator(numToKeepStr: '7')),
@@ -28,7 +30,7 @@ def mavenEnv(Map params = [:], Closure body) {
             withEnv([
               'JAVA_HOME=/opt/jdk-' + params['jdk'],
               'PATH+JDK=/opt/jdk-' + params['jdk'] + '/bin',
-              "MAVEN_ARGS=${env.MAVEN_ARGS != null ? MAVEN_ARGS : ''} -B -ntp -Dmaven.repo.local=${WORKSPACE_TMP}/m2repo",
+              "MAVEN_ARGS=${env.MAVEN_ARGS != null ? MAVEN_ARGS : ''} -B ${env.MAVEN_NTP != null ? '-ntp' : ''} -Dmaven.repo.local=${WORKSPACE_TMP}/m2repo",
               "MVN_LOCAL_REPO=${WORKSPACE_TMP}/m2repo",
             ]) {
               infra.loadMavenLocalCacheIfAny(env.MVN_LOCAL_REPO)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,9 +69,6 @@ stage('prep') {
     withEnv(['SAMPLE_PLUGIN_OPTS=-Dset.changelist']) {
       sh '''
       mvn -v
-      echo "Starting artifact caching proxy pre-heat"
-      mvn -ntp org.apache.maven.plugins:maven-dependency-plugin:3.9.0:go-offline
-      echo "Finished artifact caching proxy pre-heat"
       bash prep.sh
       '''
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,18 +31,7 @@ def mavenEnv(Map params = [:], Closure body) {
               "MAVEN_ARGS=${env.MAVEN_ARGS != null ? MAVEN_ARGS : ''} -B -ntp -Dmaven.repo.local=${WORKSPACE_TMP}/m2repo",
               "MVN_LOCAL_REPO=${WORKSPACE_TMP}/m2repo",
             ]) {
-              // Load Maven Repo Cache if available
-              sh '''
-              mkdir -p "${MVN_LOCAL_REPO}"
-              if test -f /cache/maven-bom-local-repo.tar.gz;
-              then
-                pushd "${MVN_LOCAL_REPO}"
-                time cp /cache/maven-bom-local-repo.tar.gz ../
-                time tar xzf ../maven-bom-local-repo.tar.gz ./
-                rm ../maven-bom-local-repo.tar.gz
-                popd
-              fi
-              '''
+              infra.loadMavenLocalCacheIfAny(env.MVN_LOCAL_REPO)
 
               body()
             }


### PR DESCRIPTION
This PR introduces a few improvements (1 commit per improvement) in the Maven cache management:

- Delegate cache loading to pipeline library (see https://github.com/jenkins-infra/pipeline-library/pull/1025 as part of https://github.com/jenkins-infra/helpdesk/issues/5193). No real change except cache is now shared with other builds than BOM
- Allow debuging the artifact download transfer in Maven with a pipeline env. boolean to control the `-ntp` flag (easier when replaying a pipeline to check cache behavior)
- Remove the "pre-heat" phase as it's not needed anymore: it wasn't efficient (only `prep` phase dependencies, almost no caching for the hundreds of PCT branches) and unneeded since we started to use the maven cache
  - One less moving piece to avoid issues such as https://github.com/jenkinsci/bom/pull/6959