### PR TITLE
fix(pipeline): publish status check when a plugin couldn't be built

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -162,6 +162,7 @@ if (BRANCH_NAME == 'master' || fullTest || weeklyTest) {
                     '''
                   } catch (e) {
                     if (!(e instanceof InterruptedException) && !(e instanceof org.jenkinsci.plugins.workflow.support.steps.AgentOfflineException)) {
+                      publishChecks status: 'COMPLETED', conclusion: 'FAILURE', title: 'Tests could not be executed'
                       unstable('PCT failed in ' + repository + ' - line ' + line)
                     } else {
                       throw e

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,12 @@ def maxSplitsPerLine = 20
 // Run pct tests on a limited set of repositories and their plugin(s) if not empty
 // Expected list item format: jenkinsci/<repo-name>, tab, <coma separated plugin(s)>
 // Ex: 'jenkinsci/pipeline-stage-view-plugin\tpipeline-rest-api,pipeline-stage-view'
-final String[] limitedPluginSet = []
+final String[] limitedPluginSet = [
+  'jenkinsci/warnings-ng-plugin	warnings-ng',
+  'jenkinsci/coverage-plugin	coverage',
+  'jenkinsci/mcp-server-plugin	mcp-server',
+  'jenkinsci/cron_column-plugin	cron_column',
+]
 
 properties([
   disableConcurrentBuilds(abortPrevious: true),
@@ -92,7 +97,7 @@ mavenEnv(jdk: 21) {
     if (limitedPluginSet) {
       plugins = limitedPluginSet
       maxSplitsPerLine = 3
-      unstable "Running on a limited plugin set (maxSplitsPerLine reduced to ${maxSplitsPerLine})"
+      echo "Running on a limited plugin set (maxSplitsPerLine reduced to ${maxSplitsPerLine})"
     }
     pluginsByRepository = parsePlugins(plugins)
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,12 +10,7 @@ def maxSplitsPerLine = 20
 // Run pct tests on a limited set of repositories and their plugin(s) if not empty
 // Expected list item format: jenkinsci/<repo-name>, tab, <coma separated plugin(s)>
 // Ex: 'jenkinsci/pipeline-stage-view-plugin\tpipeline-rest-api,pipeline-stage-view'
-final String[] limitedPluginSet = [
-  'jenkinsci/warnings-ng-plugin	warnings-ng',
-  'jenkinsci/coverage-plugin	coverage',
-  'jenkinsci/mcp-server-plugin	mcp-server',
-  'jenkinsci/cron_column-plugin	cron_column',
-]
+final String[] limitedPluginSet = []
 
 properties([
   disableConcurrentBuilds(abortPrevious: true),
@@ -97,7 +92,7 @@ mavenEnv(jdk: 21) {
     if (limitedPluginSet) {
       plugins = limitedPluginSet
       maxSplitsPerLine = 3
-      echo "Running on a limited plugin set (maxSplitsPerLine reduced to ${maxSplitsPerLine})"
+      unstable "Running on a limited plugin set (maxSplitsPerLine reduced to ${maxSplitsPerLine})"
     }
     pluginsByRepository = parsePlugins(plugins)
 

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -14,7 +14,7 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <bom>weekly</bom>
-    <jenkins.version>2.578-rc38577.6b_9a_00378de9</jenkins.version>
+    <jenkins.version>2.577</jenkins.version>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>
   <dependencyManagement>

--- a/sample-plugin/pom.xml
+++ b/sample-plugin/pom.xml
@@ -14,7 +14,7 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <bom>weekly</bom>
-    <jenkins.version>2.577</jenkins.version>
+    <jenkins.version>2.578-rc38577.6b_9a_00378de9</jenkins.version>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>
   <dependencyManagement>


### PR DESCRIPTION
This change makes the pipeline publishing checks for plugins that could not be built (ex: https://github.com/jenkinsci/bom/pull/6234#issuecomment-5282382617)

Ref:
- #7283 

### Testing done

CI

Build with `jenkins.version` set to `2.578-rc38577.6b_9a_00378de9` in ./sample-plugin/pom.xml like in #6234 in which warning-ng & coverage fail to build, and mcp-server has test failures (on a limited plugin set), showing all status checks as completed: https://ci.jenkins.io/job/Tools/job/bom/job/PR-7284/1
> <img width="834" height="545" alt="image" src="https://github.com/user-attachments/assets/d75fc888-f959-4556-a41b-721cd77810e6" />

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
