### PR TITLE
feat(pipeline): fixed splits

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,8 @@ if(env.BRANCH_NAME == "master") {
 }
 
 env.MAVEN_NTP = true
+def maxSplitsPerLine = 20
+
 // Run pct tests on a limited set of repositories and their plugin(s) if not empty
 // Expected list item format: jenkinsci/<repo-name>, tab, <coma separated plugin(s)>
 // Ex: 'jenkinsci/pipeline-stage-view-plugin\tpipeline-rest-api,pipeline-stage-view'
@@ -29,22 +31,16 @@ def mavenEnv(Map params = [:], Closure body) {
     // no Dockerized tests; https://github.com/jenkins-infra/documentation/blob/master/ci.adoc#container-agents
     node('maven-bom') {
       timeout(120) {
-        withChecks(name: 'Tests', includeStage: true) {
-          infra.withArtifactCachingProxy {
-            withEnv([
-              'JAVA_HOME=/opt/jdk-' + params['jdk'],
-              'PATH+JDK=/opt/jdk-' + params['jdk'] + '/bin',
-              "MAVEN_ARGS=${env.MAVEN_ARGS != null ? MAVEN_ARGS : ''} -B ${env.MAVEN_NTP != null ? '-ntp' : ''} -Dmaven.repo.local=${WORKSPACE_TMP}/m2repo",
-              "MVN_LOCAL_REPO=${WORKSPACE_TMP}/m2repo",
-            ]) {
-              infra.loadMavenLocalCacheIfAny(env.MVN_LOCAL_REPO)
+        infra.withArtifactCachingProxy {
+          withEnv([
+            'JAVA_HOME=/opt/jdk-' + params['jdk'],
+            'PATH+JDK=/opt/jdk-' + params['jdk'] + '/bin',
+            "MAVEN_ARGS=${env.MAVEN_ARGS != null ? MAVEN_ARGS : ''} -B ${env.MAVEN_NTP != null ? '-ntp' : ''} -Dmaven.repo.local=${WORKSPACE_TMP}/m2repo",
+            "MVN_LOCAL_REPO=${WORKSPACE_TMP}/m2repo",
+          ]) {
+            infra.loadMavenLocalCacheIfAny(env.MVN_LOCAL_REPO)
 
-              body()
-            }
-          }
-          if (junit(testResults: '**/target/surefire-reports/TEST-*.xml,**/target/failsafe-reports/TEST-*.xml').failCount > 0) {
-            // TODO JENKINS-27092 throw up UNSTABLE status in this case
-            error 'Some test failures, not going to continue'
+            body()
           }
         }
       }
@@ -57,7 +53,7 @@ def parsePlugins(plugins) {
   def pluginsByRepository = [:]
   plugins.each { plugin ->
     def splits = plugin.split('\t')
-    pluginsByRepository[splits[0].split('/')[1]] = splits[1].split(',')
+    pluginsByRepository[splits[0].split('/')[1]] = splits[1]
   }
   pluginsByRepository
 }
@@ -68,16 +64,22 @@ def fullTestMarkerFile
 def weeklyTestMarkerFile
 boolean fullTest = false
 boolean weeklyTest = false
+def splits = [:]
 def durations = [:]
 
 mavenEnv(jdk: 21) {
   stage('prep') {
     checkout scm
-    withEnv(['SAMPLE_PLUGIN_OPTS=-Dset.changelist']) {
-      sh '''
-      mvn -v
-      bash prep.sh
-      '''
+    withChecks(name: 'Tests', includeStage: true) {
+      withEnv(['SAMPLE_PLUGIN_OPTS=-Dset.changelist']) {
+        sh '''
+        mvn -v
+        bash prep.sh
+        '''
+      }
+      if (junit(testResults: '**/target/surefire-reports/TEST-*.xml,**/target/failsafe-reports/TEST-*.xml').failCount > 0) {
+        error 'Some test failures during prep.sh, not going to continue'
+      }
     }
     infra.prepareToPublishIncrementals()
 
@@ -88,8 +90,9 @@ mavenEnv(jdk: 21) {
 
     def plugins = readFile('target/plugins.txt').split('\n')
     if (limitedPluginSet) {
-      unstable 'Running on a limited plugin set'
       plugins = limitedPluginSet
+      maxSplitsPerLine = 3
+      unstable "Running on a limited plugin set (maxSplitsPerLine reduced to ${maxSplitsPerLine})"
     }
     pluginsByRepository = parsePlugins(plugins)
 
@@ -101,6 +104,20 @@ mavenEnv(jdk: 21) {
     }
     echo "${pluginsByRepository.size()} repositories:\n${plugins.join('\n')}"
     echo "${lines.size()} lines: ${lines.join(' ')} "
+
+    // Fixed splits, each split using only one line
+    lines.each { line ->
+      pluginsByRepository.eachWithIndex { repository, repoPlugins, idx ->
+        def index = (idx % maxSplitsPerLine) + 1 // to get split1 to split<maxSplitsPerLine>
+        def name = "split-${index}:${line}"
+        def repositoryAndPlugins = "${repository} ${repoPlugins}"
+
+        splits[name] = splits[name] ?: []
+        splits[name] << repositoryAndPlugins
+      }
+    }
+    echo "${splits.size()} splits"
+    echo splits.collect { split, combinations -> "split: ${split}, combinations: ${combinations}" }.join('\n')
   }
   stage('stash line(s)') {
     lines.each { line ->
@@ -112,35 +129,48 @@ mavenEnv(jdk: 21) {
 if (BRANCH_NAME == 'master' || fullTest || weeklyTest) {
   stage('run pct') {
     def branches = [failFast: false]
-    lines.each {line ->
-      pluginsByRepository.each { repository, plugins ->
-        branches["pct-$repository-$line"] = {
-          def jdk = line == 'weekly' || line == '2.555.x' ? 21 : 17
-          mavenEnv(jdk: jdk) {
-            stage('unstash line') {
-              unstash line
-            }
-            stage('pct tests') {
-              withEnv([
-                "PLUGINS=${plugins.join(',')}",
-                "LINE=$line",
-                'EXTRA_MAVEN_PROPERTIES=maven.test.failure.ignore=true:surefire.rerunFailingTestsCount=1'
-              ]) {
-                def start = System.currentTimeMillis()
-                try {
-                  sh '''
-                  mvn -v
-                  bash pct.sh
-                  '''
-                } catch (e) {
-                  if (!(e instanceof InterruptedException) && !(e instanceof org.jenkinsci.plugins.workflow.support.steps.AgentOfflineException)) {
-                    unstable('PCT failed in ' + repository + ' - line ' + line)
-                  } else {
-                    throw e
+    splits.each { split, combinations ->
+      def line = split.split(':')[1]
+      def jdk = line == 'weekly' || line == '2.555.x' ? 21 : 17
+      branches[split] = {
+        mavenEnv(jdk: jdk) {
+          stage('unstash line') {
+            unstash line
+          }
+          combinations.eachWithIndex { repositoryAndPlugins, idx ->
+            def parts = repositoryAndPlugins.split(' ')
+            def repository = parts[0]
+            def plugins = parts[1]
+            def combination = "${repository}:${line}"
+            stage("${combination} (${idx + 1}/${combinations.size()})") {
+              withChecks(name: "PCT / ${combination}") {
+                withEnv([
+                  "PLUGINS=${plugins}",
+                  "LINE=$line",
+                  'EXTRA_MAVEN_PROPERTIES=maven.test.failure.ignore=true:surefire.rerunFailingTestsCount=1'
+                ]) {
+                  def start = System.currentTimeMillis()
+                  try {
+                    sh '''
+                    mvn -v
+                    bash pct.sh
+                    '''
+                  } catch (e) {
+                    if (!(e instanceof InterruptedException) && !(e instanceof org.jenkinsci.plugins.workflow.support.steps.AgentOfflineException)) {
+                      unstable('PCT failed in ' + repository + ' - line ' + line)
+                    } else {
+                      throw e
+                    }
+                  } finally {
+                    def elapsed = System.currentTimeMillis() - start
+                    durations["pct-$repository-$line"] = (elapsed / 1000.0)
+                    try {
+                      // record test results (can be missing if the plugin couldn't be built)
+                      junit(testResults: '**/target/surefire-reports/TEST-*.xml,**/target/failsafe-reports/TEST-*.xml')
+                    } catch(je) {
+                      unstable "error junitResult: ${je}"
+                    }
                   }
-                } finally {
-                  def elapsed = System.currentTimeMillis() - start
-                  durations["pct-$repository-$line"] = (elapsed / 1000.0)
                 }
               }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -117,7 +117,7 @@ mavenEnv(jdk: 21) {
       }
     }
     echo "${splits.size()} splits"
-    echo splits.collect { split, combinations -> "split: ${split}, combinations: ${combinations}" }.join('\n')
+    echo splits.collect { split, combinations -> "${split} ${combinations}" }.join('\n')
   }
   stage('stash line(s)') {
     lines.each { line ->


### PR DESCRIPTION
This change introduces splits to run multiple combinations of tests on a fixed number of agents instead of one per combination of repository and their plugin(s) with line(s).

A follow-up PR will integrate `splitTests` from parallel-test-executor plugin to take in account the elapsed time per combination and get balanced splits.

I picked 20 as default `maxSplitsPerLine` for now, to spawn up to 40 agents (versus ~600 currently) on `full-test` builds which run on two lines.

Based on my various builds on miscellaneous PRs, this number of splits takes less total time than using one agent per combination, while using only (20 × lines) agents and staying relatively constant wrt `weekly-test` vs `full-test`: this should already result in a noticeable costs reduction.

I'll report in #7073 the timings I've gathered to help refining that number which can be changed afterward.

Note: they'll give us an estimation only, there is too many variance in the type of agents provided by Karpenter depending on their current availability to allow comparing them _stricto sensu_ across builds.

> [!TIP]
> Easier review hiding whitespaces: https://github.com/jenkinsci/bom/pull/7256/changes?w=1

Refs:
- https://github.com/jenkins-infra/helpdesk/issues/5208
- #7073

### Testing done

<details><summary>Before</summary><hr>

### Build with "weekly-test" label (2h08m, 1h38m on pct tests)

https://ci.jenkins.io/job/Tools/job/bom/job/PR-6234/13
Jenkinsfile: https://github.com/jenkinsci/bom/blob/9b3f9d74c3b07de70fe631fb97159fef3b5718c7/Jenkinsfile

1) > <img width="2564" height="790" alt="image" src="https://github.com/user-attachments/assets/d8c2577d-e335-4300-ba63-666bf687dde7" />
2) > <img width="2558" height="734" alt="image" src="https://github.com/user-attachments/assets/b6a4f782-6c42-44bd-ba0c-8a5918837df4" />

Details of two plugin's `mavenEnv` steps, illustrating the contention issue on big builds (see timestamps: the "Attempt" is before the agent provision, and the junit step starts after pct tests execution on the plugin):
1) > <img width="2559" height="1178" alt="image" src="https://github.com/user-attachments/assets/8265aa73-4d66-40cd-9f59-ccf5e7ad05e5" />
2) > <img width="2535" height="1180" alt="image" src="https://github.com/user-attachments/assets/4f3466f6-1f2f-4e5e-9fdc-42605512db7e" />

### Build with "weekly-test" label (1h29m, 1h04m on pct tests)

https://ci.jenkins.io/job/Tools/job/bom/view/change-requests/job/PR-7263/1
> <img width="5182" height="32766" alt="image" src="https://github.com/user-attachments/assets/c8746bd7-f827-44c8-b6d0-18f0435203ac" />

Timing details from a random branch:
> <img width="2549" height="1092" alt="image" src="https://github.com/user-attachments/assets/3cf71481-0984-486c-baaf-15453f771626" />

</details>

<details><summary>After</summary><hr>

### Build with `weekly-test` label (1h41m, 1h07m on pct tests)

https://ci.jenkins.io/job/Tools/job/bom/job/PR-7256/39, in progress:
1) > <img width="2563" height="1457" alt="image" src="https://github.com/user-attachments/assets/9cd8c325-9b70-4025-a52b-b1caa35063eb" />
2) > <img width="5182" height="5648" alt="image" src="https://github.com/user-attachments/assets/15f71561-c863-4459-926b-88ba41ff12e9" />

In concurrency with `weekly-test` build https://ci.jenkins.io/job/Tools/job/bom/job/PR-7262/1, it had to wait almost 10m to get its final agent to record durations:
> <img width="5182" height="5728" alt="image" src="https://github.com/user-attachments/assets/1f584912-8967-4549-83d5-e42d22fce51b" />

Details of a split agent provisioning, no waiting time (less/no contention):
> <img width="2555" height="1041" alt="image" src="https://github.com/user-attachments/assets/96fba49e-9d86-44a0-accc-9b0eff1368be" />

### Build with `full-test` label (1h46m, 1h19m on pct tests)

https://ci.jenkins.io/job/Tools/job/bom/job/PR-7256/34:
1) > <img width="5182" height="7786" alt="image" src="https://github.com/user-attachments/assets/2a5f580b-46ca-426b-a902-954b4b46012f" />
2) > <img width="1027" height="1312" alt="image" src="https://github.com/user-attachments/assets/e1223610-ec91-42c0-9cce-c883ec4329f3" />
3) > <img width="1021" height="1317" alt="image" src="https://github.com/user-attachments/assets/7c0190bc-8724-40d7-9264-c1b27694d93e" />


Note: in the previous `full-test` build https://ci.jenkins.io/job/Tools/job/bom/job/PR-7256/29, the total time was 1h32m, with "run pct" taking 1h11m:
<details>

(Don't pay attention to the "duration" failed stage, early version).

1) > <img width="5182" height="6142" alt="image" src="https://github.com/user-attachments/assets/5c5d72d9-6feb-437f-8aa4-3d767cc99b30" />
2) > <img width="2565" height="1308" alt="image" src="https://github.com/user-attachments/assets/007e5349-0a4d-4896-af05-6e4014604034" />
3) > <img width="213" height="1122" alt="image" src="https://github.com/user-attachments/assets/bd12902e-129b-4353-995e-ac93dd16a9b9" />

</details>

### Build with prep from #7255, to check behavior on pct errors

Limited plugin set: warning-ng, coverage & sonarqube: https://ci.jenkins.io/job/Tools/job/bom/job/PR-7256/32
> <img width="2565" height="1118" alt="image" src="https://github.com/user-attachments/assets/06dc1ec1-d45c-4575-b596-2b2cdd73bf0f" />


Both warning-ng and coverage can't be build. Even if there is no junit test results to record, it records the elapsed time and marks the branch as 'unstable' and not 'error' to allow continuing on the next split combinations:
> <img width="2552" height="1313" alt="image" src="https://github.com/user-attachments/assets/1ddccc22-5c24-40a0-98a7-79321c512f25" />


"Normal" sonaqube plugin test errors recorded with junit:
> <img width="2552" height="1309" alt="image" src="https://github.com/user-attachments/assets/cd1c5442-c890-4060-b058-d6cad680988a" />


## Miscellaneous replays

In progress:
- https://ci.jenkins.io/job/Tools/job/bom/view/change-requests/job/PR-7262/3/

### Replay on #7255, spot agent reclaimed in one split (2h11m, 1h46m on pct tests)

`weekly-test` build: https://ci.jenkins.io/job/Tools/job/bom/view/change-requests/job/PR-7255/2
> <img width="4352" height="4262" alt="image" src="https://github.com/user-attachments/assets/a6b782e0-a5d0-409c-81d1-1d19ae5f4456" />

Reclaimed spot instance on the penultimate repo of split1:weekly, making all of them restart 🥲 
> <img width="2140" height="1206" alt="image" src="https://github.com/user-attachments/assets/8c3bb155-037b-4129-8318-464cd9fbd760" />


</details>

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
