### PR TITLE
Revert "Update dependency org.jenkins-ci.plugins:ssh-agent to v417"

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -76,10 +76,10 @@
       "matchDepNames": [
         "org.jenkins-ci.plugins:ssh-agent"
       ],
-      // skip 403.x through 416.x, see https://github.com/jenkinsci/ssh-agent-plugin/issues/290
-      // 416 still does not address the issue, see https://github.com/jenkinsci/ssh-agent-plugin/releases/tag/416.v4d76015a_5d68
-      // but allow 417.x and later so we pick up a fix when one ships
-      "allowedVersions": "!/^(40[3-9]|41[0-6])\\./"
+      // skip 403.x through 417.x, see https://github.com/jenkinsci/ssh-agent-plugin/issues/290
+      // 417 still does not address the issue, see https://github.com/jenkinsci/ssh-agent-plugin/releases/tag/417.v1d50b_f28f0e0
+      // but allow 418.x and later so we pick up a fix when one ships
+      "allowedVersions": "!/^(40[3-9]|41[0-7])\\./"
     },
     {
       "matchDepNames": [

--- a/bom-weekly/pom.xml
+++ b/bom-weekly/pom.xml
@@ -1555,7 +1555,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>ssh-agent</artifactId>
-        <version>417.v1d50b_f28f0e0</version>
+        <version>402.vc9cec9230d4b_</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Rolling back to `402.vc9cec9230d4b_` for the same reason as #7205 and #7210: `SSHAgentStepWorkflowTest.teardownDoesNotFailBuildWhenAgentAlreadyStopped` still fails under PCT.

417 could not have fixed it. The 416..417 diff is a single commit, "fix: default ssh-agent timeout when loading legacy job configuration" (jenkinsci/ssh-agent-plugin#300), touching only SSHAgentBuildWrapper.java, ExecRemoteAgent.java, and a new SSHAgentBuildWrapperTimeoutTest.java. SSHAgentStepWorkflowTest.java is byte-identical between the two tags (blob 8b2e0c73836b50ec79b58e6c5b12aed18fe608bb).

Reproduced locally against a megawar built from this repo at 417.v1d50b_f28f0e0, run in a container whose PID 1 does not reap:

  [ERROR] Tests run: 45, Failures: 1, Errors: 0, Skipped: 1
  [ERROR]   SSHAgentStepWorkflowTest.teardownDoesNotFailBuildWhenAgentAlreadyStopped:112
  Expected: a string containing "Failed to run ssh-agent -k"
       but: was "... $ ssh-agent -k / Agent pid 1177 killed; / Finished: SUCCESS"

The test asserts the build log contains "Failed to run ssh-agent -k", which only happens if the teardown's second "ssh-agent -k" fails. Because ssh-agent daemonizes and is reparented to PID 1, a non-reaping PID 1 leaves the killed agent as a zombie, kill() still succeeds, and the message is never logged. The build itself succeeds; the assertion depends on the reaping behavior of the environment.

The same run against 402.vc9cec9230d4b_ passes: Tests run: 30,
Failures: 0, Errors: 0, Skipped: 1.

Extend the Renovate skip range from 403.x-416.x to 403.x-417.x. 418.x and later are still allowed so a fix is picked up automatically.

See https://github.com/jenkinsci/ssh-agent-plugin/issues/290

### Testing done

see description of testing done

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed