### PR TITLE
Skip ssh-agent 416.x in renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -76,9 +76,10 @@
       "matchDepNames": [
         "org.jenkins-ci.plugins:ssh-agent"
       ],
-      // skip 403.x through 414.x, see https://github.com/jenkinsci/ssh-agent-plugin/issues/290
-      // but allow 415.x and later so we pick up a fix when one ships
-      "allowedVersions": "!/^(40[3-9]|41[0-4])\\./"
+      // skip 403.x through 416.x, see https://github.com/jenkinsci/ssh-agent-plugin/issues/290
+      // 416 still does not address the issue, see https://github.com/jenkinsci/ssh-agent-plugin/releases/tag/416.v4d76015a_5d68
+      // but allow 417.x and later so we pick up a fix when one ships
+      "allowedVersions": "!/^(40[3-9]|41[0-6])\\./"
     },
     {
       "matchDepNames": [


### PR DESCRIPTION
416 still does not address the issues tracked in
https://github.com/jenkinsci/ssh-agent-plugin/issues/290

### Testing done

Built the weekly megawar with ssh-agent bumped to `416.v4d76015a_5d68` and ran PCT (PLUGINS=ssh-agent LINE=weekly) inside a container with a non-reaping PID 1, to match the ci.jenkins.io Kubernetes agent environment. `SSHAgentStepWorkflowTest.teardownDoesNotFailBuildWhenAgentAlreadyStopped` still fails (Tests run: 42, Failures: 1) with the same assertion as [jenkinsci/ssh-agent-plugin#290](https://github.com/jenkinsci/ssh-agent-plugin/issues/290) — the orphaned agent becomes a zombie rather than being reaped, so `ssh-agent -k` succeeds and the expected "Failed to run ssh-agent -k" message is never logged.

The currently pinned `402.vc9cec9230d4b_` passes in the identical setup (Tests run: 30, Failures: 0). So `416` does not resolve the issue and should stay excluded.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed