### PR TITLE
Use Jenkins 2.568.1 for 2.568.x line

### DIFF
--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -1714,8 +1714,7 @@
       <id>2.568.x</id>
       <properties>
         <bom>2.568.x</bom>
-        <!-- TODO: Replace with 2.568.1 after release of 2.568.1 -->
-        <jenkins.version>2.568</jenkins.version>
+        <jenkins.version>2.568.1</jenkins.version>
       </properties>
     </profile>
     <profile>


### PR DESCRIPTION
## Use Jenkins 2.568.1 for 2.568.x line

Was 2.568 while we waited for 2.568.1 LTS release

LTS release checklist:

* https://github.com/jenkins-infra/release/issues/928

### Testing done

* `LINE=2.568.x PLUGINS=git TEST=InjectedTest bash ./local-test.sh`

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
