### PR TITLE
chore(pipeline): prevent `weekly-test` marker file to be merged

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ env.MAVEN_NTP = true
 // Run pct tests on a limited set of repositories and their plugin(s) if not empty
 // Expected list item format: jenkinsci/<repo-name>, tab, <coma separated plugin(s)>
 // Ex: 'jenkinsci/pipeline-stage-view-plugin\tpipeline-rest-api,pipeline-stage-view'
-final String[] limitedPluginSet = []
+final String[] limitedPluginSet = ['jenkinsci/badge-plugin\tbadge', 'jenkinsci/cron_column-plugin\tcron_column']
 
 properties([
   disableConcurrentBuilds(abortPrevious: true),
@@ -88,7 +88,7 @@ mavenEnv(jdk: 21) {
 
     def plugins = readFile('target/plugins.txt').split('\n')
     if (limitedPluginSet) {
-      unstable 'Running on a limited plugin set'
+      echo 'IGNORING: Running on a limited plugin set'
       plugins = limitedPluginSet
     }
     pluginsByRepository = parsePlugins(plugins)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ env.MAVEN_NTP = true
 // Run pct tests on a limited set of repositories and their plugin(s) if not empty
 // Expected list item format: jenkinsci/<repo-name>, tab, <coma separated plugin(s)>
 // Ex: 'jenkinsci/pipeline-stage-view-plugin\tpipeline-rest-api,pipeline-stage-view'
-final String[] limitedPluginSet = ['jenkinsci/badge-plugin\tbadge', 'jenkinsci/cron_column-plugin\tcron_column']
+final String[] limitedPluginSet = []
 
 properties([
   disableConcurrentBuilds(abortPrevious: true),
@@ -88,7 +88,7 @@ mavenEnv(jdk: 21) {
 
     def plugins = readFile('target/plugins.txt').split('\n')
     if (limitedPluginSet) {
-      echo 'IGNORING: Running on a limited plugin set'
+      unstable 'Running on a limited plugin set'
       plugins = limitedPluginSet
     }
     pluginsByRepository = parsePlugins(plugins)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -176,6 +176,9 @@ stage('checks') {
   if (fullTestMarkerFile) {
     error 'Remember to `git rm full-test` before taking out of draft'
   }
+  if (weeklyTestMarkerFile) {
+    error 'Remember to `git rm weekly-test` before taking out of draft'
+  }
 }
 
 stage('publish incrementals') {

--- a/weekly-test
+++ b/weekly-test
@@ -1,0 +1,1 @@
+TODO delete me

--- a/weekly-test
+++ b/weekly-test
@@ -1,1 +1,0 @@
-TODO delete me


### PR DESCRIPTION
This change ensures a `weekly-test` marker file can't be merged, similar to the `full-test` marker file from:
- https://github.com/jenkinsci/bom/pull/2166

Amends:
- https://github.com/jenkinsci/bom/pull/2644

### Testing done

Build with 8a0f1828821c6cd8051bc4f05b5ef15aabbb0d00 including a `weekly-test` file failing as expected: https://ci.jenkins.io/job/Tools/job/bom/view/change-requests/job/PR-7254/4

> <img width="2143" height="545" alt="image" src="https://github.com/user-attachments/assets/9ebdb5c7-9045-41dc-b64f-1ac73040b996" />


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
