### PR TITLE
feat(pipeline): allow to run on a limited plugin set

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,6 +140,24 @@ Keep the PR in draft until tests pass and this file can be deleted.
 To further minimize build time, tests are run only on Linux, against Java 11, and without Docker support.
 It is unusual but possible for cross-component incompatibilities to only be visible in more specialized environments (such as Windows).
 
+### Running on a limited plugin set
+
+To run on a limited plugin set, add the label `limited-plugin-set` to run PCT in a PR - You would do this when debugging pipeline changes.
+
+> [!NOTE]
+> By default the set contains 10 plugins to consume a low amount of cloud resources.
+
+If you lack triage permission and so cannot add this label, or if you want to run on your own set of plugins, then you may instead
+
+```bash
+# One per line
+echo 'jenkinsci/variant-plugin	variant' > limited-plugin-set
+git add limited-plugin-set
+git commit -m 'Run limited plugin set'
+```
+
+Keep the PR in draft until tests pass and this file can be deleted.
+
 ## LTS lines
 
 A separate BOM artifact is available for the latest weekly, current LTS line and a few historical lines.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,9 +8,11 @@ env.MAVEN_NTP = true
 
 def fullTestLabel
 def weeklyTestLabel
+def limitedPluginSetLabel
 if (env.CHANGE_ID) {
   fullTestLabel = pullRequest.labels.contains('full-test')
   weeklyTestLabel = pullRequest.labels.contains('weekly-test')
+  limitedPluginSetLabel = pullRequest.labels.contains('limited-plugin-set')
 }
 
 def fixedPrepArchiveName = '' // can be set to a specific prep archive name in case last commits aren't impacting it
@@ -65,14 +67,28 @@ def pluginsByRepository
 def lines
 def fullTestMarkerFile
 def weeklyTestMarkerFile
+def limitedPluginSetMarkerFile
+def limitedPluginSet = [
+  'jenkinsci/aws-credentials-plugin	aws-credentials',
+  'jenkinsci/aws-global-configuration-plugin	aws-global-configuration',
+  'jenkinsci/azure-credentials-plugin	azure-credentials',
+  'jenkinsci/azure-keyvault-plugin	azure-keyvault',
+  'jenkinsci/azure-sdk-plugin	azure-sdk',
+  'jenkinsci/azure-storage-plugin	windows-azure-storage',
+  'jenkinsci/badge-plugin	badge',
+  'jenkinsci/basic-branch-build-strategies-plugin	basic-branch-build-strategies',
+  'jenkinsci/cron_column-plugin	cron_column',
+  'jenkinsci/pipeline-maven-plugin	pipeline-maven,pipeline-maven-api,pipeline-maven-database',
+]
 def durations = [:]
 
 mavenEnv(jdk: 21) {
   def scmVars = checkout scm
-  commitId = scmVars.GIT_COMMIT
+  def commitId = scmVars.GIT_COMMIT
 
   fullTestMarkerFile = fileExists 'full-test'
   weeklyTestMarkerFile = fileExists 'weekly-test'
+  limitedPluginSetMarkerFile = fileExists 'limited-plugin-set'
 
   // Ensure prep archive corresponds to the current state
   def prepArchiveName = "bom-prep-${commitId}.tar.gz"
@@ -120,14 +136,37 @@ mavenEnv(jdk: 21) {
 
   stage('parse prep') {
     dir('target') {
-      def plugins = readFile('plugins.txt').split('\n')
-      pluginsByRepository = parsePlugins(plugins)
+      def plugins = []
+      def allLines = []
+      def from = 'plugins.txt'
+      if (limitedPluginSetLabel || limitedPluginSetMarkerFile) {
+        from = 'a limited set of plugins'
+        echo('[WARNING] Running on a limited set of plugins')
 
-      def allLines = readFile('lines.txt').split('\n')
+        // Limited set
+        plugins = limitedPluginSet
+        if (limitedPluginSetMarkerFile) {
+          plugins = readFile('../limited-plugin-set').split('\n')
+        }
+        // Lines from sample-plugin
+        allLines = sh (
+            script: '''
+              echo "weekly $(grep -F '.x</bom>' ../sample-plugin/pom.xml | sed -E 's, *<bom>(.+)</bom>,\\1,g' | sort -rn | xargs)"
+            ''',
+            returnStdout: true
+            ).trim().split(' ')
+      } else {
+        plugins = readFile('plugins.txt').split('\n')
+        allLines = readFile('lines.txt').split('\n')
+      }
+      pluginsByRepository = parsePlugins(plugins)
+      echo "[INFO] ${pluginsByRepository.size()} repositories retrieved from ${from}"
+      echo "[INFO] List of repositories and their plugins:\n${plugins.join('\n')}"
+
       newestAndOldestLines = [allLines[0], allLines[-1]] // Save resources by running PCT only on newest and oldest lines
       echo "[INFO] ${allLines.size()} lines retrieved from lines.txt: ${allLines.join(' ')} "
 
-      // For archival, keep track of newest and oldest lines as PR labels may change accross builds
+      // For archival, keeping track of newest and oldest lines as PR labels may change accross builds
       // For stashes, we only care about the lines of the current build
       lines = newestAndOldestLines
       if (weeklyTestMarkerFile || weeklyTestLabel) {
@@ -236,8 +275,16 @@ if (BRANCH_NAME == 'master' || fullTestMarkerFile || weeklyTestMarkerFile || env
   }
 }
 
-if (fullTestMarkerFile) {
-  error 'Remember to `git rm full-test` before taking out of draft'
+stage('checks') {
+  if (fullTestMarkerFile) {
+    error 'Remember to `git rm full-test` before taking out of draft'
+  }
+  if (limitedPluginSetMarkerFile) {
+    error 'Remember to `git rm limited-plugin-set` before taking out of draft'
+  }
+  if (limitedPluginSetLabel) {
+    error 'Remember to remove `limited-plugin-set` label before taking out of draft'
+  }
 }
 
 infra.maybePublishIncrementals()


### PR DESCRIPTION
This change allows to run on a limited plugin set via `limited-plugin-set` label or marker file, useful to test and verify pipeline changes and test cases without consuming too many resources.

First extract from:
- #7037

### Testing done

CI

Testing when a PR has `limited-plugin-set` (and `weekly-test` FTR), failing at the end as expected due to the label still there: https://ci.jenkins.io/job/Tools/job/bom/job/PR-7077/11
> <img width="2249" height="771" alt="image" src="https://github.com/user-attachments/assets/0479f6a8-7e3b-4ebb-8706-818e2fbce782" />

Testing limited-plugin-set marker file: https://ci.jenkins.io/job/Tools/job/bom/job/PR-7077/13
```
$ echo 'jenkinsci/variant-plugin     variant' > limited-plugin-set
$ git add limited-plugin-set
$ git commit -m 'Run limited plugin set'
```
> <img width="2247" height="893" alt="image" src="https://github.com/user-attachments/assets/3d32493a-94dd-47cd-9ac9-75d3c80df901" />

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
