### PR TITLE
Pin mcp-server back to 0.190 (revert #7180)

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -82,6 +82,15 @@
     },
     {
       "matchDepNames": [
+        "io.jenkins.plugins:mcp-server"
+      ],
+      // skip 0.191.x, which excludes jackson2-api from pipeline-model-definition and breaks
+      // InjectedTest, see https://github.com/jenkinsci/mcp-server-plugin/pull/201
+      // but allow 0.192.x and later so we pick up a fix when one ships
+      "allowedVersions": "!/^0\\.191\\./"
+    },
+    {
+      "matchDepNames": [
         "org.jenkins-ci.tests:plugins-compat-tester-cli"
       ],
       "labels": [

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -24,7 +24,7 @@
     <junit-plugin.version>1418.v67a_81935603c</junit-plugin.version>
     <matrix-project-plugin.version>870.v9db_fcfc2f45b_</matrix-project-plugin.version>
     <!-- TODO 0.191 excludes jackson2-api from pipeline-model-definition, breaking InjectedTest;
-         see https://github.com/jenkinsci/mcp-server-plugin/pull/201 -->
+         see https://github.com/jenkinsci/mcp-server-plugin/issues/217-->
     <mcp-server.version>0.190.ve5a_6581ffc96</mcp-server.version>
     <mina-sshd-api.version>2.19.0-192.v2b_a_7b_2c1dc71</mina-sshd-api.version>
     <okhttp-api-plugin.version>5.3.2-200.vedb_720a_cf1f8</okhttp-api-plugin.version>

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -23,7 +23,9 @@
     <git-plugin.version>5.10.1</git-plugin.version>
     <junit-plugin.version>1418.v67a_81935603c</junit-plugin.version>
     <matrix-project-plugin.version>870.v9db_fcfc2f45b_</matrix-project-plugin.version>
-    <mcp-server.version>0.191.vb_d1125775e09</mcp-server.version>
+    <!-- TODO 0.191 excludes jackson2-api from pipeline-model-definition, breaking InjectedTest;
+         see https://github.com/jenkinsci/mcp-server-plugin/pull/201 -->
+    <mcp-server.version>0.190.ve5a_6581ffc96</mcp-server.version>
     <mina-sshd-api.version>2.19.0-192.v2b_a_7b_2c1dc71</mina-sshd-api.version>
     <okhttp-api-plugin.version>5.3.2-200.vedb_720a_cf1f8</okhttp-api-plugin.version>
     <pipeline-maven-plugin.version>1760.v9a_a_e6dcb_0444</pipeline-maven-plugin.version>


### PR DESCRIPTION
mcp-server 0.191 switched from jackson2-api to jackson3-api and, as part of that, added an explicit exclusion of jackson2-api from its pipeline-model-definition test dependency:

    https://github.com/jenkinsci/mcp-server-plugin/pull/201

mcp-server itself no longer needs jackson2-api, but pipeline-model-api still does, so excluding it drops the plugin from the PCT test harness and Declarative Pipeline fails to load:

```
    pipeline-model-api - Plugin is missing: jackson2-api
    pipeline-model-extensions  -> cascades
    pipeline-model-definition  -> cascades
```

which fails `io.jenkins.plugins.mcp_server.InjectedTest#testPluginActive`.

Neither #7176 (0.190) nor #7180 (0.191) ran the PCT matrix, so this was not caught at bump time. Verified locally that 0.190 is clean against both core 2.575 and 2.576 (205 tests, 0 failures), so only #7180 needs reverting.

Also hold Renovate at 0.191.x only, so a fixed 0.192+ flows through.

### Testing done

Tested locally with 190 and 2.576.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed