### PR TITLE
Add build-token-root to the plugin BOM

### DIFF
--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -892,7 +892,8 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>build-token-root</artifactId>
-        <version>151.va_e52fe3215fc</version>
+        <!-- TODO: https://github.com/jenkinsci/build-token-root-plugin/pull/250 -->
+        <version>361.v580f2070033c</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -892,8 +892,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>build-token-root</artifactId>
-        <!-- TODO: https://github.com/jenkinsci/build-token-root-plugin/pull/251 -->
-        <version>361.vfcb_6a_3a_75957</version>
+        <version>365.v717f8685a_09e</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -892,8 +892,8 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>build-token-root</artifactId>
-        <!-- TODO: https://github.com/jenkinsci/build-token-root-plugin/pull/250 -->
-        <version>361.v580f2070033c</version>
+        <!-- TODO: https://github.com/jenkinsci/build-token-root-plugin/pull/251 -->
+        <version>361.vfcb_6a_3a_75957</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -891,6 +891,11 @@
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>build-token-root</artifactId>
+        <version>151.va_e52fe3215fc</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>build-user-vars-plugin</artifactId>
         <version>214.va_eed2ed849ca_</version>
       </dependency>

--- a/full-test
+++ b/full-test
@@ -1,1 +1,0 @@
-Run the full BOM test matrix for the build-token-root addition.

--- a/full-test
+++ b/full-test
@@ -1,0 +1,1 @@
+Run the full BOM test matrix for the build-token-root addition.

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -796,6 +796,11 @@
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>build-token-root</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>build-user-vars-plugin</artifactId>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
## Summary

- add `org.jenkins-ci.plugins:build-token-root` at released version `365.v717f8685a_09e` to `bom-weekly`
- add the plugin as a test-scoped dependency of `sample-plugin`

## Motivation

The Build Token Trigger plugin uses Build Authorization Token Root in its test suite. During review of jenkinsci/build-token-trigger-plugin#6, `jglick` recommended managing this dependency in the plugin BOM rather than declaring an explicit version.

The prior public build-token-root release lacked the SCM metadata required by the BOM plugin compatibility tooling. The first incremental restored metadata, then official PCT identified its retired `git://` source connection. jenkinsci/build-token-root-plugin#251 replaced that connection with HTTPS, was merged after upstream review, and is included in the released version used here.

## Verification

- both modified POM files parse as XML
- exactly one managed dependency and one sample dependency were added
- `git diff --check` passes
- upstream HTTPS fix merged: https://github.com/jenkinsci/build-token-root-plugin/pull/251
- released dependency: https://github.com/jenkinsci/build-token-root-plugin/releases/tag/365.v717f8685a_09e
- Java 21 preparation matrix passes: https://github.com/zerlinpi/bom/actions/runs/29389429913
- focused PCT source-checkout validation passes with 10 tests, 0 failures, and 0 errors: https://github.com/zerlinpi/bom/actions/runs/29398760727
- resource-conscious full run #4 and focused retry #5 both isolated the same `open-telemetry` failure; neither reported a `build-token-root` failure
- build #7 on the formal-release head ended with the generic status `This commit cannot be built`; the anonymous log is unavailable
- the `full-test` marker was removed after the full run and focused retry established that the remaining failure is unrelated to this dependency