### PR TITLE
chore(pipeline): collect more info from test executions

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,6 +42,7 @@ def mavenEnv(Map params = [:], Closure body) {
             'PATH+JDK=/opt/jdk-' + params['jdk'] + '/bin',
             "MAVEN_ARGS=${env.MAVEN_ARGS != null ? MAVEN_ARGS : ''} -B ${env.MAVEN_NTP != null ? '-ntp' : ''} -Dmaven.repo.local=${WORKSPACE_TMP}/m2repo",
             "MVN_LOCAL_REPO=${WORKSPACE_TMP}/m2repo",
+            "CURRENT_ATTEMPT=${attempt}",
           ]) {
             infra.loadMavenLocalCacheIfAny(env.MVN_LOCAL_REPO)
 
@@ -63,6 +64,7 @@ def parsePlugins(plugins) {
   pluginsByRepository
 }
 
+def commitId
 def pluginsByRepository
 def lines
 def fullTestMarkerFile
@@ -80,11 +82,11 @@ def limitedPluginSet = [
   'jenkinsci/cron_column-plugin	cron_column',
   'jenkinsci/pipeline-maven-plugin	pipeline-maven,pipeline-maven-api,pipeline-maven-database',
 ]
-def durations = [:]
+def results = [:]
 
 mavenEnv(jdk: 21) {
   def scmVars = checkout scm
-  def commitId = scmVars.GIT_COMMIT
+  commitId = scmVars.GIT_COMMIT
 
   fullTestMarkerFile = fileExists 'full-test'
   weeklyTestMarkerFile = fileExists 'weekly-test'
@@ -220,7 +222,8 @@ if (BRANCH_NAME == 'master' || fullTestMarkerFile || weeklyTestMarkerFile || env
       return
     }
     pluginsByRepository.each { repository, plugins ->
-      branches["pct-$repository-$line"] = {
+      def branchName = "${repository}:${line}"
+      branches[branchName] = {
         def jdk = line == 'weekly' || line == '2.555.x' ? 21 : 17
         withChecks(name: 'Tests', includeStage: true) {
           mavenEnv(jdk: jdk) {
@@ -231,6 +234,9 @@ if (BRANCH_NAME == 'master' || fullTestMarkerFile || weeklyTestMarkerFile || env
               'EXTRA_MAVEN_PROPERTIES=maven.test.failure.ignore=true:surefire.rerunFailingTestsCount=1'
             ]) {
               def start = System.currentTimeMillis()
+              def currentAttempt = env.CURRENT_ATTEMPT.toInteger()
+              echo "[INFO] Current attempt: ${currentAttempt}"
+
               try {
                 sh '''
                 mvn -v
@@ -244,7 +250,21 @@ if (BRANCH_NAME == 'master' || fullTestMarkerFile || weeklyTestMarkerFile || env
                 }
               } finally {
                 def elapsed = System.currentTimeMillis() - start
-                durations["pct-$repository-$line"] = (elapsed / 1000.0)
+                def junitResults
+                try {
+                  junitResults = junit(testResults: '**/target/surefire-reports/TEST-*.xml,**/target/failsafe-reports/TEST-*.xml')
+                } catch(e) {
+                  echo "error junitResult: ${e}"
+                }
+                results[branchName] = getResultFromJunit(junitResults)
+                results[branchName]['elapsed'] = (elapsed / 1000.0)
+                results[branchName]['plugins'] = plugins
+                results[branchName]['pluginCount'] = plugins.size()
+                results[branchName]['attempt'] = currentAttempt
+                results[branchName]['build_id'] = env.BUILD_ID
+                results[branchName]['job_base_name'] = env.JOB_BASE_NAME
+                results[branchName]['short_commit_id'] = commitId.substring(0, 7)
+                echo "[INFO] results[${branchName}]: ${results[branchName]}"
               }
             }
           }
@@ -253,22 +273,43 @@ if (BRANCH_NAME == 'master' || fullTestMarkerFile || weeklyTestMarkerFile || env
     }
   }
   parallel branches
-  stage('duration report') {
+}
+
+stage('report results') {
+  if (results.size() == 0) {
+    catchError(buildResult: 'SUCCESS', stageResult: 'NOT_BUILT') {
+      error('[INFO] No result to report')
+    }
+    return
+  } else {
     node('maven-bom') {
-      Double totalTime = 0
+      Double totalElapsed = 0
+      Double totalCount = 0
+      Double totalSkipCount = 0
+      Double totalFailCount = 0
       def reportLines = ''
-      durations.each { branch, time ->
-        totalTime += time as Double
-        reportLines += '<testcase name="' + branch + '" classname="pct-duration.' + branch + '" time="' + time + '"/>\n'
+      results.each { combination, result ->
+        totalElapsed += result['elapsed']
+        totalCount += result['totalCount']
+        totalSkipCount += result['skipCount']
+        totalFailCount += result['failCount']
+        def normalizedCombination = combination.replaceAll('-', '_').replaceAll(':', '_').replaceAll('\\.', '_')
+        reportLines += '<testcase name="' + combination + '" classname="pct-duration.' + normalizedCombination + '" time="' + result['elapsed'] + '" failures="' + result['failCount'] + '"/>\n'
       }
       if (reportLines) {
-        def content = """<?xml version="1.0" encoding="UTF-8"?>
-          <testsuite name="bom" time="${totalTime}">
+        def xmlReport = """<?xml version="1.0" encoding="UTF-8"?>
+          <testsuite name="bom" time="${totalElapsed}" tests="${totalCount}" skipped="${totalSkipCount}" failures="${totalFailCount}">
           ${reportLines}
           </testsuite>
         """
-        writeFile file: 'bom-report.xml', text: content
-        archiveArtifacts artifacts: 'bom-report.xml'
+
+        def txtReport = results.collect { combination, result ->
+          'name=' + combination + ';' + result.collect { key, value -> key + '=' + value }.join(';')
+        }.sort().join('\n')
+
+        writeFile file: 'bom-report.xml', text: xmlReport
+        writeFile file: 'bom-report.txt', text: txtReport
+        archiveArtifacts artifacts: 'bom-report.*'
         junit allowEmptyResults: true, testResults: 'bom-report.xml'
       }
     }
@@ -328,4 +369,24 @@ def copyArtifactsFromAnyPreviousBuild(archiveName, jobName) {
     }
   }
   return foundInBuildNumber
+}
+
+@NonCPS
+def getResultFromJunit(junitResults) {
+  if (!junitResults) {
+    return [
+      failCount: 0,
+      skipCount: 0,
+      passCount: 0,
+      totalCount: 0,
+      duration: 0,
+    ]
+  }
+  return [
+    failCount: junitResults.failCount ?: 0,
+    skipCount: junitResults.skipCount ?: 0,
+    passCount: junitResults.passCount ?: 0,
+    totalCount: junitResults.totalCount ?: 0,
+    duration: junitResults.duration ?: 0,
+  ]
 }


### PR DESCRIPTION
This change collects more info and stores them in a determined basic key=value; format.

Follow-up of:
- https://github.com/jenkinsci/bom/pull/7033

Extracted from:
- #7037

Refs:
- https://github.com/jenkinsci/bom/issues/7073
- https://github.com/jenkins-infra/helpdesk/issues/5208

### Testing done

CI

> <img width="4560" height="4348" alt="image" src="https://github.com/user-attachments/assets/7e9330a0-c258-47df-9028-47c8d457329d" />


Resulting bom-report.txt on limited plugin set:
```
name=aws-credentials-plugin:weekly;failCount=0;skipCount=0;passCount=8;totalCount=8;duration=15.298;elapsed=39.122;plugins=[aws-credentials];pluginCount=1;attempt=1;build_id=21;job_base_name=PR-7078;short_commit_id=d73ef89
name=aws-global-configuration-plugin:weekly;failCount=0;skipCount=1;passCount=8;totalCount=9;duration=38.697998;elapsed=52.144;plugins=[aws-global-configuration];pluginCount=1;attempt=1;build_id=21;job_base_name=PR-7078;short_commit_id=d73ef89
name=azure-credentials-plugin:weekly;failCount=0;skipCount=0;passCount=26;totalCount=26;duration=71.962;elapsed=59.138;plugins=[azure-credentials];pluginCount=1;attempt=1;build_id=21;job_base_name=PR-7078;short_commit_id=d73ef89
name=azure-keyvault-plugin:weekly;failCount=0;skipCount=1;passCount=27;totalCount=28;duration=111.931;elapsed=86.832;plugins=[azure-keyvault];pluginCount=1;attempt=1;build_id=21;job_base_name=PR-7078;short_commit_id=d73ef89
name=azure-sdk-plugin:weekly;failCount=0;skipCount=1;passCount=3;totalCount=4;duration=6.002;elapsed=39.047;plugins=[azure-sdk];pluginCount=1;attempt=1;build_id=21;job_base_name=PR-7078;short_commit_id=d73ef89
name=azure-storage-plugin:weekly;failCount=0;skipCount=3;passCount=71;totalCount=74;duration=44.003;elapsed=61.633;plugins=[windows-azure-storage];pluginCount=1;attempt=1;build_id=21;job_base_name=PR-7078;short_commit_id=d73ef89
name=badge-plugin:weekly;failCount=0;skipCount=1;passCount=181;totalCount=182;duration=161.11499;elapsed=104.907;plugins=[badge];pluginCount=1;attempt=1;build_id=21;job_base_name=PR-7078;short_commit_id=d73ef89
name=basic-branch-build-strategies-plugin:weekly;failCount=0;skipCount=0;passCount=78;totalCount=78;duration=79.111;elapsed=76.307;plugins=[basic-branch-build-strategies];pluginCount=1;attempt=1;build_id=21;job_base_name=PR-7078;short_commit_id=d73ef89
name=cron_column-plugin:weekly;failCount=0;skipCount=0;passCount=9;totalCount=9;duration=5.363;elapsed=34.032;plugins=[cron_column];pluginCount=1;attempt=1;build_id=21;job_base_name=PR-7078;short_commit_id=d73ef89
name=pipeline-maven-plugin:weekly;failCount=0;skipCount=4;passCount=268;totalCount=272;duration=121.903;elapsed=253.155;plugins=[pipeline-maven, pipeline-maven-api, pipeline-maven-database];pluginCount=3;attempt=1;build_id=21;job_base_name=PR-7078;short_commit_id=d73ef89
```

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
