### PR TITLE
Revert ssh-agent from 413 to 402

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -74,6 +74,14 @@
     },
     {
       "matchDepNames": [
+        "org.jenkins-ci.plugins:ssh-agent"
+      ],
+      // skip 403.x through 413.x, see https://github.com/jenkinsci/ssh-agent-plugin/issues/290
+      // but allow 414.x and later so we pick up a fix when one ships
+      "allowedVersions": "!/^(40[3-9]|41[0-3])\\./"
+    },
+    {
+      "matchDepNames": [
         "org.jenkins-ci.tests:plugins-compat-tester-cli"
       ],
       "labels": [

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -1553,7 +1553,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>ssh-agent</artifactId>
-        <version>413.v1fd573533a_ec</version>
+        <version>402.vc9cec9230d4b_</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Rolling back to `402.vc9cec9230d4b_` due to a persistent PCT failure on the weekly line. `SSHAgentStepWorkflowTest.teardownDoesNotFailBuildWhenAgentAlreadyStopped` fails on ci.jenkins.io agents, blocking the weekly core bump in #7195.

See notification to author:
https://github.com/jenkinsci/ssh-agent-plugin/issues/290#issuecomment-5196823470

### Testing done

No direct testing done since the new problem is the same as the existing problem.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed