### PR TITLE
chore(pipeline): balanced splits

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -72,6 +72,7 @@ def splits = [:]
 def results = [:]
 def commit
 def pctDuration
+def reportNamePrefix = 'bom-report_'
 
 mavenEnv(jdk: 21) {
   stage('prep') {
@@ -116,18 +117,43 @@ mavenEnv(jdk: 21) {
     echo "${pluginsByRepository.size()} repositories:\n${plugins.join('\n')}"
     echo "${lines.size()} lines: ${lines.join(' ')}"
 
-    // Fixed splits, each split using only one line
+    def currentRepositories = pluginsByRepository.keySet().sort()
+    // Balanced splits, each split using only one line
     lines.each { line ->
-      pluginsByRepository.eachWithIndex { repository, repoPlugins, idx ->
-        def index = (idx % maxSplitsPerLine) + 1 // to get split1 to split<maxSplitsPerLine>
-        def name = "split-${index}:${line}"
-        splits[name] = splits[name] ?: []
-        splits[name] << repository
+      // Retrieve splits from last completed build's junit records from bom report stages
+      def splitsFromJunitRecords = splitTests(parallelism: count(maxSplitsPerLine), testMode: testCase(), stage: "${reportNamePrefix}${line}")
+      // As splitTests returns exclusion lists, we need to list first all its test cases (repositories)
+      def previousRepositories = [] as Set
+      splitsFromJunitRecords.each { exclusions ->
+        exclusions.each { repository ->
+          // Keep one of each exclusion list items that are in current repositories
+          if (!previousRepositories.contains(repository) && currentRepositories.contains(repository)) previousRepositories << repository
+        }
+      }
+      def balancedSplits = splitsFromJunitRecords.collect { exclusions ->
+        previousRepositories - exclusions
+      }
+      def newRepositories = currentRepositories - previousRepositories
+      echo "INFO: ${previousRepositories.size()} repositories returned by splitTests from junit records for '${line}' line"
+      echo "INFO: ${newRepositories.size()} new repositor${newRepositories.size() <= 1 ? 'y' : 'ies' } not returned by splitTests for '${line}' line"
+
+      // Generate current line's splits
+      balancedSplits.eachWithIndex { repositories, i ->
+        splits["split-${(i + 1).toString().padLeft(2, '0')}:${line}"] = repositories
+      }
+      if (newRepositories) {
+        // Fixed splits by default for the remaining new repositories
+        newRepositories.eachWithIndex { repository, idx ->
+          def index = ((idx % maxSplitsPerLine) + 1).toString().padLeft(2, '0') // to get split01 to split<maxSplitsPerLine>
+          def name = "new-${index}:${line}"
+          splits[name] = splits[name] ?: []
+          splits[name] << repository
+        }
       }
     }
     echo "${splits.size()} split(s)"
     echo splits.collect { split, repositories ->
-      "${split} (${repositories.size()}) ${repositories}"
+      "${split} [${repositories.size()}]:\n - ${repositories.join('\n - ')}"
     }.join('\n')
   }
   stage('stash line(s)') {
@@ -211,13 +237,12 @@ if (BRANCH_NAME == 'master' || fullTest || weeklyTest) {
   }
   node('maven-bom') {
     stage('reports') {
-      def branches = [:]
       lines.each { line ->
-        def testSuiteName = "bom-report_${line}"
+        def testSuiteName = "${reportNamePrefix}${line}"
         // We need junit records in distinct stages later on for splitTests
         // Otherwise it would try to balance all repositories across all lines
         // While we want one line per split (agent)
-        branches[testSuiteName] = {
+        stage(testSuiteName) {
           def testCases = []
           results.each { combination, result ->
             def repository = combination.split(':')[0]
@@ -236,7 +261,6 @@ if (BRANCH_NAME == 'master' || fullTest || weeklyTest) {
           archiveArtifacts artifacts: "${testSuiteName}.xml"
         }
       }
-      parallel branches
     }
   }
 }


### PR DESCRIPTION
This change implements balanced splits using `splitTests` from parallel executor plugin extracting splits from junit records of previous builds[^1]. This plugin packs all combinations of repositories and their plugin(s) from the longest elapsed time to the shortest, getting similar pct tests durations across all splits for more efficiency.

New repositories that were not in previous junit records are divided into additional fixed splits with the same method as in #7256 to avoid unbalancing the splits we've obtained from `splitTests`.

With this change, I observed in my weekly-test builds that the whole `run pct` stage take about 40\~55m, versus currently 1h to 1h30m with fixed splits, and far less variance between each split durations (more efficient packing). [^4]

Refs:
- #7073
- https://github.com/jenkins-infra/helpdesk/issues/5208
- #7310

### Testing done

## Before

- **"weekly-test"**, pct tests took 1h02m (total: 1h09m[^3])
  <details>
  
  - From a PR with no significant changes from `master`
  - https://ci.jenkins.io/job/Tools/job/bom/view/change-requests/job/PR-7290/156/stages/?selected-node=109

  1) > <img width="4458" height="4728" alt="image" src="https://github.com/user-attachments/assets/5ef138bf-9a19-49e5-b389-ab17c6b81a2b" />

  </details>

- **"weekly-test"**, pct tests took 1h28m (total: 1h59m)
  <details>
  
  - From a PR
  - https://ci.jenkins.io/job/Tools/job/bom/job/PR-6234/38/stages/?selected-node=109

  1) > <img width="4458" height="6362" alt="image" src="https://github.com/user-attachments/assets/b7040972-1a2e-4246-8611-d3fa7820ba6e" />
  
  2) > <img width="1560" height="728" alt="image" src="https://github.com/user-attachments/assets/54da46da-099b-4fea-9ede-ca67ffcb9434" />
  
  </details>

- **"full-test"**, pct tests took 1h09m (total: 1h33m)
  <details>
  
  - From `master`
  - https://ci.jenkins.io/job/Tools/job/bom/job/master/483/stages/?selected-node=133

  1) > <img width="4458" height="7254" alt="image" src="https://github.com/user-attachments/assets/089d65bd-ceda-4338-b022-69a7ce5ac1f3" />
  
  2) > <img width="1557" height="688" alt="image" src="https://github.com/user-attachments/assets/b8ae1626-8cf4-4ed6-a00a-68eb1bed9349" />
  
  </details>


## After

- **"weekly-test"**, pct tests took 39m (total: 57m)
  <details>
  
  - From this PR
  - https://ci.jenkins.io/job/Tools/job/bom/job/PR-7273/25/stages/?selected-node=115

  1) > <img width="4458" height="4636" alt="image" src="https://github.com/user-attachments/assets/2a97b8f8-09f0-40a2-a68b-9d18bd4424f7" />
  
  2) > <img width="1546" height="614" alt="image" src="https://github.com/user-attachments/assets/a9672f32-eb26-45cc-a180-f2d72fc8ac8f" />
  
  </details>

- **"weekly-test"** first build of #7310, pct tests took 36m 🥇 (total: 39m[^3])
  <details>
  
  - No prior junit records in the job, splitTests retries them from `master`.
  - https://ci.jenkins.io/job/Tools/job/bom/view/change-requests/job/PR-7310/1/stages/?selected-node=97

  1) > <img width="4458" height="4756" alt="image" src="https://github.com/user-attachments/assets/09b6619a-74ba-45fa-8aee-a1a461c393fe" />
  
  2) > <img width="1550" height="1207" alt="image" src="https://github.com/user-attachments/assets/96ffbd6e-bd88-479a-94af-d7c75815b5de" />
  
  </details>

- **"weekly-test"** after the first build of #7310, pct tests took 41m (total: 43m[^3])
  <details>
  
  - Using junit records from the first build.
  - https://ci.jenkins.io/job/Tools/job/bom/job/PR-7310/2/stages/?selected-node=105

  1) > <img width="4458" height="4820" alt="image" src="https://github.com/user-attachments/assets/e1720bd1-a48f-4dfe-a8d1-e35381209313" />
  
  2) > <img width="1554" height="863" alt="image" src="https://github.com/user-attachments/assets/4ea46e1c-f99a-46e2-a0a1-1f68ae12a91c" />
  
  </details>

- **"full-test"** in the middle of the second build of #7310, pct tests took 1h11mm (total: 11h15m[^3])
  <details>
  
  - Using junit records from the first **weekly-test** build (as the second one was still in progress, no junit recorded yet).
  - Shows how `splitTests` retrieves junit test results anyway even if there were no 2.541.x junit results recorded in the first build.
  - https://ci.jenkins.io/job/Tools/job/bom/view/change-requests/job/PR-7310/3/stages/?selected-node=??

  1) > <img width="4458" height="7742" alt="image" src="https://github.com/user-attachments/assets/7fea0d41-1335-4913-8fb9-034421a32f10" />
  
  2) > <img width="1564" height="515" alt="image" src="https://github.com/user-attachments/assets/360d23c8-8cb4-4bb6-b432-15bdd02d5459" />

  3) > <img width="1565" height="849" alt="image" src="https://github.com/user-attachments/assets/dd094f30-b330-4a72-8260-7f5d83d59576" />

  4) > <img width="1552" height="604" alt="image" src="https://github.com/user-attachments/assets/dd91e0f4-2603-47a7-b8ce-1e70913639fe" />

  </details>

<hr>

#### Earlier version (since trimmed down)[^2]

- **"weekly-test"**, pct tests took 44m (total: 48m[^3])
  <details>
  
  - No prior junit records in the job, splitTests retrieved them from `master`.
  - https://ci.jenkins.io/job/Tools/job/bom/view/change-requests/job/PR-7273/10/stages/?selected-node=98

  1) > <img width="4458" height="4954" alt="image" src="https://github.com/user-attachments/assets/f11456b5-d8b5-4f06-8db8-b6317710d1e5" />
  
  2) > <img width="1560" height="246" alt="image" src="https://github.com/user-attachments/assets/6d9a6a17-31b7-48f2-b372-01c0175bf4de" />
  
  </details>

- **"full-test"**, pct tests took 44m (total: 48m[^3])

  <details>
  
  - Following the "weekly-test" above
  - https://ci.jenkins.io/job/Tools/job/bom/view/change-requests/job/PR-7273/11/stages/?selected-node=106

  1) > <img width="4458" height="4700" alt="image" src="https://github.com/user-attachments/assets/8ff7a146-8f33-4b56-9195-1ae48e8807f3" />
  
  2) > <img width="1556" height="760" alt="image" src="https://github.com/user-attachments/assets/ffbac390-2cf6-4124-8618-4235fa35cd3d" />
  
  </details>

- **"weekly-test"**, pct tests took 53m (total: 1h19m)
  <details>
  
  - Running after the "full-test" above
  - https://ci.jenkins.io/job/Tools/job/bom/job/PR-7273/15/stages/?selected-node=129

  1) > <img width="4458" height="6476" alt="image" src="https://github.com/user-attachments/assets/1a50fa23-e5db-48c5-a0cc-7078a304c8ec" />
  
  2) > <img width="1560" height="246" alt="image" src="https://github.com/user-attachments/assets/6d9a6a17-31b7-48f2-b372-01c0175bf4de" />
  
  </details>

## Replay on various PRs[^2]

- **"weekly-test"** on a PR updating Jenkins Core to 2.578, pct tests took 36m 🥇 (total: 54m)

  <details>

  - https://github.com/jenkinsci/bom/pull/7311#issuecomment-5333411704
  - https://ci.jenkins.io/job/Tools/job/bom/view/change-requests/job/PR-7311/2/stages/?selected-node=106

  1) > <img width="4458" height="6596" alt="image" src="https://github.com/user-attachments/assets/3c095c26-e469-43f1-8f8f-11bb4bba72d5" />
  
  2) > <img width="1557" height="823" alt="image" src="https://github.com/user-attachments/assets/61e8c6d2-ce1f-4fb4-acc9-81091163b3f0" />
  
  </details>


- **"weekly-test"** on a PR consuming incrementals, pct tests took 49m (total: 1h12m)

  <details>

  - https://github.com/jenkinsci/bom/pull/7301#issuecomment-5327197241
  - https://ci.jenkins.io/job/Tools/job/bom/job/PR-7301/2/stages/?selected-node=106

  1) > <img width="4458" height="5414" alt="image" src="https://github.com/user-attachments/assets/2c8726f7-77dc-44d1-b7b0-6a442cc45256" />
  
  2) > <img width="1554" height="781" alt="image" src="https://github.com/user-attachments/assets/b04fa1aa-b4d5-4080-8f9b-59e562536edc" />
  
  </details>

- **"full-test"** on a PR testing a LTS RC, pct tests took 1h14m (total: 1h40m)

  <details>

  - https://github.com/jenkinsci/bom/pull/7300#issuecomment-5327803884
  - https://ci.jenkins.io/job/Tools/job/bom/job/PR-7300/6/stages/?selected-node=145

  1) > <img width="4458" height="5236" alt="image" src="https://github.com/user-attachments/assets/2d28a1ae-3d0d-4010-9611-96318799e4db" />
  
  2) > <img width="1553" height="815" alt="image" src="https://github.com/user-attachments/assets/99c99c78-d852-4090-9945-5e0735cd8867" />
  
  </details>

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

[^1]: The plugin search junit tests results from the target branch of a PR if it doesn't find any in the previous build(s) of that PR.

[^2]: Earlier versions of this change included a separate 'split' stage visible in some screenshots. I didn't keep in the end, inlined into the 'prep' one.

[^3]: Those builds included a debug/testing commit allowing to retrieve prep archive from prep-only job, skipping prep.sh entirely without impacting the rest of the pipeline. (Stage 'prep' shortened from 20 minutes to 1 minute)

[^4]: The gains  between fixed and balanced builds are less evident on full-test builds. May worth studying later if modulating the max splits per line in that case could be beneficial.
