### PR TITLE
chore(pipeline): honor `limited-plugin-set` marker file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,6 +140,27 @@ Keep the PR in draft until tests pass and this file can be deleted.
 To further minimize build time, tests are run only on Linux, against Java 11, and without Docker support.
 It is unusual but possible for cross-component incompatibilities to only be visible in more specialized environments (such as Windows).
 
+### Running a limited plugin set
+
+To run a build against a specific set of repository(ies) and their plugin(s), you can add it via a replay on top of the Jenkinsfile:
+```diff
+-def limitedPluginSetReplay = []
++def limitedPluginSetReplay = ['jenkinsci/badge-plugin\tbadge', 'jenkinsci/pipeline-stage-view-plugin\tpipeline-rest-api,pipeline-stage-view']
+```
+
+Don't commit that change: if you lack permission to replay a build, then you may instead
+
+```bash
+echo 'jenkinsci/badge-plugin\tbadge' > limited-plugin-set
+echo 'jenkinsci/pipeline-stage-view-plugin\tpipeline-rest-api,pipeline-stage-view' >> limited-plugin-set
+git add limited-plugin-set
+git commit -m 'Run tests on limited plugin set'
+```
+
+Expected line format: jenkinsci/<repo-name>, tab, <coma separated plugin(s)>
+
+Keep the PR in draft until tests pass and this file can be deleted.
+
 ## LTS lines
 
 A separate BOM artifact is available for the latest weekly, current LTS line and a few historical lines.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,10 +7,9 @@ if(env.BRANCH_NAME == "master") {
 env.MAVEN_NTP = true
 def maxSplitsPerLine = 20
 
-// Run pct tests on a limited set of repositories and their plugin(s) if not empty
-// Expected list item format: jenkinsci/<repo-name>, tab, <coma separated plugin(s)>
-// Ex: 'jenkinsci/pipeline-stage-view-plugin\tpipeline-rest-api,pipeline-stage-view'
-final String[] limitedPluginSet = []
+// Run pct tests on a limited set of repositories and their plugin(s) if not empty (take precedence over `limited-plugin-set` marker)
+// Ex: ['jenkinsci/badge-plugin\tbadge', 'jenkinsci/pipeline-stage-view-plugin\tpipeline-rest-api,pipeline-stage-view']
+def limitedPluginSetReplay = []
 
 properties([
   disableConcurrentBuilds(abortPrevious: true),
@@ -85,14 +84,16 @@ mavenEnv(jdk: 21) {
 
     fullTestMarkerFile = fileExists 'full-test'
     weeklyTestMarkerFile = fileExists 'weekly-test'
+    limitedPluginSetMarkerFile = fileExists 'limited-plugin-set'
     fullTest = fullTestMarkerFile || (env.CHANGE_ID && pullRequest.labels.contains('full-test'))
     weeklyTest = weeklyTestMarkerFile || (env.CHANGE_ID && pullRequest.labels.contains('weekly-test'))
+    limitedPluginSet = limitedPluginSetReplay || limitedPluginSetMarkerFile
 
     def plugins = readFile('target/plugins.txt').split('\n')
     if (limitedPluginSet) {
-      plugins = limitedPluginSet
+      plugins = limitedPluginSetReplay ? limitedPluginSetReplay : readFile('limited-plugin-set').split('\n')
       maxSplitsPerLine = 3
-      unstable "Running on a limited plugin set (maxSplitsPerLine reduced to ${maxSplitsPerLine})"
+      echo "Running on a limited plugin set (maxSplitsPerLine reduced to ${maxSplitsPerLine})"
     }
     pluginsByRepository = parsePlugins(plugins)
 
@@ -208,6 +209,9 @@ stage('checks') {
   }
   if (weeklyTestMarkerFile) {
     unstable 'Remember to `git rm weekly-test` before taking out of draft'
+  }
+  if (limitedPluginSetMarkerFile) {
+    unstable 'Remember to `git rm limited-plugin-set` before taking out of draft'
   }
 }
 

--- a/limited-plugin-set
+++ b/limited-plugin-set
@@ -1,0 +1,2 @@
+jenkinsci/badge-plugin	badge
+jenkinsci/pipeline-stage-view-plugin	pipeline-rest-api,pipeline-stage-view


### PR DESCRIPTION
This change allows to run a build on a limited plugin set via a marker file similar to the `weekly-test` and `full-test` ones for a better tracability of what ran in a build using such limited set (not only in the replay diff of a job), and to allow anyone to use this functionality.

Note: keeping the `limitedPluginSetReplay` variable taking the precedence over everything as quite useful in replay to avoid pushing changes.

Follow-up of:
- https://github.com/jenkinsci/bom/pull/7215

Refs:
- https://github.com/jenkinsci/bom/issues/2151
- https://github.com/jenkinsci/bom/pull/2166
- https://github.com/jenkinsci/bom/pull/2644
- https://github.com/jenkinsci/bom/pull/7254#issuecomment-5256265171

### Testing done

CI build with a marker file from 06408e58c855d6025d0317011daec3ef01aeb0a0:
> <img width="1960" height="1245" alt="image" src="https://github.com/user-attachments/assets/1fca0b8e-41ef-47bc-87b1-701b3ad565b1" />


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
