### PR TITLE
Revert "Update dependency org.jenkins-ci.plugins:ssh-agent to v414"

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -76,9 +76,9 @@
       "matchDepNames": [
         "org.jenkins-ci.plugins:ssh-agent"
       ],
-      // skip 403.x through 413.x, see https://github.com/jenkinsci/ssh-agent-plugin/issues/290
-      // but allow 414.x and later so we pick up a fix when one ships
-      "allowedVersions": "!/^(40[3-9]|41[0-3])\\./"
+      // skip 403.x through 414.x, see https://github.com/jenkinsci/ssh-agent-plugin/issues/290
+      // but allow 415.x and later so we pick up a fix when one ships
+      "allowedVersions": "!/^(40[3-9]|41[0-4])\\./"
     },
     {
       "matchDepNames": [

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -1555,7 +1555,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>ssh-agent</artifactId>
-        <version>414.vc161b_f183543</version>
+        <version>402.vc9cec9230d4b_</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Rolling back to `402.vc9cec9230d4b_` for the same reason as #7199, which reverted 413: SSHAgentStepWorkflowTest.teardownDoesNotFailBuildWhenAgentAlreadyStopped still fails under PCT.

414 could not have fixed it. The 413..414 diff touches only ExecRemoteAgent.java (the "Unify sub-process command execution" refactor, jenkinsci/ssh-agent-plugin#295); SSHAgentStepWorkflowTest.java is byte-identical between the two tags.

Reproduced locally against a megawar built from this repo at `414.vc161b_f183543` (PCT checked out c161bf1):

  [ERROR] Tests run: 42, Failures: 1, Errors: 0, Skipped: 1
  [ERROR]   SSHAgentStepWorkflowTest.teardownDoesNotFailBuildWhenAgentAlreadyStopped
  Expected: a string containing "Failed to run ssh-agent -k"
       but: was "... $ ssh-agent -k / Agent pid 1190 killed; / Finished: SUCCESS"

The test asserts the build log contains "Failed to run ssh-agent -k", which only happens if the teardown's second "ssh-agent -k" fails. Because ssh-agent daemonizes and is reparented to PID 1, a non-reaping PID 1 leaves the killed agent as a zombie, kill() still succeeds, and the message is never logged. The build itself succeeds; the assertion depends on the reaping behavior of the environment.

Extend the Renovate skip range from 403.x-413.x to 403.x-414.x. 415.x and later are still allowed so a fix is picked up automatically.

See https://github.com/jenkinsci/ssh-agent-plugin/issues/290

### Testing done

local testing described above

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed