### PR TITLE
chore(git/github): add .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,21 @@
+## Ignore mass rollback of PRs
+# feat(pipeline): retrieve prep from archive if it exists (#7079)
+# hotfix: pullRequest not available on master (fixup of #7079)
+# feat(pipeline): allow to run on a limited plugin set (#7077)
+# chore(pipeline): collect more info from test executions (#7078)
+# chore(pipeline): cleanup before splits introduction (#7085)
+# chore(pipeline): rollback prep archive (#7089)
+# chore(pipeline): rollback limited plugin set (#7090)
+# chore(pipeline): rollback collect more info (#7091)
+# chore(pipeline): remaining changes to rollback (#7094)
+4062d3a7
+84e4da84
+e32a4ff6
+55a01f18
+771a33d0
+23e60e13
+c83ee7d6
+c70385df
+4f9428e9
+# chore(pipeline): revert to last complete release revision f1cd358b7 (#7095)
+52bc0022


### PR DESCRIPTION
Follow-up of my mess to restore a sane Jenkinsfile blame view on GitHub and in local git repository.

Refs:
- https://docs.github.com/en/repositories/working-with-files/using-files/viewing-and-understanding-files\#ignore-commits-in-the-blame-view (locally: `git config blame.ignoreRevsFile .git-blame-ignore-revs`)
- https://github.com/jenkinsci/bom/issues/7073#issuecomment-5003582295

<!-- Please describe your pull request here. -->

### Testing done

N/A

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
