### PR TITLE
Record elapsed time per combination of tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -134,6 +134,7 @@ if (BRANCH_NAME == 'master' || fullTestMarkerFile || weeklyTestMarkerFile || env
             } finally {
               // Generate duration of all tests executed in this branch
               def duration = sh(returnStdout:true, script: '''#!/bin/bash
+              set -x
               duration=0
               while IFS= read -r file; do
                 time=$(xmllint --xpath "string(/testsuite/@time)" "${file}" 2>/dev/null || true)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,7 +76,13 @@ stage('prep') {
     fullTestMarkerFile = fileExists 'full-test'
     weeklyTestMarkerFile = fileExists 'weekly-test'
     dir('target') {
-      def plugins = readFile('plugins.txt').split('\n')
+      // def plugins = readFile('plugins.txt').split('\n')
+      // TODO: for debug only, to remove
+      def plugins = [
+        'jenkinsci/aws-credentials-plugin	aws-credentials',
+        'jenkinsci/aws-global-configuration-plugin	aws-global-configuration',
+        'jenkinsci/aws-java-sdk-plugin	aws-java-sdk-api-gateway,aws-java-sdk-autoscaling,aws-java-sdk-cloudformation,aws-java-sdk-cloudfront,aws-java-sdk-cloudwatch,aws-java-sdk-codebuild,aws-java-sdk-codedeploy,aws-java-sdk-ec2,aws-java-sdk-ecr,aws-java-sdk-ecs,aws-java-sdk-efs,aws-java-sdk-elasticbeanstalk,aws-java-sdk-elasticloadbalancingv2,aws-java-sdk-iam,aws-java-sdk-kinesis,aws-java-sdk-lambda,aws-java-sdk-logs,aws-java-sdk-minimal,aws-java-sdk-organizations,aws-java-sdk-secretsmanager,aws-java-sdk-sns,aws-java-sdk-sqs,aws-java-sdk-ssm'
+      ]
       pluginsByRepository = parsePlugins(plugins)
 
       lines = readFile('lines.txt').split('\n')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,7 +62,7 @@ def pluginsByRepository
 def lines
 def fullTestMarkerFile
 def weeklyTestMarkerFile
-def durations
+def durations = [:]
 
 stage('prep') {
   mavenEnv(jdk: 21) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -105,6 +105,7 @@ if (BRANCH_NAME == 'master' || fullTestMarkerFile || weeklyTestMarkerFile || env
             "LINE=$line",
             'EXTRA_MAVEN_PROPERTIES=maven.test.failure.ignore=true:surefire.rerunFailingTestsCount=1'
           ]) {
+            def start = System.currentTimeMillis()
             try {
               sh '''
               mvn -v
@@ -117,22 +118,8 @@ if (BRANCH_NAME == 'master' || fullTestMarkerFile || weeklyTestMarkerFile || env
                 throw e
               }
             } finally {
-              // Generate duration of all tests executed in this branch
-              def duration = sh(returnStdout:true, script: '''#!/bin/bash
-              set -x
-              duration=0
-              while IFS= read -r file; do
-                time=$(xmllint --xpath "string(/testsuite/@time)" "${file}" 2>/dev/null || true)
-                if [ -n "${time}" ]; then
-                  duration=$(bc <<< "scale=2; ${duration} + ${time}")
-                  if [[ "${duration}" == .* ]]; then
-                    duration="0${duration}"
-                  fi
-                fi
-              done <<< $(find . -path '*/target/surefire-reports/*' -name 'TEST-*.xml')
-              echo "${duration}"
-              ''').trim()
-              durations["pct-$repository-$line"] = duration.toFloat()
+              def elapsed = System.currentTimeMillis() - start
+              durations["pct-$repository-$line"] = (elapsed / 1000.0)
             }
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -118,8 +118,7 @@ if (BRANCH_NAME == 'master' || fullTestMarkerFile || weeklyTestMarkerFile || env
               } else {
                 throw e
               }
-            }
-            finally {
+            } finally {
               // Generate duration of all tests executed in this branch
               def duration = sh(returnStdout:true, script: '''#!/bin/bash
               duration=0

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,7 +76,9 @@ stage('prep') {
     fullTestMarkerFile = fileExists 'full-test'
     weeklyTestMarkerFile = fileExists 'weekly-test'
     dir('target') {
-      def plugins = readFile('plugins.txt').split('\n')
+      // def plugins = readFile('plugins.txt').split('\n')
+      // TODO: remove before merging, for debugging only
+      def plugins = readFile('plugins_debug.txt').split('\n')
       pluginsByRepository = parsePlugins(plugins)
 
       lines = readFile('lines.txt').split('\n')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -81,7 +81,15 @@ stage('prep') {
       def plugins = [
         'jenkinsci/aws-credentials-plugin	aws-credentials',
         'jenkinsci/aws-global-configuration-plugin	aws-global-configuration',
-        'jenkinsci/aws-java-sdk-plugin	aws-java-sdk-api-gateway,aws-java-sdk-autoscaling,aws-java-sdk-cloudformation,aws-java-sdk-cloudfront,aws-java-sdk-cloudwatch,aws-java-sdk-codebuild,aws-java-sdk-codedeploy,aws-java-sdk-ec2,aws-java-sdk-ecr,aws-java-sdk-ecs,aws-java-sdk-efs,aws-java-sdk-elasticbeanstalk,aws-java-sdk-elasticloadbalancingv2,aws-java-sdk-iam,aws-java-sdk-kinesis,aws-java-sdk-lambda,aws-java-sdk-logs,aws-java-sdk-minimal,aws-java-sdk-organizations,aws-java-sdk-secretsmanager,aws-java-sdk-sns,aws-java-sdk-sqs,aws-java-sdk-ssm'
+        'jenkinsci/aws-java-sdk-plugin	aws-java-sdk-api-gateway,aws-java-sdk-autoscaling,aws-java-sdk-cloudformation,aws-java-sdk-cloudfront,aws-java-sdk-cloudwatch,aws-java-sdk-codebuild,aws-java-sdk-codedeploy,aws-java-sdk-ec2,aws-java-sdk-ecr,aws-java-sdk-ecs,aws-java-sdk-efs,aws-java-sdk-elasticbeanstalk,aws-java-sdk-elasticloadbalancingv2,aws-java-sdk-iam,aws-java-sdk-kinesis,aws-java-sdk-lambda,aws-java-sdk-logs,aws-java-sdk-minimal,aws-java-sdk-organizations,aws-java-sdk-secretsmanager,aws-java-sdk-sns,aws-java-sdk-sqs,aws-java-sdk-ssm',
+        'jenkinsci/azure-credentials-plugin	azure-credentials',
+        'jenkinsci/azure-keyvault-plugin	azure-keyvault',
+        'jenkinsci/azure-sdk-plugin	azure-sdk',
+        'jenkinsci/azure-storage-plugin	windows-azure-storage',
+        'jenkinsci/azure-vm-agents-plugin	azure-vm-agents',
+        'jenkinsci/badge-plugin	badge',
+        'jenkinsci/basic-branch-build-strategies-plugin	basic-branch-build-strategies',
+        'jenkinsci/bitbucket-branch-source-plugin	cloudbees-bitbucket-branch-source',
       ]
       pluginsByRepository = parsePlugins(plugins)
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -144,18 +144,18 @@ if (BRANCH_NAME == 'master' || fullTestMarkerFile || weeklyTestMarkerFile || env
     Double totalTime = 0
     def reportLines = ''
     durations.each { branch, time ->
-        totalTime += time as Double
-        reportLines += '<testcase name="'+branch+'" classname="pct-duration.'+branch+'" time="'+time+'"/>\n'
+      totalTime += time as Double
+      reportLines += '<testcase name="'+branch+'" classname="pct-duration.'+branch+'" time="'+time+'"/>\n'
     }
     if (reportLines) {
-        def content = """<?xml version="1.0" encoding="UTF-8"?>
-            <testsuite name="bom" time="${totalTime}">
-            ${reportLines}
-            </testsuite>
-        """
-        writeFile file: 'bom-report.xml', text: content
-        archiveArtifacts artifacts: 'bom-report.xml'
-        junit allowEmptyResults: true, testResults: 'bom-report.xml'
+      def content = """<?xml version="1.0" encoding="UTF-8"?>
+        <testsuite name="bom" time="${totalTime}">
+        ${reportLines}
+        </testsuite>
+      """
+      writeFile file: 'bom-report.xml', text: content
+      archiveArtifacts artifacts: 'bom-report.xml'
+      junit allowEmptyResults: true, testResults: 'bom-report.xml'
     }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -154,21 +154,23 @@ if (BRANCH_NAME == 'master' || fullTestMarkerFile || weeklyTestMarkerFile || env
   }
   parallel branches
   stage('duration report') {
-    Double totalTime = 0
-    def reportLines = ''
-    durations.each { branch, time ->
-      totalTime += time as Double
-      reportLines += '<testcase name="'+branch+'" classname="pct-duration.'+branch+'" time="'+time+'"/>\n'
-    }
-    if (reportLines) {
-      def content = """<?xml version="1.0" encoding="UTF-8"?>
-        <testsuite name="bom" time="${totalTime}">
-        ${reportLines}
-        </testsuite>
-      """
-      writeFile file: 'bom-report.xml', text: content
-      archiveArtifacts artifacts: 'bom-report.xml'
-      junit allowEmptyResults: true, testResults: 'bom-report.xml'
+    node('maven-bom') {
+      Double totalTime = 0
+      def reportLines = ''
+      durations.each { branch, time ->
+        totalTime += time as Double
+        reportLines += '<testcase name="'+branch+'" classname="pct-duration.'+branch+'" time="'+time+'"/>\n'
+      }
+      if (reportLines) {
+        def content = """<?xml version="1.0" encoding="UTF-8"?>
+          <testsuite name="bom" time="${totalTime}">
+          ${reportLines}
+          </testsuite>
+        """
+        writeFile file: 'bom-report.xml', text: content
+        archiveArtifacts artifacts: 'bom-report.xml'
+        junit allowEmptyResults: true, testResults: 'bom-report.xml'
+      }
     }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -90,6 +90,7 @@ stage('prep') {
         'jenkinsci/badge-plugin	badge',
         'jenkinsci/basic-branch-build-strategies-plugin	basic-branch-build-strategies',
         'jenkinsci/bitbucket-branch-source-plugin	cloudbees-bitbucket-branch-source',
+        'jenkinsci/pipeline-model-definition-plugin	pipeline-model-api,pipeline-model-definition,pipeline-model-extensions,pipeline-stage-tags-metadata',
       ]
       pluginsByRepository = parsePlugins(plugins)
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -161,7 +161,7 @@ if (BRANCH_NAME == 'master' || fullTestMarkerFile || weeklyTestMarkerFile || env
       def reportLines = ''
       durations.each { branch, time ->
         totalTime += time as Double
-        reportLines += '<testcase name="'+branch+'" classname="pct-duration.'+branch+'" time="'+time+'"/>\n'
+        reportLines += '<testcase name="' + branch + '" classname="pct-duration.' + branch + '" time="' + time + '"/>\n'
       }
       if (reportLines) {
         def content = """<?xml version="1.0" encoding="UTF-8"?>

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -90,7 +90,7 @@ stage('prep') {
 }
 
 if (BRANCH_NAME == 'master' || fullTestMarkerFile || weeklyTestMarkerFile || env.CHANGE_ID && (pullRequest.labels.contains('full-test') || pullRequest.labels.contains('weekly-test'))) {
-  branches = [failFast: false]
+  def branches = [failFast: false]
   lines.each {line ->
     if (line != 'weekly' && (weeklyTestMarkerFile || env.CHANGE_ID && pullRequest.labels.contains('weekly-test'))) {
       return

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,9 +76,7 @@ stage('prep') {
     fullTestMarkerFile = fileExists 'full-test'
     weeklyTestMarkerFile = fileExists 'weekly-test'
     dir('target') {
-      // def plugins = readFile('plugins.txt').split('\n')
-      // TODO: remove before merging, for debugging only
-      def plugins = readFile('plugins_debug.txt').split('\n')
+      def plugins = readFile('plugins.txt').split('\n')
       pluginsByRepository = parsePlugins(plugins)
 
       lines = readFile('lines.txt').split('\n')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,6 +62,7 @@ def pluginsByRepository
 def lines
 def fullTestMarkerFile
 def weeklyTestMarkerFile
+def durations
 
 stage('prep') {
   mavenEnv(jdk: 21) {
@@ -104,16 +105,59 @@ if (BRANCH_NAME == 'master' || fullTestMarkerFile || weeklyTestMarkerFile || env
             "LINE=$line",
             'EXTRA_MAVEN_PROPERTIES=maven.test.failure.ignore=true:surefire.rerunFailingTestsCount=1'
           ]) {
-            sh '''
-            mvn -v
-            bash pct.sh
-            '''
+            try {
+              sh '''
+              mvn -v
+              bash pct.sh
+              '''
+            } catch (e) {
+              if (!(e instanceof InterruptedException) && !(e instanceof org.jenkinsci.plugins.workflow.support.steps.AgentOfflineException)) {
+                unstable('PCT failed in ' + repository + ' - line ' + line)
+              } else {
+                throw e
+              }
+            }
+            finally {
+              // Generate duration of all tests executed in this branch
+              def duration = sh(returnStdout:true, script: '''#!/bin/bash
+              duration=0
+              while IFS= read -r file; do
+                time=$(xmllint --xpath "string(/testsuite/@time)" "${file}" 2>/dev/null || true)
+                if [ -n "${time}" ]; then
+                  duration=$(bc <<< "scale=2; ${duration} + ${time}")
+                  if [[ "${duration}" == .* ]]; then
+                    duration="0${duration}"
+                  fi
+                fi
+              done <<< $(find . -path '*/target/surefire-reports/*' -name 'TEST-*.xml')
+              echo "${duration}"
+              ''').trim()
+              durations["pct-$repository-$line"] = duration.toFloat()
+            }
           }
         }
       }
     }
   }
   parallel branches
+  stage('duration report') {
+    Double totalTime = 0
+    def reportLines = ''
+    durations.each { branch, time ->
+        totalTime += time as Double
+        reportLines += '<testcase name="'+branch+'" classname="pct-duration.'+branch+'" time="'+time+'"/>\n'
+    }
+    if (reportLines) {
+        def content = """<?xml version="1.0" encoding="UTF-8"?>
+            <testsuite name="bom" time="${totalTime}">
+            ${reportLines}
+            </testsuite>
+        """
+        writeFile file: 'bom-report.xml', text: content
+        archiveArtifacts artifacts: 'bom-report.xml'
+        junit allowEmptyResults: true, testResults: 'bom-report.xml'
+    }
+  }
 }
 
 if (fullTestMarkerFile) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,22 +76,7 @@ stage('prep') {
     fullTestMarkerFile = fileExists 'full-test'
     weeklyTestMarkerFile = fileExists 'weekly-test'
     dir('target') {
-      // def plugins = readFile('plugins.txt').split('\n')
-      // TODO: for debug only, to remove
-      def plugins = [
-        'jenkinsci/aws-credentials-plugin	aws-credentials',
-        'jenkinsci/aws-global-configuration-plugin	aws-global-configuration',
-        'jenkinsci/aws-java-sdk-plugin	aws-java-sdk-api-gateway,aws-java-sdk-autoscaling,aws-java-sdk-cloudformation,aws-java-sdk-cloudfront,aws-java-sdk-cloudwatch,aws-java-sdk-codebuild,aws-java-sdk-codedeploy,aws-java-sdk-ec2,aws-java-sdk-ecr,aws-java-sdk-ecs,aws-java-sdk-efs,aws-java-sdk-elasticbeanstalk,aws-java-sdk-elasticloadbalancingv2,aws-java-sdk-iam,aws-java-sdk-kinesis,aws-java-sdk-lambda,aws-java-sdk-logs,aws-java-sdk-minimal,aws-java-sdk-organizations,aws-java-sdk-secretsmanager,aws-java-sdk-sns,aws-java-sdk-sqs,aws-java-sdk-ssm',
-        'jenkinsci/azure-credentials-plugin	azure-credentials',
-        'jenkinsci/azure-keyvault-plugin	azure-keyvault',
-        'jenkinsci/azure-sdk-plugin	azure-sdk',
-        'jenkinsci/azure-storage-plugin	windows-azure-storage',
-        'jenkinsci/azure-vm-agents-plugin	azure-vm-agents',
-        'jenkinsci/badge-plugin	badge',
-        'jenkinsci/basic-branch-build-strategies-plugin	basic-branch-build-strategies',
-        'jenkinsci/bitbucket-branch-source-plugin	cloudbees-bitbucket-branch-source',
-        'jenkinsci/pipeline-model-definition-plugin	pipeline-model-api,pipeline-model-definition,pipeline-model-extensions,pipeline-stage-tags-metadata',
-      ]
+      def plugins = readFile('plugins.txt').split('\n')
       pluginsByRepository = parsePlugins(plugins)
 
       lines = readFile('lines.txt').split('\n')

--- a/plugins_debug.txt
+++ b/plugins_debug.txt
@@ -1,8 +1,0 @@
-jenkinsci/aws-credentials-plugin	aws-credentials
-jenkinsci/aws-global-configuration-plugin	aws-global-configuration
-jenkinsci/aws-java-sdk-plugin	aws-java-sdk-api-gateway,aws-java-sdk-autoscaling,aws-java-sdk-cloudformation,aws-java-sdk-cloudfront,aws-java-sdk-cloudwatch,aws-java-sdk-codebuild,aws-java-sdk-codedeploy,aws-java-sdk-ec2,aws-java-sdk-ecr,aws-java-sdk-ecs,aws-java-sdk-efs,aws-java-sdk-elasticbeanstalk,aws-java-sdk-elasticloadbalancingv2,aws-java-sdk-iam,aws-java-sdk-kinesis,aws-java-sdk-lambda,aws-java-sdk-logs,aws-java-sdk-minimal,aws-java-sdk-organizations,aws-java-sdk-secretsmanager,aws-java-sdk-sns,aws-java-sdk-sqs,aws-java-sdk-ssm
-jenkinsci/aws-java-sdk2-plugin	aws-java-sdk2-apigateway,aws-java-sdk2-autoscaling,aws-java-sdk2-cloudformation,aws-java-sdk2-cloudfront,aws-java-sdk2-cloudwatch,aws-java-sdk2-cloudwatchlogs,aws-java-sdk2-codebuild,aws-java-sdk2-codedeploy,aws-java-sdk2-core,aws-java-sdk2-ec2,aws-java-sdk2-ecr,aws-java-sdk2-ecs,aws-java-sdk2-efs,aws-java-sdk2-elasticbeanstalk,aws-java-sdk2-elasticloadbalancingv2,aws-java-sdk2-iam,aws-java-sdk2-kinesis,aws-java-sdk2-lambda,aws-java-sdk2-netty-nio-client,aws-java-sdk2-organizations,aws-java-sdk2-s3,aws-java-sdk2-secretsmanager,aws-java-sdk2-sns,aws-java-sdk2-sqs,aws-java-sdk2-ssm,aws-java-sdk2-sso
-jenkinsci/azure-credentials-plugin	azure-credentials
-jenkinsci/azure-keyvault-plugin	azure-keyvault
-jenkinsci/azure-sdk-plugin	azure-sdk
-jenkinsci/azure-storage-plugin	windows-azure-storage

--- a/plugins_debug.txt
+++ b/plugins_debug.txt
@@ -1,0 +1,8 @@
+jenkinsci/aws-credentials-plugin	aws-credentials
+jenkinsci/aws-global-configuration-plugin	aws-global-configuration
+jenkinsci/aws-java-sdk-plugin	aws-java-sdk-api-gateway,aws-java-sdk-autoscaling,aws-java-sdk-cloudformation,aws-java-sdk-cloudfront,aws-java-sdk-cloudwatch,aws-java-sdk-codebuild,aws-java-sdk-codedeploy,aws-java-sdk-ec2,aws-java-sdk-ecr,aws-java-sdk-ecs,aws-java-sdk-efs,aws-java-sdk-elasticbeanstalk,aws-java-sdk-elasticloadbalancingv2,aws-java-sdk-iam,aws-java-sdk-kinesis,aws-java-sdk-lambda,aws-java-sdk-logs,aws-java-sdk-minimal,aws-java-sdk-organizations,aws-java-sdk-secretsmanager,aws-java-sdk-sns,aws-java-sdk-sqs,aws-java-sdk-ssm
+jenkinsci/aws-java-sdk2-plugin	aws-java-sdk2-apigateway,aws-java-sdk2-autoscaling,aws-java-sdk2-cloudformation,aws-java-sdk2-cloudfront,aws-java-sdk2-cloudwatch,aws-java-sdk2-cloudwatchlogs,aws-java-sdk2-codebuild,aws-java-sdk2-codedeploy,aws-java-sdk2-core,aws-java-sdk2-ec2,aws-java-sdk2-ecr,aws-java-sdk2-ecs,aws-java-sdk2-efs,aws-java-sdk2-elasticbeanstalk,aws-java-sdk2-elasticloadbalancingv2,aws-java-sdk2-iam,aws-java-sdk2-kinesis,aws-java-sdk2-lambda,aws-java-sdk2-netty-nio-client,aws-java-sdk2-organizations,aws-java-sdk2-s3,aws-java-sdk2-secretsmanager,aws-java-sdk2-sns,aws-java-sdk2-sqs,aws-java-sdk2-ssm,aws-java-sdk2-sso
+jenkinsci/azure-credentials-plugin	azure-credentials
+jenkinsci/azure-keyvault-plugin	azure-keyvault
+jenkinsci/azure-sdk-plugin	azure-sdk
+jenkinsci/azure-storage-plugin	windows-azure-storage


### PR DESCRIPTION
This change ~~totalises test durations per branch (one per repository of plugins and release line couple)~~ collects the time spent on `bash pct.sh` per branch (see https://github.com/jenkinsci/bom/pull/7033#issuecomment-4874658659 why), then generate a XML junit report containing one line per branch duration for the whole build, in order to have data to pass to the `splitTests` function of https://plugins.jenkins.io/parallel-test-executor's.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/5208

### Testing done

CI

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
