### PR TITLE
chore(pipeline): mark builds containing a marker file as unstable

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -174,10 +174,10 @@ if (BRANCH_NAME == 'master' || fullTest || weeklyTest) {
 
 stage('checks') {
   if (fullTestMarkerFile) {
-    error 'Remember to `git rm full-test` before taking out of draft'
+    unstable 'Remember to `git rm full-test` before taking out of draft'
   }
   if (weeklyTestMarkerFile) {
-    error 'Remember to `git rm weekly-test` before taking out of draft'
+    unstable 'Remember to `git rm weekly-test` before taking out of draft'
   }
 }
 


### PR DESCRIPTION
This change clarifies that such builds are not "broken" and just makes the PR ineligible for merging by branch protections.

Ref:
- https://github.com/jenkinsci/bom/pull/7254#issuecomment-5255553030

### Testing done

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
