### PR TITLE
chore(pipeline): split existing stages for better timing overview

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -99,43 +99,45 @@ stage('prep') {
 }
 
 if (BRANCH_NAME == 'master' || fullTestMarkerFile || weeklyTestMarkerFile || env.CHANGE_ID && (pullRequest.labels.contains('full-test') || pullRequest.labels.contains('weekly-test'))) {
-  def branches = [failFast: false]
-  lines.each {line ->
-    if (line != 'weekly' && (weeklyTestMarkerFile || env.CHANGE_ID && pullRequest.labels.contains('weekly-test'))) {
-      return
-    }
-    pluginsByRepository.each { repository, plugins ->
-      branches["pct-$repository-$line"] = {
-        def jdk = line == 'weekly' || line == '2.555.x' ? 21 : 17
-        mavenEnv(jdk: jdk) {
-          unstash line
-          withEnv([
-            "PLUGINS=${plugins.join(',')}",
-            "LINE=$line",
-            'EXTRA_MAVEN_PROPERTIES=maven.test.failure.ignore=true:surefire.rerunFailingTestsCount=1'
-          ]) {
-            def start = System.currentTimeMillis()
-            try {
-              sh '''
-              mvn -v
-              bash pct.sh
-              '''
-            } catch (e) {
-              if (!(e instanceof InterruptedException) && !(e instanceof org.jenkinsci.plugins.workflow.support.steps.AgentOfflineException)) {
-                unstable('PCT failed in ' + repository + ' - line ' + line)
-              } else {
-                throw e
+  stage('run pct') {
+    def branches = [failFast: false]
+    lines.each {line ->
+      if (line != 'weekly' && (weeklyTestMarkerFile || env.CHANGE_ID && pullRequest.labels.contains('weekly-test'))) {
+        return
+      }
+      pluginsByRepository.each { repository, plugins ->
+        branches["pct-$repository-$line"] = {
+          def jdk = line == 'weekly' || line == '2.555.x' ? 21 : 17
+          mavenEnv(jdk: jdk) {
+            unstash line
+            withEnv([
+              "PLUGINS=${plugins.join(',')}",
+              "LINE=$line",
+              'EXTRA_MAVEN_PROPERTIES=maven.test.failure.ignore=true:surefire.rerunFailingTestsCount=1'
+            ]) {
+              def start = System.currentTimeMillis()
+              try {
+                sh '''
+                mvn -v
+                bash pct.sh
+                '''
+              } catch (e) {
+                if (!(e instanceof InterruptedException) && !(e instanceof org.jenkinsci.plugins.workflow.support.steps.AgentOfflineException)) {
+                  unstable('PCT failed in ' + repository + ' - line ' + line)
+                } else {
+                  throw e
+                }
+              } finally {
+                def elapsed = System.currentTimeMillis() - start
+                durations["pct-$repository-$line"] = (elapsed / 1000.0)
               }
-            } finally {
-              def elapsed = System.currentTimeMillis() - start
-              durations["pct-$repository-$line"] = (elapsed / 1000.0)
             }
           }
         }
       }
     }
+    parallel branches
   }
-  parallel branches
   stage('duration report') {
     node('maven-bom') {
       Double totalTime = 0

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -111,27 +111,31 @@ if (BRANCH_NAME == 'master' || fullTestMarkerFile || weeklyTestMarkerFile || env
         branches["pct-$repository-$line"] = {
           def jdk = line == 'weekly' || line == '2.555.x' ? 21 : 17
           mavenEnv(jdk: jdk) {
-            unstash line
-            withEnv([
-              "PLUGINS=${plugins.join(',')}",
-              "LINE=$line",
-              'EXTRA_MAVEN_PROPERTIES=maven.test.failure.ignore=true:surefire.rerunFailingTestsCount=1'
-            ]) {
-              def start = System.currentTimeMillis()
-              try {
-                sh '''
-                mvn -v
-                bash pct.sh
-                '''
-              } catch (e) {
-                if (!(e instanceof InterruptedException) && !(e instanceof org.jenkinsci.plugins.workflow.support.steps.AgentOfflineException)) {
-                  unstable('PCT failed in ' + repository + ' - line ' + line)
-                } else {
-                  throw e
+            stage('unstash line') {
+              unstash line
+            }
+            stage('pct tests') {
+              withEnv([
+                "PLUGINS=${plugins.join(',')}",
+                "LINE=$line",
+                'EXTRA_MAVEN_PROPERTIES=maven.test.failure.ignore=true:surefire.rerunFailingTestsCount=1'
+              ]) {
+                def start = System.currentTimeMillis()
+                try {
+                  sh '''
+                  mvn -v
+                  bash pct.sh
+                  '''
+                } catch (e) {
+                  if (!(e instanceof InterruptedException) && !(e instanceof org.jenkinsci.plugins.workflow.support.steps.AgentOfflineException)) {
+                    unstable('PCT failed in ' + repository + ' - line ' + line)
+                  } else {
+                    throw e
+                  }
+                } finally {
+                  def elapsed = System.currentTimeMillis() - start
+                  durations["pct-$repository-$line"] = (elapsed / 1000.0)
                 }
-              } finally {
-                def elapsed = System.currentTimeMillis() - start
-                durations["pct-$repository-$line"] = (elapsed / 1000.0)
               }
             }
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -158,8 +158,12 @@ if (BRANCH_NAME == 'master' || fullTestMarkerFile || weeklyTestMarkerFile || env
   }
 }
 
-if (fullTestMarkerFile) {
-  error 'Remember to `git rm full-test` before taking out of draft'
+stage('checks') {
+  if (fullTestMarkerFile) {
+    error 'Remember to `git rm full-test` before taking out of draft'
+  }
 }
 
-infra.maybePublishIncrementals()
+stage('publish incrementals') {
+  infra.maybePublishIncrementals()
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -68,8 +68,8 @@ def fullTestMarkerFile
 def weeklyTestMarkerFile
 def durations = [:]
 
-stage('prep') {
-  mavenEnv(jdk: 21) {
+mavenEnv(jdk: 21) {
+  stage('prep') {
     checkout scm
     withEnv(['SAMPLE_PLUGIN_OPTS=-Dset.changelist']) {
       sh '''
@@ -77,6 +77,8 @@ stage('prep') {
       bash prep.sh
       '''
     }
+    infra.prepareToPublishIncrementals()
+
     fullTestMarkerFile = fileExists 'full-test'
     weeklyTestMarkerFile = fileExists 'weekly-test'
     def plugins = readFile('target/plugins.txt').split('\n')
@@ -88,13 +90,13 @@ stage('prep') {
 
     lines = readFile('target/lines.txt').split('\n')
     lines = [lines[0], lines[-1]] // Save resources by running PCT only on newest and oldest lines
+    echo "${pluginsByRepository.size()} repositories:\n${plugins.join('\n')}"
+    echo "${lines.size()} lines: ${lines.join(' ')} "
+  }
+  stage('stash lines') {
     lines.each { line ->
       stash name: line, includes: "pct.sh,excludes.txt,bom-*/excludes.txt,target/pct.jar,target/megawar-${line}.war"
     }
-    echo "${pluginsByRepository.size()} repositories:\n${plugins.join('\n')}"
-    echo "${lines.size()} lines: ${lines.join(' ')} "
-
-    infra.prepareToPublishIncrementals()
   }
 }
 


### PR DESCRIPTION
This change splits the pipeline for better timing overview and adds visibility in pipeline graph view for commands out of stage.

40a4fb72: encapsulate out of stage commands into 'checks' and 'publish incremental'
9be9e8dd: encapsulate parallel branches into 'run pct'
304a432: split 'prep' stage into 'prep' and 'stash lines'
2d7c893f: split pct branch stage into 'unstash line' and 'pct tests' [^1]

> [!TIP]
> Best reviewed hiding whitespaces: https://github.com/jenkinsci/bom/pull/7221/changes?w=1

Ref:
- #7220

Related:
- #7073
- https://github.com/jenkins-infra/helpdesk/issues/5208

### Testing done

<details><summary>Before:</summary><hr>

Build "full-test" on master: https://ci.jenkins.io/job/Tools/job/bom/job/master/397

1) > <img width="538" height="236" alt="image" src="https://github.com/user-attachments/assets/8d9d5b05-fae0-4ee9-b88b-e15daa99b36f" />
2) > <img width="2278" height="1053" alt="image" src="https://github.com/user-attachments/assets/7e68287d-35ec-49c3-a780-49bb362215c2" />

Focus on a branch showing `mavenEnv` steps mixed with its owns:
> <img width="2154" height="556" alt="image" src="https://github.com/user-attachments/assets/cd9c12cd-f7c8-4d00-80d4-502513c181a3" />

Status checks from #7189:
1) > <img width="797" height="316" alt="image" src="https://github.com/user-attachments/assets/e43a4b36-3135-4840-b6f9-e61eceece69b" />
2) > <img width="799" height="212" alt="image" src="https://github.com/user-attachments/assets/6282dc33-3a48-483c-85f9-4c3e2d01667a" />


</details>

<details><summary>After:</summary><hr>

Replay[^2] with "weekly-test" label: https://ci.jenkins.io/job/Tools/job/bom/view/change-requests/job/PR-7221/14

1) > <img width="2160" height="990" alt="image" src="https://github.com/user-attachments/assets/48053e20-6039-47dd-a6dc-8645694ec205" />
2) > <img width="2149" height="668" alt="image" src="https://github.com/user-attachments/assets/97bacf02-e3a8-411f-8f58-43b79028c8f5" />
3) > <img width="2150" height="674" alt="image" src="https://github.com/user-attachments/assets/a7fca51a-0c4c-490f-b457-b8830c3c5397" />

Focus on a branch distinctly showing `mavenEnv` steps:
> <img width="2156" height="676" alt="image" src="https://github.com/user-attachments/assets/4f095ad2-e553-4a45-a15c-6f3010d664fa" />

Separated 'unstash' and 'pct tests' stages:
1) > <img width="2153" height="395" alt="image" src="https://github.com/user-attachments/assets/088bbda2-4c5a-44b4-bdc4-dbd4a1bae2c3" />
2) > <img width="2150" height="392" alt="image" src="https://github.com/user-attachments/assets/9f2ded9b-0523-494b-b966-6c85fa079bc0" />

Status checks[^2]:
> <img width="805" height="376" alt="image" src="https://github.com/user-attachments/assets/79d9b431-4a92-45ff-96e3-c3e0aaf7b95e" />

</details>

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->

[^1]: When I'll split tests later, each parallel branch (one per agent) will run more than one combination, but I'll only unstash the line once. Having the timing integrated before the split will be beneficial for future references and comparisons.
[^2]: Replay on a limited plugin set to avoid burning resources, with the 'unstable' instruction commented out to get a passing build: https://ci.jenkins.io/job/Tools/job/bom/view/change-requests/job/PR-7221/14/replay/diff