### PR TITLE
chore(pipeline): allow to run pct tests on a limited plugin set

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -81,7 +81,7 @@ stage('prep') {
     weeklyTestMarkerFile = fileExists 'weekly-test'
     def plugins = readFile('target/plugins.txt').split('\n')
     if (limitedPluginSet) {
-      unstable 'WARNING: running on a limited plugin set'
+      unstable 'Running on a limited plugin set'
       plugins = limitedPluginSet
     }
     pluginsByRepository = parsePlugins(plugins)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,8 +6,8 @@ if(env.BRANCH_NAME == "master") {
 
 env.MAVEN_NTP = true
 // Run pct tests on a limited set of repositories and their plugin(s) if not empty
-// Expected format: jenkinsci/<repo-name>, tab, <coma separated plugin(s)>
-// Ex: 'jenkinsci/pipeline-stage-view-plugin	pipeline-rest-api,pipeline-stage-view'
+// Expected list item format: jenkinsci/<repo-name>, tab, <coma separated plugin(s)>
+// Ex: 'jenkinsci/pipeline-stage-view-plugin\tpipeline-rest-api,pipeline-stage-view'
 final String[] limitedPluginSet = []
 
 properties([

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,10 @@ if(env.BRANCH_NAME == "master") {
 }
 
 env.MAVEN_NTP = true
+// Run pct tests on a limited set of repositories and their plugin(s) if not empty
+// Expected format: jenkinsci/<repo-name>, tab, <coma separated plugin(s)>
+// Ex: 'jenkinsci/pipeline-stage-view-plugin	pipeline-rest-api,pipeline-stage-view'
+final String[] limitedPluginSet = []
 
 properties([
   disableConcurrentBuilds(abortPrevious: true),
@@ -76,6 +80,10 @@ stage('prep') {
     fullTestMarkerFile = fileExists 'full-test'
     weeklyTestMarkerFile = fileExists 'weekly-test'
     def plugins = readFile('target/plugins.txt').split('\n')
+    if (limitedPluginSet) {
+      unstable 'WARNING: running on a limited plugin set'
+      plugins = limitedPluginSet
+    }
     pluginsByRepository = parsePlugins(plugins)
 
     lines = readFile('target/lines.txt').split('\n')


### PR DESCRIPTION
This change allows to specify in a replay or via a commit a limited set of plugins on which to run pct tests, and marks the build as unstable if not empty to avoid any mistake or oversight.

Ref:
- https://github.com/jenkinsci/bom/issues/7216

### Testing done

#### Replay with `weekly-test` label:
https://ci.jenkins.io/job/Tools/job/bom/view/change-requests/job/PR-7215/5/
```diff
-final String[] limitedPluginSet = []
+final String[] limitedPluginSet = [
+  'jenkinsci/pipeline-stage-view-plugin\tpipeline-rest-api,pipeline-stage-view',
+  'jenkinsci/ssh-agent-plugin\tssh-agent',
+]
```
> <img width="3950" height="3544" alt="image" src="https://github.com/user-attachments/assets/f8462e10-b39c-443e-8a3a-3e720700ae68" />


#### Normal build with no value set:
https://ci.jenkins.io/job/Tools/job/bom/view/change-requests/job/PR-7215/6/stages/?selected-node=51

Build logs show that all repositories from the plugins.txt file generated by prep.sh are taken in account, as expected:
> <img width="1473" height="382" alt="image" src="https://github.com/user-attachments/assets/a0e5e7e9-8883-4b6d-ab39-7d91bca780dd" />

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
