### PR TITLE
chore(pipeline): set limited plugin set unstable in `checks` stage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,6 +140,21 @@ Keep the PR in draft until tests pass and this file can be deleted.
 To further minimize build time, tests are run only on Linux, against Java 11, and without Docker support.
 It is unusual but possible for cross-component incompatibilities to only be visible in more specialized environments (such as Windows).
 
+### Running a limited plugin set
+
+To run a build against a specific set of repositories and their plugin(s), you can alter the Jenkinsfile via a commit or a replay (if you have permission to do so):
+```diff
+-def limitedPluginSet = []
++def limitedPluginSet = [
++  'jenkinsci/cron_column-plugin\tcron_column',
++  'jenkinsci/pipeline-stage-view-plugin\tpipeline-rest-api,pipeline-stage-view'
++]
+```
+
+Expected line format: jenkinsci/<repo-name>, tab, <coma separated plugin(s)>
+
+Keep the PR in draft until tests pass and this change can be reverted.
+
 ## LTS lines
 
 A separate BOM artifact is available for the latest weekly, current LTS line and a few historical lines.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ def maxSplitsPerLine = 20
 
 // Run pct tests on a limited set of repositories and their plugin(s) if not empty
 // Ex: ['jenkinsci/badge-plugin\tbadge', 'jenkinsci/cron_column-plugin\tcron_column']
-def limitedPluginSet = []
+def limitedPluginSet = ['jenkinsci/badge-plugin\tbadge', 'jenkinsci/cron_column-plugin\tcron_column']
 
 properties([
   disableConcurrentBuilds(abortPrevious: true),

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,9 +8,8 @@ env.MAVEN_NTP = true
 def maxSplitsPerLine = 20
 
 // Run pct tests on a limited set of repositories and their plugin(s) if not empty
-// Expected list item format: jenkinsci/<repo-name>, tab, <coma separated plugin(s)>
-// Ex: 'jenkinsci/pipeline-stage-view-plugin\tpipeline-rest-api,pipeline-stage-view'
-final String[] limitedPluginSet = []
+// Ex: ['jenkinsci/badge-plugin\tbadge', 'jenkinsci/cron_column-plugin\tcron_column']
+def limitedPluginSet = []
 
 properties([
   disableConcurrentBuilds(abortPrevious: true),
@@ -92,7 +91,7 @@ mavenEnv(jdk: 21) {
     if (limitedPluginSet) {
       plugins = limitedPluginSet
       maxSplitsPerLine = 3
-      unstable "Running on a limited plugin set (maxSplitsPerLine reduced to ${maxSplitsPerLine})"
+      echo "INFO: running on a limited plugin set (maxSplitsPerLine reduced to ${maxSplitsPerLine})"
     }
     pluginsByRepository = parsePlugins(plugins)
 
@@ -208,6 +207,9 @@ stage('checks') {
   }
   if (weeklyTestMarkerFile) {
     unstable 'Remember to `git rm weekly-test` before taking out of draft'
+  }
+  if (limitedPluginSet) {
+    unstable 'Remember to empty `limitedPluginSet` in Jenkinsfile before taking out of draft'
   }
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ def maxSplitsPerLine = 20
 
 // Run pct tests on a limited set of repositories and their plugin(s) if not empty
 // Ex: ['jenkinsci/badge-plugin\tbadge', 'jenkinsci/cron_column-plugin\tcron_column']
-def limitedPluginSet = ['jenkinsci/badge-plugin\tbadge', 'jenkinsci/cron_column-plugin\tcron_column']
+def limitedPluginSet = []
 
 properties([
   disableConcurrentBuilds(abortPrevious: true),


### PR DESCRIPTION
This change checks that the pipeline isn't modified to prevent merges including this change like the marker files, and adds a section describing this limited plugin set option in CONTRIBUTING.md.

Amends:
- #7215

Ref:
- #7216 

### Testing done

Build with e0ff75b commit setting a limited plugin set: https://ci.jenkins.io/job/Tools/job/bom/job/PR-7286/3

1) > <img width="2091" height="1119" alt="image" src="https://github.com/user-attachments/assets/cfbe2d47-21d0-4031-bc7e-8b1c39ee71d4" />
2) > <img width="2078" height="426" alt="image" src="https://github.com/user-attachments/assets/6c93b1ca-6fb3-4407-870f-e9b474347ad2" />

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
