### PR TITLE
chore(pipeline): adjustments before balanced splits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,21 +167,20 @@ It is unusual but possible for cross-component incompatibilities to only be visi
 ### Running a limited plugin set
 
 To run a build against a specific set of repositories and their plugin(s), you can alter the Jenkinsfile via a commit or a replay (if you have permission to do so):
-```diff
--def limitedPluginSet = []
-+def limitedPluginSet = [
-+  'jenkinsci/aws-credentials-plugin	aws-credentials',
-+  'jenkinsci/aws-global-configuration-plugin	aws-global-configuration',
-+  'jenkinsci/azure-credentials-plugin	azure-credentials',
-+  'jenkinsci/azure-keyvault-plugin	azure-keyvault',
-+  'jenkinsci/azure-sdk-plugin	azure-sdk',
-+  'jenkinsci/azure-storage-plugin	windows-azure-storage',
-+  'jenkinsci/badge-plugin	badge',
-+  'jenkinsci/basic-branch-build-strategies-plugin	basic-branch-build-strategies',
-+  'jenkinsci/coverage-plugin	coverage',
-+  'jenkinsci/cron_column-plugin	cron_column',
-+  'jenkinsci/pipeline-maven-plugin	pipeline-maven,pipeline-maven-api,pipeline-maven-database',
-+]
+```groovy
+def limitedPluginSet = [
+  'jenkinsci/aws-credentials-plugin	aws-credentials',
+  'jenkinsci/aws-global-configuration-plugin	aws-global-configuration',
+  'jenkinsci/azure-credentials-plugin	azure-credentials',
+  'jenkinsci/azure-keyvault-plugin	azure-keyvault',
+  'jenkinsci/azure-sdk-plugin	azure-sdk',
+  'jenkinsci/azure-storage-plugin	windows-azure-storage',
+  'jenkinsci/badge-plugin	badge',
+  'jenkinsci/basic-branch-build-strategies-plugin	basic-branch-build-strategies',
+  'jenkinsci/coverage-plugin	coverage',
+  'jenkinsci/cron_column-plugin	cron_column',
+  'jenkinsci/pipeline-maven-plugin	pipeline-maven,pipeline-maven-api,pipeline-maven-database',
+]
 ```
 
 Expected line format: jenkinsci/<repo-name>, tab, <coma separated plugin(s)>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -170,8 +170,17 @@ To run a build against a specific set of repositories and their plugin(s), you c
 ```diff
 -def limitedPluginSet = []
 +def limitedPluginSet = [
-+  'jenkinsci/cron_column-plugin\tcron_column',
-+  'jenkinsci/pipeline-stage-view-plugin\tpipeline-rest-api,pipeline-stage-view'
++  'jenkinsci/aws-credentials-plugin	aws-credentials',
++  'jenkinsci/aws-global-configuration-plugin	aws-global-configuration',
++  'jenkinsci/azure-credentials-plugin	azure-credentials',
++  'jenkinsci/azure-keyvault-plugin	azure-keyvault',
++  'jenkinsci/azure-sdk-plugin	azure-sdk',
++  'jenkinsci/azure-storage-plugin	windows-azure-storage',
++  'jenkinsci/badge-plugin	badge',
++  'jenkinsci/basic-branch-build-strategies-plugin	basic-branch-build-strategies',
++  'jenkinsci/coverage-plugin	coverage',
++  'jenkinsci/cron_column-plugin	cron_column',
++  'jenkinsci/pipeline-maven-plugin	pipeline-maven,pipeline-maven-api,pipeline-maven-database',
 +]
 ```
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -142,7 +142,7 @@ if (BRANCH_NAME == 'master' || fullTest || weeklyTest) {
     splits.each { split, repositories ->
       def line = split.split(':')[1]
       def jdk = line == 'weekly' || line == '2.555.x' ? 21 : 17
-      branches["${split} (${repositories.size()})"] = {
+      branches["${split} [${repositories.size()}]"] = {
         echo "In this split: ${repositories.join(',')}"
         mavenEnv(jdk: jdk) {
           def provisionStart = env.PROVISONING_START.toLong()
@@ -211,29 +211,27 @@ if (BRANCH_NAME == 'master' || fullTest || weeklyTest) {
     stage('reports') {
       def branches = [:]
       lines.each { line ->
-        branches[line] = {
-          // We need junit records in distinct stages later on for splitTests
-          // Otherwise it would try to balance all repositories across all lines
-          // While we want one line per split (agent)
-          stage("report ${line}") {
-            def testSuiteName = "bom-report_${line}"
-            def testCases = []
-            results.each { combination, result ->
-              def repository = combination.split(':')[0]
-              def resultLine = combination.split(':')[1]
-              if (line == resultLine) {
-                testCases << '<testcase split="' + result['split'] + '" name="' + repository + '" classname="pct-report.' + repository + '" time="' + result['elapsed'] + '" readyin="' + result['readyIn'] + '" attempt="' + result['attempt'] + '"/>\n'
-              }
+        def testSuiteName = "bom-report_${line}"
+        // We need junit records in distinct stages later on for splitTests
+        // Otherwise it would try to balance all repositories across all lines
+        // While we want one line per split (agent)
+        branches[testSuiteName] = {
+          def testCases = []
+          results.each { combination, result ->
+            def repository = combination.split(':')[0]
+            def resultLine = combination.split(':')[1]
+            if (line == resultLine) {
+              testCases << '<testcase split="' + result['split'] + '" name="' + repository + '" classname="pct-report.' + repository + '" time="' + result['elapsed'] + '" readyin="' + result['readyIn'] + '" attempt="' + result['attempt'] + '"/>\n'
             }
-            def content = """<?xml version="1.0" encoding="UTF-8"?>
-              <testsuite name="${testSuiteName}" line="${line}" pctduration="${pctDuration}" commit="${commit}" build="${env.BUILD_URL}">
-              ${testCases.sort().join('\n')}
-              </testsuite>
-            """
-            writeFile file: "${testSuiteName}.xml", text: content
-            junit testResults: "${testSuiteName}.xml"
-            archiveArtifacts artifacts: "${testSuiteName}.xml"
           }
+          def content = """<?xml version="1.0" encoding="UTF-8"?>
+            <testsuite name="${testSuiteName}" line="${line}" pctduration="${pctDuration}" commit="${commit}" build="${env.BUILD_URL}">
+            ${testCases.sort().join('\n')}
+            </testsuite>
+          """
+          writeFile file: "${testSuiteName}.xml", text: content
+          junit testResults: "${testSuiteName}.xml"
+          archiveArtifacts artifacts: "${testSuiteName}.xml"
         }
       }
       parallel branches

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,6 +26,7 @@ def mavenEnv(Map params = [:], Closure body) {
   def attempt = 0
   def attempts = 6
   retry(count: attempts, conditions: [kubernetesAgent(handleNonKubernetes: true), nonresumable()]) {
+    def provisioningStart = System.currentTimeMillis()
     echo 'Attempt ' + ++attempt + ' of ' + attempts
     // no Dockerized tests; https://github.com/jenkins-infra/documentation/blob/master/ci.adoc#container-agents
     node('maven-bom') {
@@ -36,6 +37,8 @@ def mavenEnv(Map params = [:], Closure body) {
             'PATH+JDK=/opt/jdk-' + params['jdk'] + '/bin',
             "MAVEN_ARGS=${env.MAVEN_ARGS != null ? MAVEN_ARGS : ''} -B ${env.MAVEN_NTP != null ? '-ntp' : ''} -Dmaven.repo.local=${WORKSPACE_TMP}/m2repo",
             "MVN_LOCAL_REPO=${WORKSPACE_TMP}/m2repo",
+            "PROVISONING_START=${provisioningStart}",
+            "CURRENT_ATTEMPT=${attempt}",
           ]) {
             infra.loadMavenLocalCacheIfAny(env.MVN_LOCAL_REPO)
 
@@ -62,15 +65,17 @@ def lines
 def fullTestMarkerFile
 def weeklyTestMarkerFile
 def consumeIncrementalsMarkerFile
-boolean fullTest = false
-boolean weeklyTest = false
-boolean consumeIncrementals = false
+def fullTest = false
+def weeklyTest = false
+def consumeIncrementals = false
 def splits = [:]
 def results = [:]
+def commit
+def pctDuration
 
 mavenEnv(jdk: 21) {
   stage('prep') {
-    checkout scm
+    commit = checkout(scm).GIT_COMMIT.take(7)
     consumeIncrementalsMarkerFile = fileExists 'consume-incrementals'
     consumeIncrementals = consumeIncrementalsMarkerFile || (env.CHANGE_ID && pullRequest.labels.contains('consume-incrementals'))
     if (!consumeIncrementals) {
@@ -109,21 +114,19 @@ mavenEnv(jdk: 21) {
       lines = ['weekly']
     }
     echo "${pluginsByRepository.size()} repositories:\n${plugins.join('\n')}"
-    echo "${lines.size()} lines: ${lines.join(' ')} "
+    echo "${lines.size()} lines: ${lines.join(' ')}"
 
     // Fixed splits, each split using only one line
     lines.each { line ->
       pluginsByRepository.eachWithIndex { repository, repoPlugins, idx ->
         def index = (idx % maxSplitsPerLine) + 1 // to get split1 to split<maxSplitsPerLine>
         def name = "split-${index}:${line}"
-        def repositoryAndPlugins = "${repository} ${repoPlugins}"
-
         splits[name] = splits[name] ?: []
-        splits[name] << repositoryAndPlugins
+        splits[name] << repository
       }
     }
-    echo "${splits.size()} splits"
-    echo splits.collect { split, combinations -> "${split} ${combinations}" }.join('\n')
+    echo "${splits.size()} split(s)"
+    echo splits.collect { split, repositories -> "${split} (${repositories.size()}) ${repositories}" }.join('\n')
   }
   stage('stash line(s)') {
     lines.each { line ->
@@ -134,29 +137,31 @@ mavenEnv(jdk: 21) {
 
 if (BRANCH_NAME == 'master' || fullTest || weeklyTest) {
   stage('run pct') {
+    def pctStart = System.currentTimeMillis()
     def branches = [failFast: false]
-    splits.each { split, combinations ->
+    splits.each { split, repositories ->
       def line = split.split(':')[1]
       def jdk = line == 'weekly' || line == '2.555.x' ? 21 : 17
-      branches[split] = {
+      branches["${split} (${repositories.size()})"] = {
+        echo "In this split: ${repositories.join(',')}"
         mavenEnv(jdk: jdk) {
+          def provisionStart = env.PROVISONING_START.toLong()
+          def readyIn = (System.currentTimeMillis() - provisionStart) / 1000.0
+          echo "INFO: agent ready to run pct in ${readyIn}s"
           stage('unstash line') {
             unstash line
           }
-          combinations.eachWithIndex { repositoryAndPlugins, idx ->
-            def parts = repositoryAndPlugins.split(' ')
-            def repository = parts[0]
-            def plugins = parts[1]
+          repositories.eachWithIndex { repository, idx ->
             def combination = "${repository}:${line}"
             // if the tests ran with success in a previous attempt, skip the combination (ex: in case of reclaimed spot agent)
             def previousResult = results[combination] ?: [totalCount: 0, failCount: 0]
             if (previousResult.totalCount > 0 && previousResult.failCount == 0) {
               echo "${combination} has already ran ${previousResult.totalCount} test(s) with success in a previous attempt, skipping"
             } else {
-              stage("${combination} (${idx + 1}/${combinations.size()})") {
+              stage("${combination} (${idx + 1}/${repositories.size()})") {
                 withChecks(name: "PCT / ${combination}") {
                   withEnv([
-                    "PLUGINS=${plugins}",
+                    "PLUGINS=${pluginsByRepository[repository]}",
                     "LINE=$line",
                     "CONSUME_INCREMENTALS=${consumeIncrementals}",
                     'EXTRA_MAVEN_PROPERTIES=maven.test.failure.ignore=true:surefire.rerunFailingTestsCount=1'
@@ -181,37 +186,57 @@ if (BRANCH_NAME == 'master' || fullTest || weeklyTest) {
                         'elapsed': (System.currentTimeMillis() - start) / 1000.0,
                         'totalCount': junitResults ? junitResults.totalCount : 0,
                         'failCount': junitResults ? junitResults.failCount : 0,
+                        'split': split,
+                        'readyIn': readyIn,
+                        'attempt': env.CURRENT_ATTEMPT,
                       ]
                     }
                   }
                 }
               }
+              echo "${combination}: ${results[combination]['totalCount']} tests executed in ${results[combination]['elapsed']}s"
             }
           }
+          def totalTime = (System.currentTimeMillis() - provisionStart) / 1000.0
+          def runningTime = totalTime - readyIn
+          echo "INFO: pct tests of ${split} took ${runningTime}s"
         }
       }
     }
     parallel branches
+    pctDuration = (System.currentTimeMillis() - pctStart) / 1000.0
+    echo "INFO: pct tests took ${pctDuration}s in total"
   }
-  stage('duration report') {
-    node('maven-bom') {
-      Double totalTime = 0
-      def reportLines = ''
-      results.each { combination, result ->
-        totalTime += result.elapsed as Double
-        def normalizedCombination = combination.replace(':', '-')
-        reportLines += '<testcase name="' + normalizedCombination + '" classname="pct-report.' + normalizedCombination + '" time="' + result.elapsed + '"/>\n'
+  node('maven-bom') {
+    stage('reports') {
+      def branches = [:]
+      lines.each { line ->
+        branches[line] = {
+          // We need junit records in distinct stages later on for splitTests
+          // Otherwise it would try to balance all repositories across all lines
+          // While we want one line per split (agent)
+          stage("report ${line}") {
+            def testSuiteName = "bom-report_${line}"
+            def testCases = []
+            results.each { combination, result ->
+              def repository = combination.split(':')[0]
+              def resultLine = combination.split(':')[1]
+              if (line == resultLine) {
+                testCases << '<testcase split="' + result['split'] + '" name="' + repository + '" classname="pct-report.' + repository + '" time="' + result['elapsed'] + '" readyin="' + result['readyIn'] + '" attempt="' + result['attempt'] + '"/>\n'
+              }
+            }
+            def content = """<?xml version="1.0" encoding="UTF-8"?>
+              <testsuite name="${testSuiteName}" line="${line}" pctduration="${pctDuration}" commit="${commit}" build="${env.BUILD_URL}">
+              ${testCases.sort().join('\n')}
+              </testsuite>
+            """
+            writeFile file: "${testSuiteName}.xml", text: content
+            junit testResults: "${testSuiteName}.xml"
+            archiveArtifacts artifacts: "${testSuiteName}.xml"
+          }
+        }
       }
-      if (reportLines) {
-        def content = """<?xml version="1.0" encoding="UTF-8"?>
-          <testsuite name="bom" time="${totalTime}">
-          ${reportLines}
-          </testsuite>
-        """
-        writeFile file: 'bom-report.xml', text: content
-        archiveArtifacts artifacts: 'bom-report.xml'
-        junit allowEmptyResults: true, testResults: 'bom-report.xml'
-      }
+      parallel branches
     }
   }
 }


### PR DESCRIPTION
This PR makes some adjustments in the pipeline to minimise #7273 changeset:
- Simplified `splits` containing only repositories
- BOM reports stored per line (required later on for `splitTests` to avoid mixing lines results)
- More info in BOM reports:
  - Current split name, to be able to get balanced builds on first build of a PR or when no junit test results from a previous build are available (ex: weekly-test before, full-test now)
  - The time in which the agent was ready for running PCT tests, for future references (more data to eventually adjust `maxSplitsPerLine`)
  - Attempt, for future references (can be used as hint to understand why a build took more time than another)
  - Total PCT duration, commit id and build URL, for future references

> [!TIP]
> Best reviewed hiding whitespaces: https://github.com/jenkinsci/bom/pull/7296/changes?w=1

Extracted from:
- #7273

Amends:
- #7256
- `s/boolean/def`: https://github.com/jenkinsci/bom/pull/7241#discussion_r3751552704

Ref:
- #7073

### Testing done

CI

<details><summary>Before</summary><hr>

1) > <img width="1555" height="1187" alt="image" src="https://github.com/user-attachments/assets/2388ccb2-66f9-4bf5-833b-a76e06740563" />
2) > <img width="2198" height="307" alt="image" src="https://github.com/user-attachments/assets/ce08a40b-9415-405d-8845-cd511a170519" />

<details><summary>bom-report.xml</summary>

```xml
<testsuite name="bom" time="83093.99599999993">
  <testcase name="JiraTestResultReporter-plugin-weekly" classname="pct-report.JiraTestResultReporter-plugin-weekly" time="40.265"/>
  <testcase name="azure-credentials-plugin-weekly" classname="pct-report.azure-credentials-plugin-weekly" time="45.778"/>
  <testcase name="caffeine-api-plugin-weekly" classname="pct-report.caffeine-api-plugin-weekly" time="24.651"/>
  <testcase name="analysis-model-api-plugin-weekly" classname="pct-report.analysis-model-api-plugin-weekly" time="51.198"/>
  <testcase name="adoptopenjdk-plugin-weekly" classname="pct-report.adoptopenjdk-plugin-weekly" time="54.438"/>
  <testcase name="antisamy-markup-formatter-plugin-weekly" classname="pct-report.antisamy-markup-formatter-plugin-weekly" time="54.362"/>
  <testcase name="artifactory-client-api-plugin-weekly" classname="pct-report.artifactory-client-api-plugin-weekly" time="71.248"/>
  <testcase name="apache-httpcomponents-client-5-api-plugin-weekly" classname="pct-report.apache-httpcomponents-client-5-api-plugin-weekly" time="71.223"/>
  <testcase name="asm-api-plugin-weekly" classname="pct-report.asm-api-plugin-weekly" time="56.77"/>
  <testcase name="ansible-plugin-weekly" classname="pct-report.ansible-plugin-weekly" time="108.026"/>
  <testcase name="aws-credentials-plugin-weekly" classname="pct-report.aws-credentials-plugin-weekly" time="90.141"/>
  <testcase name="apache-httpcomponents-client-4-api-plugin-weekly" classname="pct-report.apache-httpcomponents-client-4-api-plugin-weekly" time="90.087"/>
  <testcase name="authentication-tokens-plugin-weekly" classname="pct-report.authentication-tokens-plugin-weekly" time="75.599"/>
  <testcase name="aws-global-configuration-plugin-weekly" classname="pct-report.aws-global-configuration-plugin-weekly" time="75.532"/>
  <testcase name="ansicolor-plugin-weekly" classname="pct-report.ansicolor-plugin-weekly" time="117.714"/>
  <testcase name="credentials-binding-plugin-weekly" classname="pct-report.credentials-binding-plugin-weekly" time="153.192"/>
  <testcase name="apache-httpcomponents-client-5-api-plugin-2.541.x" classname="pct-report.apache-httpcomponents-client-5-api-plugin-2.541.x" time="58.825"/>
  <testcase name="antisamy-markup-formatter-plugin-2.541.x" classname="pct-report.antisamy-markup-formatter-plugin-2.541.x" time="58.759"/>
  <testcase name="adoptopenjdk-plugin-2.541.x" classname="pct-report.adoptopenjdk-plugin-2.541.x" time="58.674"/>
  <testcase name="analysis-model-api-plugin-2.541.x" classname="pct-report.analysis-model-api-plugin-2.541.x" time="58.619"/>
  <testcase name="asm-api-plugin-2.541.x" classname="pct-report.asm-api-plugin-2.541.x" time="52.673"/>
  <testcase name="artifactory-client-api-plugin-2.541.x" classname="pct-report.artifactory-client-api-plugin-2.541.x" time="52.644"/>
  <testcase name="apache-httpcomponents-client-4-api-plugin-2.541.x" classname="pct-report.apache-httpcomponents-client-4-api-plugin-2.541.x" time="54.642"/>
  <testcase name="azure-sdk-plugin-weekly" classname="pct-report.azure-sdk-plugin-weekly" time="44.242"/>
  <testcase name="ant-plugin-weekly" classname="pct-report.ant-plugin-weekly" time="139.212"/>
  <testcase name="authentication-tokens-plugin-2.541.x" classname="pct-report.authentication-tokens-plugin-2.541.x" time="53.566"/>
  <testcase name="active-directory-plugin-weekly" classname="pct-report.active-directory-plugin-weekly" time="157.245"/>
  <testcase name="ansible-plugin-2.541.x" classname="pct-report.ansible-plugin-2.541.x" time="80.095"/>
  <testcase name="azure-storage-plugin-weekly" classname="pct-report.azure-storage-plugin-weekly" time="68.353"/>
  <testcase name="build-name-setter-plugin-weekly" classname="pct-report.build-name-setter-plugin-weekly" time="41.29"/>
  <testcase name="bouncycastle-api-plugin-weekly" classname="pct-report.bouncycastle-api-plugin-weekly" time="43.203"/>
  <testcase name="JiraTestResultReporter-plugin-2.541.x" classname="pct-report.JiraTestResultReporter-plugin-2.541.x" time="55.707"/>
  <testcase name="aws-credentials-plugin-2.541.x" classname="pct-report.aws-credentials-plugin-2.541.x" time="71.967"/>
  <testcase name="docker-java-api-plugin-weekly" classname="pct-report.docker-java-api-plugin-weekly" time="42.758"/>
  <testcase name="aws-global-configuration-plugin-2.541.x" classname="pct-report.aws-global-configuration-plugin-2.541.x" time="76.895"/>
  <testcase name="build-token-root-plugin-weekly" classname="pct-report.build-token-root-plugin-weekly" time="55.147"/>
  <testcase name="artifact-manager-s3-plugin-weekly" classname="pct-report.artifact-manager-s3-plugin-weekly" time="156.579"/>
  <testcase name="bootstrap5-api-plugin-weekly" classname="pct-report.bootstrap5-api-plugin-weekly" time="63.508"/>
  <testcase name="azure-sdk-plugin-2.541.x" classname="pct-report.azure-sdk-plugin-2.541.x" time="45.689"/>
  <testcase name="azure-vm-agents-plugin-weekly" classname="pct-report.azure-vm-agents-plugin-weekly" time="69.158"/>
  <testcase name="bouncycastle-api-plugin-2.541.x" classname="pct-report.bouncycastle-api-plugin-2.541.x" time="49.468"/>
  <testcase name="build-user-vars-plugin-weekly" classname="pct-report.build-user-vars-plugin-weekly" time="74.572"/>
  <testcase name="ansicolor-plugin-2.541.x" classname="pct-report.ansicolor-plugin-2.541.x" time="129.939"/>
  <testcase name="build-name-setter-plugin-2.541.x" classname="pct-report.build-name-setter-plugin-2.541.x" time="56.67"/>
  <testcase name="commons-text-api-plugin-weekly" classname="pct-report.commons-text-api-plugin-weekly" time="32.613"/>
  <testcase name="commons-collections4-api-plugin-weekly" classname="pct-report.commons-collections4-api-plugin-weekly" time="39.398"/>
  <testcase name="authorize-project-plugin-weekly" classname="pct-report.authorize-project-plugin-weekly" time="189.605"/>
  <testcase name="ant-plugin-2.541.x" classname="pct-report.ant-plugin-2.541.x" time="144.915"/>
  <testcase name="azure-storage-plugin-2.541.x" classname="pct-report.azure-storage-plugin-2.541.x" time="78.56"/>
  <testcase name="bootstrap5-api-plugin-2.541.x" classname="pct-report.bootstrap5-api-plugin-2.541.x" time="72.877"/>
  <testcase name="favorite-plugin-weekly" classname="pct-report.favorite-plugin-weekly" time="47.835"/>
  <testcase name="artifactory-artifact-manager-plugin-weekly" classname="pct-report.artifactory-artifact-manager-plugin-weekly" time="205.219"/>
  <testcase name="basic-branch-build-strategies-plugin-weekly" classname="pct-report.basic-branch-build-strategies-plugin-weekly" time="80.324"/>
  <testcase name="build-token-root-plugin-2.541.x" classname="pct-report.build-token-root-plugin-2.541.x" time="60.416"/>
  <testcase name="database-sqlite-plugin-weekly" classname="pct-report.database-sqlite-plugin-weekly" time="33.397"/>
  <testcase name="commons-collections4-api-plugin-2.541.x" classname="pct-report.commons-collections4-api-plugin-2.541.x" time="42.34"/>
  <testcase name="azure-credentials-plugin-2.541.x" classname="pct-report.azure-credentials-plugin-2.541.x" time="74.798"/>
  <testcase name="badge-plugin-weekly" classname="pct-report.badge-plugin-weekly" time="134.124"/>
  <testcase name="checks-api-plugin-weekly" classname="pct-report.checks-api-plugin-weekly" time="100.068"/>
  <testcase name="azure-vm-agents-plugin-2.541.x" classname="pct-report.azure-vm-agents-plugin-2.541.x" time="87.788"/>
  <testcase name="commons-text-api-plugin-2.541.x" classname="pct-report.commons-text-api-plugin-2.541.x" time="46.257"/>
  <testcase name="database-mariadb-plugin-weekly" classname="pct-report.database-mariadb-plugin-weekly" time="43.186"/>
  <testcase name="build-timestamp-plugin-weekly" classname="pct-report.build-timestamp-plugin-weekly" time="37.528"/>
  <testcase name="command-launcher-plugin-weekly" classname="pct-report.command-launcher-plugin-weekly" time="84.984"/>
  <testcase name="azure-keyvault-plugin-weekly" classname="pct-report.azure-keyvault-plugin-weekly" time="108.723"/>
  <testcase name="artifact-manager-s3-plugin-2.541.x" classname="pct-report.artifact-manager-s3-plugin-2.541.x" time="207.054"/>
  <testcase name="build-monitor-plugin-weekly" classname="pct-report.build-monitor-plugin-weekly" time="173.2"/>
  <testcase name="envinject-api-plugin-weekly" classname="pct-report.envinject-api-plugin-weekly" time="30.1"/>
  <testcase name="build-user-vars-plugin-2.541.x" classname="pct-report.build-user-vars-plugin-2.541.x" time="105.331"/>
  <testcase name="cloud-stats-plugin-weekly" classname="pct-report.cloud-stats-plugin-weekly" time="92.839"/>
  <testcase name="active-directory-plugin-2.541.x" classname="pct-report.active-directory-plugin-2.541.x" time="199.666"/>
  <testcase name="github-oauth-plugin-weekly" classname="pct-report.github-oauth-plugin-weekly" time="62.153"/>
  <testcase name="caffeine-api-plugin-2.541.x" classname="pct-report.caffeine-api-plugin-2.541.x" time="39.313"/>
  <testcase name="database-mariadb-plugin-2.541.x" classname="pct-report.database-mariadb-plugin-2.541.x" time="45.591"/>
  <testcase name="configuration-as-code-plugin-weekly" classname="pct-report.configuration-as-code-plugin-weekly" time="122.905"/>
  <testcase name="checks-api-plugin-2.541.x" classname="pct-report.checks-api-plugin-2.541.x" time="114.709"/>
  <testcase name="basic-branch-build-strategies-plugin-2.541.x" classname="pct-report.basic-branch-build-strategies-plugin-2.541.x" time="87.553"/>
  <testcase name="build-timeout-plugin-weekly" classname="pct-report.build-timeout-plugin-weekly" time="190.997"/>
  <testcase name="cron_column-plugin-weekly" classname="pct-report.cron_column-plugin-weekly" time="44.039"/>
  <testcase name="cloudbees-disk-usage-simple-plugin-weekly" classname="pct-report.cloudbees-disk-usage-simple-plugin-weekly" time="44.017"/>
  <testcase name="command-launcher-plugin-2.541.x" classname="pct-report.command-launcher-plugin-2.541.x" time="86.631"/>
  <testcase name="database-sqlite-plugin-2.541.x" classname="pct-report.database-sqlite-plugin-2.541.x" time="45.82"/>
  <testcase name="authorize-project-plugin-2.541.x" classname="pct-report.authorize-project-plugin-2.541.x" time="257.2"/>
  <testcase name="database-h2-plugin-weekly" classname="pct-report.database-h2-plugin-weekly" time="48.713"/>
  <testcase name="commons-math3-api-plugin-weekly" classname="pct-report.commons-math3-api-plugin-weekly" time="40.129"/>
  <testcase name="build-monitor-plugin-2.541.x" classname="pct-report.build-monitor-plugin-2.541.x" time="189.845"/>
  <testcase name="badge-plugin-2.541.x" classname="pct-report.badge-plugin-2.541.x" time="131.698"/>
  <testcase name="cron_column-plugin-2.541.x" classname="pct-report.cron_column-plugin-2.541.x" time="41.615"/>
  <testcase name="cloud-stats-plugin-2.541.x" classname="pct-report.cloud-stats-plugin-2.541.x" time="95.653"/>
  <testcase name="conditional-buildstep-plugin-weekly" classname="pct-report.conditional-buildstep-plugin-weekly" time="42.24"/>
  <testcase name="customizable-header-plugin-weekly" classname="pct-report.customizable-header-plugin-weekly" time="73.858"/>
  <testcase name="configuration-as-code-plugin-2.541.x" classname="pct-report.configuration-as-code-plugin-2.541.x" time="129.102"/>
  <testcase name="description-setter-plugin-weekly" classname="pct-report.description-setter-plugin-weekly" time="57.699"/>
  <testcase name="database-h2-plugin-2.541.x" classname="pct-report.database-h2-plugin-2.541.x" time="47.253"/>
  <testcase name="envinject-api-plugin-2.541.x" classname="pct-report.envinject-api-plugin-2.541.x" time="47.227"/>
  <testcase name="dark-theme-plugin-weekly" classname="pct-report.dark-theme-plugin-weekly" time="53.888"/>
  <testcase name="artifactory-artifact-manager-plugin-2.541.x" classname="pct-report.artifactory-artifact-manager-plugin-2.541.x" time="319.844"/>
  <testcase name="database-postgresql-plugin-weekly" classname="pct-report.database-postgresql-plugin-weekly" time="50.773"/>
  <testcase name="build-timestamp-plugin-2.541.x" classname="pct-report.build-timestamp-plugin-2.541.x" time="51.907"/>
  <testcase name="commons-math3-api-plugin-2.541.x" classname="pct-report.commons-math3-api-plugin-2.541.x" time="50.614"/>
  <testcase name="build-timeout-plugin-2.541.x" classname="pct-report.build-timeout-plugin-2.541.x" time="233.469"/>
  <testcase name="cloudbees-disk-usage-simple-plugin-2.541.x" classname="pct-report.cloudbees-disk-usage-simple-plugin-2.541.x" time="48.56"/>
  <testcase name="azure-keyvault-plugin-2.541.x" classname="pct-report.azure-keyvault-plugin-2.541.x" time="109.858"/>
  <testcase name="database-sqlserver-plugin-weekly" classname="pct-report.database-sqlserver-plugin-weekly" time="35.357"/>
  <testcase name="cloudbees-folder-plugin-weekly" classname="pct-report.cloudbees-folder-plugin-weekly" time="165.41"/>
  <testcase name="claim-plugin-weekly" classname="pct-report.claim-plugin-weekly" time="254.491"/>
  <testcase name="calendar-view-plugin-weekly" classname="pct-report.calendar-view-plugin-weekly" time="146.185"/>
  <testcase name="emoji-symbols-api-plugin-weekly" classname="pct-report.emoji-symbols-api-plugin-weekly" time="38.26"/>
  <testcase name="electricflow-plugin-weekly" classname="pct-report.electricflow-plugin-weekly" time="103.272"/>
  <testcase name="bitbucket-branch-source-plugin-weekly" classname="pct-report.bitbucket-branch-source-plugin-weekly" time="346.35"/>
  <testcase name="customizable-header-plugin-2.541.x" classname="pct-report.customizable-header-plugin-2.541.x" time="81.449"/>
  <testcase name="description-setter-plugin-2.541.x" classname="pct-report.description-setter-plugin-2.541.x" time="59.51"/>
  <testcase name="database-postgresql-plugin-2.541.x" classname="pct-report.database-postgresql-plugin-2.541.x" time="47.081"/>
  <testcase name="config-file-provider-plugin-weekly" classname="pct-report.config-file-provider-plugin-weekly" time="187.483"/>
  <testcase name="http-request-plugin-weekly" classname="pct-report.http-request-plugin-weekly" time="159.888"/>
  <testcase name="dark-theme-plugin-2.541.x" classname="pct-report.dark-theme-plugin-2.541.x" time="54.828"/>
  <testcase name="conditional-buildstep-plugin-2.541.x" classname="pct-report.conditional-buildstep-plugin-2.541.x" time="60.619"/>
  <testcase name="docker-workflow-plugin-weekly" classname="pct-report.docker-workflow-plugin-weekly" time="150.572"/>
  <testcase name="claim-plugin-2.541.x" classname="pct-report.claim-plugin-2.541.x" time="262.453"/>
  <testcase name="branch-api-plugin-weekly" classname="pct-report.branch-api-plugin-weekly" time="307.394"/>
  <testcase name="cloudbees-folder-plugin-2.541.x" classname="pct-report.cloudbees-folder-plugin-2.541.x" time="178.282"/>
  <testcase name="emoji-symbols-api-plugin-2.541.x" classname="pct-report.emoji-symbols-api-plugin-2.541.x" time="43.135"/>
  <testcase name="bitbucket-branch-source-plugin-2.541.x" classname="pct-report.bitbucket-branch-source-plugin-2.541.x" time="365.78"/>
  <testcase name="electricflow-plugin-2.541.x" classname="pct-report.electricflow-plugin-2.541.x" time="120.143"/>
  <testcase name="database-sqlserver-plugin-2.541.x" classname="pct-report.database-sqlserver-plugin-2.541.x" time="43.805"/>
  <testcase name="credentials-binding-plugin-2.541.x" classname="pct-report.credentials-binding-plugin-2.541.x" time="209.974"/>
  <testcase name="envinject-plugin-weekly" classname="pct-report.envinject-plugin-weekly" time="107.569"/>
  <testcase name="docker-workflow-plugin-2.541.x" classname="pct-report.docker-workflow-plugin-2.541.x" time="157.113"/>
  <testcase name="commons-compress-api-plugin-weekly" classname="pct-report.commons-compress-api-plugin-weekly" time="30.489"/>
  <testcase name="gcp-java-sdk-plugin-weekly" classname="pct-report.gcp-java-sdk-plugin-weekly" time="89.196"/>
  <testcase name="dashboard-view-plugin-weekly" classname="pct-report.dashboard-view-plugin-weekly" time="123.725"/>
  <testcase name="cloudbees-jenkins-advisor-plugin-weekly" classname="pct-report.cloudbees-jenkins-advisor-plugin-weekly" time="100.164"/>
  <testcase name="durable-task-plugin-weekly" classname="pct-report.durable-task-plugin-weekly" time="180.072"/>
  <testcase name="build-failure-analyzer-plugin-weekly" classname="pct-report.build-failure-analyzer-plugin-weekly" time="325.758"/>
  <testcase name="database-mysql-plugin-weekly" classname="pct-report.database-mysql-plugin-weekly" time="33.51"/>
  <testcase name="docker-java-api-plugin-2.541.x" classname="pct-report.docker-java-api-plugin-2.541.x" time="46.263"/>
  <testcase name="git-server-plugin-weekly" classname="pct-report.git-server-plugin-weekly" time="44.71"/>
  <testcase name="file-parameters-plugin-weekly" classname="pct-report.file-parameters-plugin-weekly" time="96.317"/>
  <testcase name="calendar-view-plugin-2.541.x" classname="pct-report.calendar-view-plugin-2.541.x" time="164.472"/>
  <testcase name="flatpickr-api-plugin-weekly" classname="pct-report.flatpickr-api-plugin-weekly" time="33.42"/>
  <testcase name="commons-lang3-api-plugin-weekly" classname="pct-report.commons-lang3-api-plugin-weekly" time="30.41"/>
  <testcase name="extensible-choice-parameter-plugin-weekly" classname="pct-report.extensible-choice-parameter-plugin-weekly" time="208.366"/>
  <testcase name="echarts-api-plugin-weekly" classname="pct-report.echarts-api-plugin-weekly" time="56.878"/>
  <testcase name="data-tables-api-plugin-weekly" classname="pct-report.data-tables-api-plugin-weekly" time="50.664"/>
  <testcase name="gcp-java-sdk-plugin-2.541.x" classname="pct-report.gcp-java-sdk-plugin-2.541.x" time="94.303"/>
  <testcase name="custom-folder-icon-plugin-weekly" classname="pct-report.custom-folder-icon-plugin-weekly" time="188.781"/>
  <testcase name="git-parameter-plugin-weekly" classname="pct-report.git-parameter-plugin-weekly" time="166.909"/>
  <testcase name="cloudbees-jenkins-advisor-plugin-2.541.x" classname="pct-report.cloudbees-jenkins-advisor-plugin-2.541.x" time="106.216"/>
  <testcase name="github-scm-trait-notification-context-plugin-weekly" classname="pct-report.github-scm-trait-notification-context-plugin-weekly" time="45.265"/>
  <testcase name="file-parameters-plugin-2.541.x" classname="pct-report.file-parameters-plugin-2.541.x" time="97.937"/>
  <testcase name="emailext-template-plugin-weekly" classname="pct-report.emailext-template-plugin-weekly" time="59.876"/>
  <testcase name="database-plugin-weekly" classname="pct-report.database-plugin-weekly" time="32.744"/>
  <testcase name="dashboard-view-plugin-2.541.x" classname="pct-report.dashboard-view-plugin-2.541.x" time="134.988"/>
  <testcase name="declarative-pipeline-migration-assistant-plugin-weekly" classname="pct-report.declarative-pipeline-migration-assistant-plugin-weekly" time="174.1"/>
  <testcase name="favorite-plugin-2.541.x" classname="pct-report.favorite-plugin-2.541.x" time="71.388"/>
  <testcase name="copyartifact-plugin-weekly" classname="pct-report.copyartifact-plugin-weekly" time="443.96"/>
  <testcase name="durable-task-plugin-2.541.x" classname="pct-report.durable-task-plugin-2.541.x" time="195.541"/>
  <testcase name="config-file-provider-plugin-2.541.x" classname="pct-report.config-file-provider-plugin-2.541.x" time="251.064"/>
  <testcase name="branch-api-plugin-2.541.x" classname="pct-report.branch-api-plugin-2.541.x" time="374.871"/>
  <testcase name="font-awesome-api-plugin-weekly" classname="pct-report.font-awesome-api-plugin-weekly" time="59.287"/>
  <testcase name="envinject-plugin-2.541.x" classname="pct-report.envinject-plugin-2.541.x" time="145.289"/>
  <testcase name="email-ext-plugin-weekly" classname="pct-report.email-ext-plugin-weekly" time="394.941"/>
  <testcase name="groovy-postbuild-plugin-weekly" classname="pct-report.groovy-postbuild-plugin-weekly" time="93.155"/>
  <testcase name="eddsa-api-plugin-weekly" classname="pct-report.eddsa-api-plugin-weekly" time="73.844"/>
  <testcase name="instance-identity-plugin-weekly" classname="pct-report.instance-identity-plugin-weekly" time="51.735"/>
  <testcase name="extended-timer-trigger-plugin-weekly" classname="pct-report.extended-timer-trigger-plugin-weekly" time="39.251"/>
  <testcase name="git-parameter-plugin-2.541.x" classname="pct-report.git-parameter-plugin-2.541.x" time="179.326"/>
  <testcase name="data-tables-api-plugin-2.541.x" classname="pct-report.data-tables-api-plugin-2.541.x" time="60.143"/>
  <testcase name="github-scm-trait-notification-context-plugin-2.541.x" classname="pct-report.github-scm-trait-notification-context-plugin-2.541.x" time="55.101"/>
  <testcase name="credentials-plugin-weekly" classname="pct-report.credentials-plugin-weekly" time="260.812"/>
  <testcase name="extensible-choice-parameter-plugin-2.541.x" classname="pct-report.extensible-choice-parameter-plugin-2.541.x" time="236.657"/>
  <testcase name="embeddable-build-status-plugin-weekly" classname="pct-report.embeddable-build-status-plugin-weekly" time="56.217"/>
  <testcase name="gitea-plugin-weekly" classname="pct-report.gitea-plugin-weekly" time="92.914"/>
  <testcase name="flatpickr-api-plugin-2.541.x" classname="pct-report.flatpickr-api-plugin-2.541.x" time="42.7"/>
  <testcase name="google-oauth-plugin-weekly" classname="pct-report.google-oauth-plugin-weekly" time="83.126"/>
  <testcase name="gitlab-branch-source-plugin-weekly" classname="pct-report.gitlab-branch-source-plugin-weekly" time="107.783"/>
  <testcase name="job-config-history-plugin-weekly" classname="pct-report.job-config-history-plugin-weekly" time="243.117"/>
  <testcase name="custom-folder-icon-plugin-2.541.x" classname="pct-report.custom-folder-icon-plugin-2.541.x" time="217.169"/>
  <testcase name="commons-compress-api-plugin-2.541.x" classname="pct-report.commons-compress-api-plugin-2.541.x" time="48.571"/>
  <testcase name="echarts-api-plugin-2.541.x" classname="pct-report.echarts-api-plugin-2.541.x" time="73.948"/>
  <testcase name="gitlab-logo-plugin-weekly" classname="pct-report.gitlab-logo-plugin-weekly" time="42.196"/>
  <testcase name="jaxb-plugin-weekly" classname="pct-report.jaxb-plugin-weekly" time="34.73"/>
  <testcase name="email-ext-plugin-2.541.x" classname="pct-report.email-ext-plugin-2.541.x" time="410.883"/>
  <testcase name="generic-tool-plugin-weekly" classname="pct-report.generic-tool-plugin-weekly" time="42.099"/>
  <testcase name="design-library-plugin-weekly" classname="pct-report.design-library-plugin-weekly" time="70.891"/>
  <testcase name="ec2-plugin-weekly" classname="pct-report.ec2-plugin-weekly" time="343.678"/>
  <testcase name="git-server-plugin-2.541.x" classname="pct-report.git-server-plugin-2.541.x" time="63.683"/>
  <testcase name="job-import-plugin-weekly" classname="pct-report.job-import-plugin-weekly" time="50.754"/>
  <testcase name="aws-java-sdk-plugin-weekly" classname="pct-report.aws-java-sdk-plugin-weekly" time="721.257"/>
  <testcase name="github-oauth-plugin-2.541.x" classname="pct-report.github-oauth-plugin-2.541.x" time="94.905"/>
  <testcase name="gitea-checks-plugin-weekly" classname="pct-report.gitea-checks-plugin-weekly" time="62.61"/>
  <testcase name="instance-identity-plugin-2.541.x" classname="pct-report.instance-identity-plugin-2.541.x" time="51.623"/>
  <testcase name="h2-api-plugin-weekly" classname="pct-report.h2-api-plugin-weekly" time="36.993"/>
  <testcase name="javax-activation-api-plugin-weekly" classname="pct-report.javax-activation-api-plugin-weekly" time="38.19"/>
  <testcase name="ionicons-api-plugin-weekly" classname="pct-report.ionicons-api-plugin-weekly" time="42.366"/>
  <testcase name="eddsa-api-plugin-2.541.x" classname="pct-report.eddsa-api-plugin-2.541.x" time="74.235"/>
  <testcase name="git-forensics-plugin-weekly" classname="pct-report.git-forensics-plugin-weekly" time="64.386"/>
  <testcase name="database-mysql-plugin-2.541.x" classname="pct-report.database-mysql-plugin-2.541.x" time="46.639"/>
  <testcase name="forensics-api-plugin-weekly" classname="pct-report.forensics-api-plugin-weekly" time="94.461"/>
  <testcase name="google-oauth-plugin-2.541.x" classname="pct-report.google-oauth-plugin-2.541.x" time="86.361"/>
  <testcase name="locale-plugin-weekly" classname="pct-report.locale-plugin-weekly" time="53.636"/>
  <testcase name="jackson2-api-plugin-weekly" classname="pct-report.jackson2-api-plugin-weekly" time="43.802"/>
  <testcase name="dockerhub-notification-plugin-weekly" classname="pct-report.dockerhub-notification-plugin-weekly" time="171.323"/>
  <testcase name="external-monitor-job-plugin-weekly" classname="pct-report.external-monitor-job-plugin-weekly" time="41.246"/>
  <testcase name="generic-tool-plugin-2.541.x" classname="pct-report.generic-tool-plugin-2.541.x" time="45.943"/>
  <testcase name="built-on-column-plugin-weekly" classname="pct-report.built-on-column-plugin-weekly" time="38.939"/>
  <testcase name="flyway-api-plugin-weekly" classname="pct-report.flyway-api-plugin-weekly" time="44.084"/>
  <testcase name="font-awesome-api-plugin-2.541.x" classname="pct-report.font-awesome-api-plugin-2.541.x" time="76.78"/>
  <testcase name="gson-api-plugin-weekly" classname="pct-report.gson-api-plugin-weekly" time="38.276"/>
  <testcase name="ec2-plugin-2.541.x" classname="pct-report.ec2-plugin-2.541.x" time="355.049"/>
  <testcase name="gitea-plugin-2.541.x" classname="pct-report.gitea-plugin-2.541.x" time="114.077"/>
  <testcase name="google-metadata-plugin-weekly" classname="pct-report.google-metadata-plugin-weekly" time="38.279"/>
  <testcase name="job-import-plugin-2.541.x" classname="pct-report.job-import-plugin-2.541.x" time="67.844"/>
  <testcase name="gitlab-branch-source-plugin-2.541.x" classname="pct-report.gitlab-branch-source-plugin-2.541.x" time="128.332"/>
  <testcase name="javax-activation-api-plugin-2.541.x" classname="pct-report.javax-activation-api-plugin-2.541.x" time="44.429"/>
  <testcase name="github-api-plugin-weekly" classname="pct-report.github-api-plugin-weekly" time="42.475"/>
  <testcase name="copyartifact-plugin-2.541.x" classname="pct-report.copyartifact-plugin-2.541.x" time="562.41"/>
  <testcase name="credentials-plugin-2.541.x" classname="pct-report.credentials-plugin-2.541.x" time="275.009"/>
  <testcase name="junit-realtime-test-reporter-plugin-weekly" classname="pct-report.junit-realtime-test-reporter-plugin-weekly" time="116.57"/>
  <testcase name="build-failure-analyzer-plugin-2.541.x" classname="pct-report.build-failure-analyzer-plugin-2.541.x" time="460.08"/>
  <testcase name="emailext-template-plugin-2.541.x" classname="pct-report.emailext-template-plugin-2.541.x" time="79.15"/>
  <testcase name="coverage-badges-extension-plugin-weekly" classname="pct-report.coverage-badges-extension-plugin-weekly" time="62.06"/>
  <testcase name="forensics-api-plugin-2.541.x" classname="pct-report.forensics-api-plugin-2.541.x" time="102.218"/>
  <testcase name="gitlab-logo-plugin-2.541.x" classname="pct-report.gitlab-logo-plugin-2.541.x" time="48.967"/>
  <testcase name="jdk-tool-plugin-weekly" classname="pct-report.jdk-tool-plugin-weekly" time="49.499"/>
  <testcase name="groovy-postbuild-plugin-2.541.x" classname="pct-report.groovy-postbuild-plugin-2.541.x" time="129.513"/>
  <testcase name="declarative-pipeline-migration-assistant-plugin-2.541.x" classname="pct-report.declarative-pipeline-migration-assistant-plugin-2.541.x" time="236.567"/>
  <testcase name="h2-api-plugin-2.541.x" classname="pct-report.h2-api-plugin-2.541.x" time="39.538"/>
  <testcase name="flyway-api-plugin-2.541.x" classname="pct-report.flyway-api-plugin-2.541.x" time="49.38"/>
  <testcase name="dockerhub-notification-plugin-2.541.x" classname="pct-report.dockerhub-notification-plugin-2.541.x" time="179.978"/>
  <testcase name="handy-uri-templates-2-api-plugin-weekly" classname="pct-report.handy-uri-templates-2-api-plugin-weekly" time="40.476"/>
  <testcase name="ionicons-api-plugin-2.541.x" classname="pct-report.ionicons-api-plugin-2.541.x" time="47.758"/>
  <testcase name="commons-lang3-api-plugin-2.541.x" classname="pct-report.commons-lang3-api-plugin-2.541.x" time="40.767"/>
  <testcase name="git-client-plugin-weekly" classname="pct-report.git-client-plugin-weekly" time="298.02"/>
  <testcase name="kubernetes-client-api-plugin-weekly" classname="pct-report.kubernetes-client-api-plugin-weekly" time="32.549"/>
  <testcase name="junit-attachments-plugin-2.541.x" classname="pct-report.junit-attachments-plugin-2.541.x" time="76.053"/>
  <testcase name="javadoc-plugin-weekly" classname="pct-report.javadoc-plugin-weekly" time="92.328"/>
  <testcase name="jaxb-plugin-2.541.x" classname="pct-report.jaxb-plugin-2.541.x" time="42.126"/>
  <testcase name="jackson2-api-plugin-2.541.x" classname="pct-report.jackson2-api-plugin-2.541.x" time="48.929"/>
  <testcase name="google-compute-engine-plugin-2.541.x" classname="pct-report.google-compute-engine-plugin-2.541.x" time="143.678"/>
  <testcase name="design-library-plugin-2.541.x" classname="pct-report.design-library-plugin-2.541.x" time="79.468"/>
  <testcase name="extended-timer-trigger-plugin-2.541.x" classname="pct-report.extended-timer-trigger-plugin-2.541.x" time="42.383"/>
  <testcase name="gitlab-oauth-plugin-2.541.x" classname="pct-report.gitlab-oauth-plugin-2.541.x" time="57.303"/>
  <testcase name="display-url-api-plugin-weekly" classname="pct-report.display-url-api-plugin-weekly" time="62.118"/>
  <testcase name="jersey3-api-plugin-weekly" classname="pct-report.jersey3-api-plugin-weekly" time="40.279"/>
  <testcase name="http-request-plugin-2.541.x" classname="pct-report.http-request-plugin-2.541.x" time="210.038"/>
  <testcase name="jersey2-api-plugin-2.541.x" classname="pct-report.jersey2-api-plugin-2.541.x" time="59.071"/>
  <testcase name="gitlab-plugin-2.541.x" classname="pct-report.gitlab-plugin-2.541.x" time="367.426"/>
  <testcase name="gitlab-kubernetes-credentials-plugin-2.541.x" classname="pct-report.gitlab-kubernetes-credentials-plugin-2.541.x" time="60.046"/>
  <testcase name="database-plugin-2.541.x" classname="pct-report.database-plugin-2.541.x" time="53.228"/>
  <testcase name="google-kubernetes-engine-plugin-weekly" classname="pct-report.google-kubernetes-engine-plugin-weekly" time="48.381"/>
  <testcase name="jspecify-api-plugin-weekly" classname="pct-report.jspecify-api-plugin-weekly" time="32.887"/>
  <testcase name="flaky-test-handler-plugin-2.541.x" classname="pct-report.flaky-test-handler-plugin-2.541.x" time="66.372"/>
  <testcase name="netty-api-plugin-weekly" classname="pct-report.netty-api-plugin-weekly" time="47.869"/>
  <testcase name="mina-sshd-api-plugin-weekly" classname="pct-report.mina-sshd-api-plugin-weekly" time="131.817"/>
  <testcase name="flaky-test-handler-plugin-weekly" classname="pct-report.flaky-test-handler-plugin-weekly" time="66.007"/>
  <testcase name="jakarta-mail-api-plugin-2.541.x" classname="pct-report.jakarta-mail-api-plugin-2.541.x" time="42.9"/>
  <testcase name="extra-columns-plugin-weekly" classname="pct-report.extra-columns-plugin-weekly" time="37.147"/>
  <testcase name="docker-plugin-2.541.x" classname="pct-report.docker-plugin-2.541.x" time="145.081"/>
  <testcase name="jquery3-api-plugin-2.541.x" classname="pct-report.jquery3-api-plugin-2.541.x" time="60.254"/>
  <testcase name="external-monitor-job-plugin-2.541.x" classname="pct-report.external-monitor-job-plugin-2.541.x" time="56.156"/>
  <testcase name="jackson3-api-plugin-2.541.x" classname="pct-report.jackson3-api-plugin-2.541.x" time="62.079"/>
  <testcase name="jakarta-xml-bind-api-plugin-weekly" classname="pct-report.jakarta-xml-bind-api-plugin-weekly" time="38.005"/>
  <testcase name="jakarta-activation-api-plugin-2.541.x" classname="pct-report.jakarta-activation-api-plugin-2.541.x" time="47.243"/>
  <testcase name="jackson-annotations2-api-plugin-2.541.x" classname="pct-report.jackson-annotations2-api-plugin-2.541.x" time="47.215"/>
  <testcase name="gitea-checks-plugin-2.541.x" classname="pct-report.gitea-checks-plugin-2.541.x" time="76.411"/>
  <testcase name="kubernetes-credentials-provider-plugin-weekly" classname="pct-report.kubernetes-credentials-provider-plugin-weekly" time="65.923"/>
  <testcase name="metrics-plugin-2.541.x" classname="pct-report.metrics-plugin-2.541.x" time="103.435"/>
  <testcase name="oss-symbols-api-plugin-weekly" classname="pct-report.oss-symbols-api-plugin-weekly" time="35.143"/>
  <testcase name="gitlab-api-plugin-2.541.x" classname="pct-report.gitlab-api-plugin-2.541.x" time="55.921"/>
  <testcase name="pipeline-aggregator-view-plugin-weekly" classname="pct-report.pipeline-aggregator-view-plugin-weekly" time="55.894"/>
  <testcase name="json-path-api-plugin-2.541.x" classname="pct-report.json-path-api-plugin-2.541.x" time="47.67"/>
  <testcase name="mailer-plugin-2.541.x" classname="pct-report.mailer-plugin-2.541.x" time="201.298"/>
  <testcase name="jobcacher-plugin-2.541.x" classname="pct-report.jobcacher-plugin-2.541.x" time="138.314"/>
  <testcase name="gitlab-api-plugin-weekly" classname="pct-report.gitlab-api-plugin-weekly" time="53.46"/>
  <testcase name="kubernetes-credentials-plugin-2.541.x" classname="pct-report.kubernetes-credentials-plugin-2.541.x" time="79.889"/>
  <testcase name="embeddable-build-status-plugin-2.541.x" classname="pct-report.embeddable-build-status-plugin-2.541.x" time="83.811"/>
  <testcase name="aws-java-sdk-plugin-2.541.x" classname="pct-report.aws-java-sdk-plugin-2.541.x" time="1006.535"/>
  <testcase name="file-leak-detector-plugin-2.541.x" classname="pct-report.file-leak-detector-plugin-2.541.x" time="73.64"/>
  <testcase name="github-api-plugin-2.541.x" classname="pct-report.github-api-plugin-2.541.x" time="73.615"/>
  <testcase name="jsoup-plugin-weekly" classname="pct-report.jsoup-plugin-weekly" time="49.463"/>
  <testcase name="joda-time-api-plugin-2.541.x" classname="pct-report.joda-time-api-plugin-2.541.x" time="77.037"/>
  <testcase name="json-api-plugin-2.541.x" classname="pct-report.json-api-plugin-2.541.x" time="77.05"/>
  <testcase name="junit-realtime-test-reporter-plugin-2.541.x" classname="pct-report.junit-realtime-test-reporter-plugin-2.541.x" time="183.893"/>
  <testcase name="gson-api-plugin-2.541.x" classname="pct-report.gson-api-plugin-2.541.x" time="71.535"/>
  <testcase name="mercurial-plugin-weekly" classname="pct-report.mercurial-plugin-weekly" time="141.328"/>
  <testcase name="plain-credentials-plugin-weekly" classname="pct-report.plain-credentials-plugin-weekly" time="70.603"/>
  <testcase name="mask-passwords-plugin-2.541.x" classname="pct-report.mask-passwords-plugin-2.541.x" time="120.37"/>
  <testcase name="nimbus-jose-jwt-api-plugin-2.541.x" classname="pct-report.nimbus-jose-jwt-api-plugin-2.541.x" time="59.243"/>
  <testcase name="multibranch-build-strategy-extension-plugin-weekly" classname="pct-report.multibranch-build-strategy-extension-plugin-weekly" time="94.778"/>
  <testcase name="mariadb-api-plugin-2.541.x" classname="pct-report.mariadb-api-plugin-2.541.x" time="59.281"/>
  <testcase name="aws-java-sdk2-plugin-weekly" classname="pct-report.aws-java-sdk2-plugin-weekly" time="1095.607"/>
  <testcase name="aws-java-sdk2-plugin-2.541.x" classname="pct-report.aws-java-sdk2-plugin-2.541.x" time="1082.166"/>
  <testcase name="instant-messaging-plugin-2.541.x" classname="pct-report.instant-messaging-plugin-2.541.x" time="87.179"/>
  <testcase name="gitlab-oauth-plugin-weekly" classname="pct-report.gitlab-oauth-plugin-weekly" time="68.049"/>
  <testcase name="jsch-plugin-2.541.x" classname="pct-report.jsch-plugin-2.541.x" time="133.789"/>
  <testcase name="msbuild-plugin-2.541.x" classname="pct-report.msbuild-plugin-2.541.x" time="66.787"/>
  <testcase name="mock-slave-plugin-weekly" classname="pct-report.mock-slave-plugin-weekly" time="256.099"/>
  <testcase name="instant-messaging-plugin-weekly" classname="pct-report.instant-messaging-plugin-weekly" time="82.493"/>
  <testcase name="jquery3-api-plugin-weekly" classname="pct-report.jquery3-api-plugin-weekly" time="67.387"/>
  <testcase name="jersey2-api-plugin-weekly" classname="pct-report.jersey2-api-plugin-weekly" time="67.334"/>
  <testcase name="git-plugin-weekly" classname="pct-report.git-plugin-weekly" time="923.519"/>
  <testcase name="prometheus-plugin-weekly" classname="pct-report.prometheus-plugin-weekly" time="127.706"/>
  <testcase name="built-on-column-plugin-2.541.x" classname="pct-report.built-on-column-plugin-2.541.x" time="60.667"/>
  <testcase name="handy-uri-templates-2-api-plugin-2.541.x" classname="pct-report.handy-uri-templates-2-api-plugin-2.541.x" time="59.558"/>
  <testcase name="junit-attachments-plugin-weekly" classname="pct-report.junit-attachments-plugin-weekly" time="89.618"/>
  <testcase name="gitlab-kubernetes-credentials-plugin-weekly" classname="pct-report.gitlab-kubernetes-credentials-plugin-weekly" time="63.238"/>
  <testcase name="markdown-formatter-plugin-2.541.x" classname="pct-report.markdown-formatter-plugin-2.541.x" time="56.552"/>
  <testcase name="git-forensics-plugin-2.541.x" classname="pct-report.git-forensics-plugin-2.541.x" time="91.981"/>
  <testcase name="jdk-tool-plugin-2.541.x" classname="pct-report.jdk-tool-plugin-2.541.x" time="75.853"/>
  <testcase name="oauth-credentials-plugin-2.541.x" classname="pct-report.oauth-credentials-plugin-2.541.x" time="63.807"/>
  <testcase name="pipeline-github-lib-plugin-2.541.x" classname="pct-report.pipeline-github-lib-plugin-2.541.x" time="61.878"/>
  <testcase name="byte-buddy-api-plugin-weekly" classname="pct-report.byte-buddy-api-plugin-weekly" time="51.891"/>
  <testcase name="opentelemetry-api-plugin-weekly" classname="pct-report.opentelemetry-api-plugin-weekly" time="88.869"/>
  <testcase name="jobcacher-plugin-weekly" classname="pct-report.jobcacher-plugin-weekly" time="133.12"/>
  <testcase name="parameter-separator-plugin-weekly" classname="pct-report.parameter-separator-plugin-weekly" time="69.746"/>
  <testcase name="byte-buddy-api-plugin-2.541.x" classname="pct-report.byte-buddy-api-plugin-2.541.x" time="57.733"/>
  <testcase name="job-restrictions-plugin-2.541.x" classname="pct-report.job-restrictions-plugin-2.541.x" time="66.561"/>
  <testcase name="jackson3-api-plugin-weekly" classname="pct-report.jackson3-api-plugin-weekly" time="64.357"/>
  <testcase name="pam-auth-plugin-weekly" classname="pct-report.pam-auth-plugin-weekly" time="49.907"/>
  <testcase name="docker-plugin-weekly" classname="pct-report.docker-plugin-weekly" time="148.808"/>
  <testcase name="github-branch-source-plugin-weekly" classname="pct-report.github-branch-source-plugin-weekly" time="262.5"/>
  <testcase name="google-compute-engine-plugin-weekly" classname="pct-report.google-compute-engine-plugin-weekly" time="149.653"/>
  <testcase name="job-restrictions-plugin-weekly" classname="pct-report.job-restrictions-plugin-weekly" time="60.036"/>
  <testcase name="job-config-history-plugin-2.541.x" classname="pct-report.job-config-history-plugin-2.541.x" time="324.79"/>
  <testcase name="parallel-test-executor-plugin-2.541.x" classname="pct-report.parallel-test-executor-plugin-2.541.x" time="88.055"/>
  <testcase name="snakeyaml-engine-api-plugin-weekly" classname="pct-report.snakeyaml-engine-api-plugin-weekly" time="63.916"/>
  <testcase name="git-client-plugin-2.541.x" classname="pct-report.git-client-plugin-2.541.x" time="428.822"/>
  <testcase name="jersey3-api-plugin-2.541.x" classname="pct-report.jersey3-api-plugin-2.541.x" time="84.053"/>
  <testcase name="jackson-annotations2-api-plugin-weekly" classname="pct-report.jackson-annotations2-api-plugin-weekly" time="63.854"/>
  <testcase name="mailer-plugin-weekly" classname="pct-report.mailer-plugin-weekly" time="197.412"/>
  <testcase name="nodejs-plugin-2.541.x" classname="pct-report.nodejs-plugin-2.541.x" time="134.07"/>
  <testcase name="kubernetes-credentials-plugin-weekly" classname="pct-report.kubernetes-credentials-plugin-weekly" time="95.92"/>
  <testcase name="coverage-badges-extension-plugin-2.541.x" classname="pct-report.coverage-badges-extension-plugin-2.541.x" time="86.267"/>
  <testcase name="google-metadata-plugin-2.541.x" classname="pct-report.google-metadata-plugin-2.541.x" time="64.397"/>
  <testcase name="mask-passwords-plugin-weekly" classname="pct-report.mask-passwords-plugin-weekly" time="105.999"/>
  <testcase name="matrix-project-plugin-2.541.x" classname="pct-report.matrix-project-plugin-2.541.x" time="176.285"/>
  <testcase name="script-security-plugin-weekly" classname="pct-report.script-security-plugin-weekly" time="162.289"/>
  <testcase name="kubernetes-client-api-plugin-2.541.x" classname="pct-report.kubernetes-client-api-plugin-2.541.x" time="58.015"/>
  <testcase name="pipeline-stage-step-plugin-weekly" classname="pct-report.pipeline-stage-step-plugin-weekly" time="44.135"/>
  <testcase name="postgresql-api-plugin-weekly" classname="pct-report.postgresql-api-plugin-weekly" time="46.105"/>
  <testcase name="mariadb-api-plugin-weekly" classname="pct-report.mariadb-api-plugin-weekly" time="53.605"/>
  <testcase name="metrics-plugin-weekly" classname="pct-report.metrics-plugin-weekly" time="95.728"/>
  <testcase name="mina-sshd-api-plugin-2.541.x" classname="pct-report.mina-sshd-api-plugin-2.541.x" time="192.664"/>
  <testcase name="mapdb-api-plugin-2.541.x" classname="pct-report.mapdb-api-plugin-2.541.x" time="67.877"/>
  <testcase name="file-leak-detector-plugin-weekly" classname="pct-report.file-leak-detector-plugin-weekly" time="59.482"/>
  <testcase name="coverage-plugin-weekly" classname="pct-report.coverage-plugin-weekly" time="111.214"/>
  <testcase name="jakarta-mail-api-plugin-weekly" classname="pct-report.jakarta-mail-api-plugin-weekly" time="68.216"/>
  <testcase name="hidden-parameter-plugin-weekly" classname="pct-report.hidden-parameter-plugin-weekly" time="74.523"/>
  <testcase name="plugin-util-api-plugin-weekly" classname="pct-report.plugin-util-api-plugin-weekly" time="77.554"/>
  <testcase name="mapdb-api-plugin-weekly" classname="pct-report.mapdb-api-plugin-weekly" time="64.806"/>
  <testcase name="coverage-plugin-2.541.x" classname="pct-report.coverage-plugin-2.541.x" time="109.969"/>
  <testcase name="google-storage-plugin-weekly" classname="pct-report.google-storage-plugin-weekly" time="182.013"/>
  <testcase name="nodelabelparameter-plugin-2.541.x" classname="pct-report.nodelabelparameter-plugin-2.541.x" time="155.125"/>
  <testcase name="jsch-plugin-weekly" classname="pct-report.jsch-plugin-weekly" time="94.261"/>
  <testcase name="postbuild-task-plugin-2.541.x" classname="pct-report.postbuild-task-plugin-2.541.x" time="64.753"/>
  <testcase name="joda-time-api-plugin-weekly" classname="pct-report.joda-time-api-plugin-weekly" time="54.099"/>
  <testcase name="urltrigger-plugin-weekly" classname="pct-report.urltrigger-plugin-weekly" time="81.919"/>
  <testcase name="google-kubernetes-engine-plugin-2.541.x" classname="pct-report.google-kubernetes-engine-plugin-2.541.x" time="80.854"/>
  <testcase name="nimbus-jose-jwt-api-plugin-weekly" classname="pct-report.nimbus-jose-jwt-api-plugin-weekly" time="58.041"/>
  <testcase name="msbuild-plugin-weekly" classname="pct-report.msbuild-plugin-weekly" time="58.015"/>
  <testcase name="locale-plugin-2.541.x" classname="pct-report.locale-plugin-2.541.x" time="86.845"/>
  <testcase name="github-plugin-2.541.x" classname="pct-report.github-plugin-2.541.x" time="300.182"/>
  <testcase name="oauth-credentials-plugin-weekly" classname="pct-report.oauth-credentials-plugin-weekly" time="68.095"/>
  <testcase name="skip-notifications-trait-plugin-weekly" classname="pct-report.skip-notifications-trait-plugin-weekly" time="55.214"/>
  <testcase name="kubernetes-credentials-provider-plugin-2.541.x" classname="pct-report.kubernetes-credentials-provider-plugin-2.541.x" time="111.104"/>
  <testcase name="thin-backup-plugin-weekly" classname="pct-report.thin-backup-plugin-weekly" time="81.789"/>
  <testcase name="display-url-api-plugin-2.541.x" classname="pct-report.display-url-api-plugin-2.541.x" time="98.763"/>
  <testcase name="matrix-auth-plugin-2.541.x" classname="pct-report.matrix-auth-plugin-2.541.x" time="264.128"/>
  <testcase name="oss-symbols-api-plugin-2.541.x" classname="pct-report.oss-symbols-api-plugin-2.541.x" time="57.954"/>
  <testcase name="sbt-plugin-weekly" classname="pct-report.sbt-plugin-weekly" time="94.152"/>
  <testcase name="node-iterator-api-plugin-2.541.x" classname="pct-report.node-iterator-api-plugin-2.541.x" time="68.787"/>
  <testcase name="gitlab-plugin-weekly" classname="pct-report.gitlab-plugin-weekly" time="364.757"/>
  <testcase name="json-path-api-plugin-weekly" classname="pct-report.json-path-api-plugin-weekly" time="56.116"/>
  <testcase name="jjwt-api-plugin-weekly" classname="pct-report.jjwt-api-plugin-weekly" time="49.895"/>
  <testcase name="javadoc-plugin-2.541.x" classname="pct-report.javadoc-plugin-2.541.x" time="136.659"/>
  <testcase name="secure-requester-whitelist-plugin-weekly" classname="pct-report.secure-requester-whitelist-plugin-weekly" time="67.283"/>
  <testcase name="node-iterator-api-plugin-weekly" classname="pct-report.node-iterator-api-plugin-weekly" time="67.262"/>
  <testcase name="nodejs-plugin-weekly" classname="pct-report.nodejs-plugin-weekly" time="120.359"/>
  <testcase name="javax-mail-api-plugin-weekly" classname="pct-report.javax-mail-api-plugin-weekly" time="62.555"/>
  <testcase name="git-plugin-2.541.x" classname="pct-report.git-plugin-2.541.x" time="1155.067"/>
  <testcase name="markdown-formatter-plugin-weekly" classname="pct-report.markdown-formatter-plugin-weekly" time="64.774"/>
  <testcase name="simple-theme-plugin-2.541.x" classname="pct-report.simple-theme-plugin-2.541.x" time="84.343"/>
  <testcase name="jakarta-xml-bind-api-plugin-2.541.x" classname="pct-report.jakarta-xml-bind-api-plugin-2.541.x" time="68.004"/>
  <testcase name="pipeline-github-lib-plugin-weekly" classname="pct-report.pipeline-github-lib-plugin-weekly" time="67.982"/>
  <testcase name="netty-api-plugin-2.541.x" classname="pct-report.netty-api-plugin-2.541.x" time="60.9"/>
  <testcase name="pipeline-graph-analysis-plugin-2.541.x" classname="pct-report.pipeline-graph-analysis-plugin-2.541.x" time="197.33"/>
  <testcase name="parallel-test-executor-plugin-weekly" classname="pct-report.parallel-test-executor-plugin-weekly" time="85.291"/>
  <testcase name="ignore-committer-strategy-plugin-2.541.x" classname="pct-report.ignore-committer-strategy-plugin-2.541.x" time="65.557"/>
  <testcase name="docker-commons-plugin-weekly" classname="pct-report.docker-commons-plugin-weekly" time="149.298"/>
  <testcase name="pipeline-groovy-lib-plugin-2.541.x" classname="pct-report.pipeline-groovy-lib-plugin-2.541.x" time="303.475"/>
  <testcase name="extra-columns-plugin-2.541.x" classname="pct-report.extra-columns-plugin-2.541.x" time="62.257"/>
  <testcase name="docker-commons-plugin-2.541.x" classname="pct-report.docker-commons-plugin-2.541.x" time="133.031"/>
  <testcase name="office-365-connector-plugin-2.541.x" classname="pct-report.office-365-connector-plugin-2.541.x" time="72.203"/>
  <testcase name="opentelemetry-plugin-2.541.x" classname="pct-report.opentelemetry-plugin-2.541.x" time="538.044"/>
  <testcase name="plain-credentials-plugin-2.541.x" classname="pct-report.plain-credentials-plugin-2.541.x" time="72.187"/>
  <testcase name="jakarta-activation-api-plugin-weekly" classname="pct-report.jakarta-activation-api-plugin-weekly" time="52.24"/>
  <testcase name="pipeline-github-plugin-2.541.x" classname="pct-report.pipeline-github-plugin-2.541.x" time="70.769"/>
  <testcase name="jspecify-api-plugin-2.541.x" classname="pct-report.jspecify-api-plugin-2.541.x" time="46.297"/>
  <testcase name="multibranch-build-strategy-extension-plugin-2.541.x" classname="pct-report.multibranch-build-strategy-extension-plugin-2.541.x" time="108.668"/>
  <testcase name="pipeline-github-plugin-weekly" classname="pct-report.pipeline-github-plugin-weekly" time="75.36"/>
  <testcase name="token-macro-plugin-weekly" classname="pct-report.token-macro-plugin-weekly" time="137.829"/>
  <testcase name="jsoup-plugin-2.541.x" classname="pct-report.jsoup-plugin-2.541.x" time="46.41"/>
  <testcase name="pipeline-aggregator-view-plugin-2.541.x" classname="pct-report.pipeline-aggregator-view-plugin-2.541.x" time="61.291"/>
  <testcase name="mcp-server-plugin-weekly" classname="pct-report.mcp-server-plugin-weekly" time="510.847"/>
  <testcase name="mock-slave-plugin-2.541.x" classname="pct-report.mock-slave-plugin-2.541.x" time="271.439"/>
  <testcase name="workflow-support-plugin-weekly" classname="pct-report.workflow-support-plugin-weekly" time="139.504"/>
  <testcase name="rebuild-plugin-2.541.x" classname="pct-report.rebuild-plugin-2.541.x" time="392.131"/>
  <testcase name="reverse-proxy-auth-plugin-2.541.x" classname="pct-report.reverse-proxy-auth-plugin-2.541.x" time="62.882"/>
  <testcase name="postbuild-task-plugin-weekly" classname="pct-report.postbuild-task-plugin-weekly" time="62.829"/>
  <testcase name="extra-tool-installers-plugin-weekly" classname="pct-report.extra-tool-installers-plugin-weekly" time="57.518"/>
  <testcase name="extra-tool-installers-plugin-2.541.x" classname="pct-report.extra-tool-installers-plugin-2.541.x" time="57.377"/>
  <testcase name="json-api-plugin-weekly" classname="pct-report.json-api-plugin-weekly" time="45.772"/>
  <testcase name="github-plugin-weekly" classname="pct-report.github-plugin-weekly" time="271.79"/>
  <testcase name="oic-auth-plugin-2.541.x" classname="pct-report.oic-auth-plugin-2.541.x" time="311.931"/>
  <testcase name="matrix-auth-plugin-weekly" classname="pct-report.matrix-auth-plugin-weekly" time="247.27"/>
  <testcase name="nodelabelparameter-plugin-weekly" classname="pct-report.nodelabelparameter-plugin-weekly" time="134.5"/>
  <testcase name="timestamper-plugin-2.541.x" classname="pct-report.timestamper-plugin-2.541.x" time="116.655"/>
  <testcase name="swarm-plugin-weekly" classname="pct-report.swarm-plugin-weekly" time="189.033"/>
  <testcase name="resource-disposer-plugin-2.541.x" classname="pct-report.resource-disposer-plugin-2.541.x" time="70.289"/>
  <testcase name="okhttp-api-plugin-weekly" classname="pct-report.okhttp-api-plugin-weekly" time="39.819"/>
  <testcase name="parameter-separator-plugin-2.541.x" classname="pct-report.parameter-separator-plugin-2.541.x" time="77.642"/>
  <testcase name="pam-auth-plugin-2.541.x" classname="pct-report.pam-auth-plugin-2.541.x" time="46.941"/>
  <testcase name="resource-disposer-plugin-weekly" classname="pct-report.resource-disposer-plugin-weekly" time="74.528"/>
  <testcase name="sqlserver-api-plugin-2.541.x" classname="pct-report.sqlserver-api-plugin-2.541.x" time="42.596"/>
  <testcase name="pipeline-graph-analysis-plugin-weekly" classname="pct-report.pipeline-graph-analysis-plugin-weekly" time="186.09"/>
  <testcase name="run-condition-plugin-2.541.x" classname="pct-report.run-condition-plugin-2.541.x" time="139.697"/>
  <testcase name="pipeline-groovy-lib-plugin-weekly" classname="pct-report.pipeline-groovy-lib-plugin-weekly" time="276.59"/>
  <testcase name="throttle-concurrent-builds-plugin-weekly" classname="pct-report.throttle-concurrent-builds-plugin-weekly" time="211.17"/>
  <testcase name="simple-theme-plugin-weekly" classname="pct-report.simple-theme-plugin-weekly" time="65.521"/>
  <testcase name="junit-plugin-weekly" classname="pct-report.junit-plugin-weekly" time="211.939"/>
  <testcase name="ignore-committer-strategy-plugin-weekly" classname="pct-report.ignore-committer-strategy-plugin-weekly" time="55.876"/>
  <testcase name="google-storage-plugin-2.541.x" classname="pct-report.google-storage-plugin-2.541.x" time="210.858"/>
  <testcase name="office-365-connector-plugin-weekly" classname="pct-report.office-365-connector-plugin-weekly" time="52.49"/>
  <testcase name="prometheus-plugin-2.541.x" classname="pct-report.prometheus-plugin-2.541.x" time="120.786"/>
  <testcase name="github-checks-plugin-weekly" classname="pct-report.github-checks-plugin-weekly" time="97.23"/>
  <testcase name="postgresql-api-plugin-2.541.x" classname="pct-report.postgresql-api-plugin-2.541.x" time="50.54"/>
  <testcase name="mercurial-plugin-2.541.x" classname="pct-report.mercurial-plugin-2.541.x" time="152.631"/>
  <testcase name="pipeline-input-step-plugin-2.541.x" classname="pct-report.pipeline-input-step-plugin-2.541.x" time="186.169"/>
  <testcase name="github-checks-plugin-2.541.x" classname="pct-report.github-checks-plugin-2.541.x" time="99.78"/>
  <testcase name="reverse-proxy-auth-plugin-weekly" classname="pct-report.reverse-proxy-auth-plugin-weekly" time="47.957"/>
  <testcase name="plugin-util-api-plugin-2.541.x" classname="pct-report.plugin-util-api-plugin-2.541.x" time="62.838"/>
  <testcase name="versioncolumn-plugin-2.541.x" classname="pct-report.versioncolumn-plugin-2.541.x" time="65.074"/>
  <testcase name="ssh-steps-plugin-2.541.x" classname="pct-report.ssh-steps-plugin-2.541.x" time="65.815"/>
  <testcase name="micrometer-core-api-plugin-weekly" classname="pct-report.micrometer-core-api-plugin-weekly" time="41.354"/>
  <testcase name="xtrigger-api-plugin-2.541.x" classname="pct-report.xtrigger-api-plugin-2.541.x" time="112.576"/>
  <testcase name="pipeline-stage-view-plugin-2.541.x" classname="pct-report.pipeline-stage-view-plugin-2.541.x" time="211.074"/>
  <testcase name="script-security-plugin-2.541.x" classname="pct-report.script-security-plugin-2.541.x" time="211.048"/>
  <testcase name="ssh-agents-plugin-2.541.x" classname="pct-report.ssh-agents-plugin-2.541.x" time="147.009"/>
  <testcase name="matrix-project-plugin-weekly" classname="pct-report.matrix-project-plugin-weekly" time="141.41"/>
  <testcase name="ssh-agent-plugin-2.541.x" classname="pct-report.ssh-agent-plugin-2.541.x" time="112.653"/>
  <testcase name="ssh-agent-plugin-weekly" classname="pct-report.ssh-agent-plugin-weekly" time="89.641"/>
  <testcase name="javax-mail-api-plugin-2.541.x" classname="pct-report.javax-mail-api-plugin-2.541.x" time="47.485"/>
  <testcase name="snakeyaml-engine-api-plugin-2.541.x" classname="pct-report.snakeyaml-engine-api-plugin-2.541.x" time="56.179"/>
  <testcase name="skip-notifications-trait-plugin-2.541.x" classname="pct-report.skip-notifications-trait-plugin-2.541.x" time="56.171"/>
  <testcase name="opentelemetry-plugin-weekly" classname="pct-report.opentelemetry-plugin-weekly" time="490.108"/>
  <testcase name="timestamper-plugin-weekly" classname="pct-report.timestamper-plugin-weekly" time="100.324"/>
  <testcase name="s3-jobcacher-storage-plugin-2.541.x" classname="pct-report.s3-jobcacher-storage-plugin-2.541.x" time="53.659"/>
  <testcase name="pipeline-graph-view-plugin-2.541.x" classname="pct-report.pipeline-graph-view-plugin-2.541.x" time="446.873"/>
  <testcase name="oras-java-api-plugin-weekly" classname="pct-report.oras-java-api-plugin-weekly" time="38.695"/>
  <testcase name="opentelemetry-api-plugin-2.541.x" classname="pct-report.opentelemetry-api-plugin-2.541.x" time="88.789"/>
  <testcase name="secure-requester-whitelist-plugin-2.541.x" classname="pct-report.secure-requester-whitelist-plugin-2.541.x" time="64.218"/>
  <testcase name="kubernetes-plugin-weekly" classname="pct-report.kubernetes-plugin-weekly" time="376.842"/>
  <testcase name="github-branch-source-plugin-2.541.x" classname="pct-report.github-branch-source-plugin-2.541.x" time="300.245"/>
  <testcase name="ws-cleanup-plugin-weekly" classname="pct-report.ws-cleanup-plugin-weekly" time="135.169"/>
  <testcase name="htmlpublisher-plugin-weekly" classname="pct-report.htmlpublisher-plugin-weekly" time="97.62"/>
  <testcase name="htmlpublisher-plugin-2.541.x" classname="pct-report.htmlpublisher-plugin-2.541.x" time="94.292"/>
  <testcase name="maven-plugin-2.541.x" classname="pct-report.maven-plugin-2.541.x" time="874.241"/>
  <testcase name="run-condition-plugin-weekly" classname="pct-report.run-condition-plugin-weekly" time="159.657"/>
  <testcase name="thin-backup-plugin-2.541.x" classname="pct-report.thin-backup-plugin-2.541.x" time="78.986"/>
  <testcase name="scm-api-plugin-2.541.x" classname="pct-report.scm-api-plugin-2.541.x" time="85.634"/>
  <testcase name="urltrigger-plugin-2.541.x" classname="pct-report.urltrigger-plugin-2.541.x" time="51.423"/>
  <testcase name="ssh-agents-plugin-weekly" classname="pct-report.ssh-agents-plugin-weekly" time="131.159"/>
  <testcase name="mysql-api-plugin-weekly" classname="pct-report.mysql-api-plugin-weekly" time="29.705"/>
  <testcase name="pipeline-input-step-plugin-weekly" classname="pct-report.pipeline-input-step-plugin-weekly" time="173.539"/>
  <testcase name="pipeline-stage-step-plugin-2.541.x" classname="pct-report.pipeline-stage-step-plugin-2.541.x" time="46.182"/>
  <testcase name="jnr-posix-api-plugin-weekly" classname="pct-report.jnr-posix-api-plugin-weekly" time="40.114"/>
  <testcase name="jnr-posix-api-plugin-2.541.x" classname="pct-report.jnr-posix-api-plugin-2.541.x" time="37.641"/>
  <testcase name="workflow-multibranch-plugin-weekly" classname="pct-report.workflow-multibranch-plugin-weekly" time="274.488"/>
  <testcase name="hidden-parameter-plugin-2.541.x" classname="pct-report.hidden-parameter-plugin-2.541.x" time="60.271"/>
  <testcase name="rebuild-plugin-weekly" classname="pct-report.rebuild-plugin-weekly" time="426.243"/>
  <testcase name="xtrigger-api-plugin-weekly" classname="pct-report.xtrigger-api-plugin-weekly" time="99.721"/>
  <testcase name="ssh-steps-plugin-weekly" classname="pct-report.ssh-steps-plugin-weekly" time="46.932"/>
  <testcase name="pipeline-maven-plugin-2.541.x" classname="pct-report.pipeline-maven-plugin-2.541.x" time="301.233"/>
  <testcase name="workflow-api-plugin-2.541.x" classname="pct-report.workflow-api-plugin-2.541.x" time="167.812"/>
  <testcase name="parameterized-scheduler-plugin-weekly" classname="pct-report.parameterized-scheduler-plugin-weekly" time="49.967"/>
  <testcase name="s3-jobcacher-storage-plugin-weekly" classname="pct-report.s3-jobcacher-storage-plugin-weekly" time="53.985"/>
  <testcase name="job-dsl-plugin-2.541.x" classname="pct-report.job-dsl-plugin-2.541.x" time="452.096"/>
  <testcase name="jjwt-api-plugin-2.541.x" classname="pct-report.jjwt-api-plugin-2.541.x" time="41.794"/>
  <testcase name="sqlserver-api-plugin-weekly" classname="pct-report.sqlserver-api-plugin-weekly" time="36.112"/>
  <testcase name="token-macro-plugin-2.541.x" classname="pct-report.token-macro-plugin-2.541.x" time="158.336"/>
  <testcase name="sbt-plugin-2.541.x" classname="pct-report.sbt-plugin-2.541.x" time="76.491"/>
  <testcase name="powershell-plugin-weekly" classname="pct-report.powershell-plugin-weekly" time="36.857"/>
  <testcase name="oidc-provider-plugin-2.541.x" classname="pct-report.oidc-provider-plugin-2.541.x" time="116.328"/>
  <testcase name="text-finder-plugin-2.541.x" classname="pct-report.text-finder-plugin-2.541.x" time="117.878"/>
  <testcase name="pipeline-stage-view-plugin-weekly" classname="pct-report.pipeline-stage-view-plugin-weekly" time="186.755"/>
  <testcase name="sshd-plugin-2.541.x" classname="pct-report.sshd-plugin-2.541.x" time="179.515"/>
  <testcase name="s3-plugin-2.541.x" classname="pct-report.s3-plugin-2.541.x" time="80.104"/>
  <testcase name="workflow-support-plugin-2.541.x" classname="pct-report.workflow-support-plugin-2.541.x" time="147.416"/>
  <testcase name="versioncolumn-plugin-weekly" classname="pct-report.versioncolumn-plugin-weekly" time="54.805"/>
  <testcase name="view-job-filters-plugin-2.541.x" classname="pct-report.view-job-filters-plugin-2.541.x" time="273.796"/>
  <testcase name="view-job-filters-plugin-weekly" classname="pct-report.view-job-filters-plugin-weekly" time="281.745"/>
  <testcase name="pipeline-milestone-step-plugin-2.541.x" classname="pct-report.pipeline-milestone-step-plugin-2.541.x" time="78.91"/>
  <testcase name="pipeline-graph-view-plugin-weekly" classname="pct-report.pipeline-graph-view-plugin-weekly" time="442.347"/>
  <testcase name="junit-plugin-2.541.x" classname="pct-report.junit-plugin-2.541.x" time="286.901"/>
  <testcase name="scm-api-plugin-weekly" classname="pct-report.scm-api-plugin-weekly" time="65.847"/>
  <testcase name="workflow-api-plugin-weekly" classname="pct-report.workflow-api-plugin-weekly" time="161.082"/>
  <testcase name="slack-plugin-weekly" classname="pct-report.slack-plugin-weekly" time="105.52"/>
  <testcase name="structs-plugin-2.541.x" classname="pct-report.structs-plugin-2.541.x" time="68.478"/>
  <testcase name="throttle-concurrent-builds-plugin-2.541.x" classname="pct-report.throttle-concurrent-builds-plugin-2.541.x" time="250.762"/>
  <testcase name="oic-auth-plugin-weekly" classname="pct-report.oic-auth-plugin-weekly" time="322.047"/>
  <testcase name="workflow-scm-step-plugin-2.541.x" classname="pct-report.workflow-scm-step-plugin-2.541.x" time="114.079"/>
  <testcase name="sshd-plugin-weekly" classname="pct-report.sshd-plugin-weekly" time="176.142"/>
  <testcase name="saferestart-plugin-2.541.x" classname="pct-report.saferestart-plugin-2.541.x" time="37.285"/>
  <testcase name="job-dsl-plugin-weekly" classname="pct-report.job-dsl-plugin-weekly" time="432.609"/>
  <testcase name="micrometer-core-api-plugin-2.541.x" classname="pct-report.micrometer-core-api-plugin-2.541.x" time="36.964"/>
  <testcase name="trilead-api-plugin-weekly" classname="pct-report.trilead-api-plugin-weekly" time="33.952"/>
  <testcase name="mcp-server-plugin-2.541.x" classname="pct-report.mcp-server-plugin-2.541.x" time="564.388"/>
  <testcase name="pipeline-utility-steps-plugin-weekly" classname="pct-report.pipeline-utility-steps-plugin-weekly" time="324.158"/>
  <testcase name="ldap-plugin-weekly" classname="pct-report.ldap-plugin-weekly" time="266.526"/>
  <testcase name="ldap-plugin-2.541.x" classname="pct-report.ldap-plugin-2.541.x" time="270.522"/>
  <testcase name="role-strategy-plugin-2.541.x" classname="pct-report.role-strategy-plugin-2.541.x" time="355.332"/>
  <testcase name="oras-java-api-plugin-2.541.x" classname="pct-report.oras-java-api-plugin-2.541.x" time="42.022"/>
  <testcase name="okhttp-api-plugin-2.541.x" classname="pct-report.okhttp-api-plugin-2.541.x" time="41.7"/>
  <testcase name="swarm-plugin-2.541.x" classname="pct-report.swarm-plugin-2.541.x" time="221.638"/>
  <testcase name="text-finder-plugin-weekly" classname="pct-report.text-finder-plugin-weekly" time="117.654"/>
  <testcase name="scmskip-plugin-weekly" classname="pct-report.scmskip-plugin-weekly" time="68.389"/>
  <testcase name="maven-plugin-weekly" classname="pct-report.maven-plugin-weekly" time="791.73"/>
  <testcase name="ws-cleanup-plugin-2.541.x" classname="pct-report.ws-cleanup-plugin-2.541.x" time="132.781"/>
  <testcase name="pipeline-model-definition-plugin-weekly" classname="pct-report.pipeline-model-definition-plugin-weekly" time="617.806"/>
  <testcase name="theme-manager-plugin-weekly" classname="pct-report.theme-manager-plugin-weekly" time="33.335"/>
  <testcase name="ssh-credentials-plugin-2.541.x" classname="pct-report.ssh-credentials-plugin-2.541.x" time="75.297"/>
  <testcase name="naginator-plugin-weekly" classname="pct-report.naginator-plugin-weekly" time="109.854"/>
  <testcase name="naginator-plugin-2.541.x" classname="pct-report.naginator-plugin-2.541.x" time="109.117"/>
  <testcase name="woodstox-core-api-plugin-2.541.x" classname="pct-report.woodstox-core-api-plugin-2.541.x" time="32.611"/>
  <testcase name="workflow-scm-step-plugin-weekly" classname="pct-report.workflow-scm-step-plugin-weekly" time="98.929"/>
  <testcase name="workflow-step-api-plugin-weekly" classname="pct-report.workflow-step-api-plugin-weekly" time="46.97"/>
  <testcase name="oidc-provider-plugin-weekly" classname="pct-report.oidc-provider-plugin-weekly" time="100.535"/>
  <testcase name="workflow-basic-steps-plugin-2.541.x" classname="pct-report.workflow-basic-steps-plugin-2.541.x" time="333.378"/>
  <testcase name="saml-plugin-weekly" classname="pct-report.saml-plugin-weekly" time="83.197"/>
  <testcase name="pipeline-maven-plugin-weekly" classname="pct-report.pipeline-maven-plugin-weekly" time="280.436"/>
  <testcase name="pipeline-milestone-step-plugin-weekly" classname="pct-report.pipeline-milestone-step-plugin-weekly" time="66.84"/>
  <testcase name="kubernetes-plugin-2.541.x" classname="pct-report.kubernetes-plugin-2.541.x" time="456.436"/>
  <testcase name="subversion-plugin-2.541.x" classname="pct-report.subversion-plugin-2.541.x" time="293.852"/>
  <testcase name="saferestart-plugin-weekly" classname="pct-report.saferestart-plugin-weekly" time="33.491"/>
  <testcase name="workflow-basic-steps-plugin-weekly" classname="pct-report.workflow-basic-steps-plugin-weekly" time="329.282"/>
  <testcase name="mysql-api-plugin-2.541.x" classname="pct-report.mysql-api-plugin-2.541.x" time="33.297"/>
  <testcase name="s3-plugin-weekly" classname="pct-report.s3-plugin-weekly" time="71.578"/>
  <testcase name="role-strategy-plugin-weekly" classname="pct-report.role-strategy-plugin-weekly" time="393.917"/>
  <testcase name="warnings-ng-plugin-2.541.x" classname="pct-report.warnings-ng-plugin-2.541.x" time="717.703"/>
  <testcase name="workflow-multibranch-plugin-2.541.x" classname="pct-report.workflow-multibranch-plugin-2.541.x" time="307.908"/>
  <testcase name="parameterized-scheduler-plugin-2.541.x" classname="pct-report.parameterized-scheduler-plugin-2.541.x" time="49.898"/>
  <testcase name="structs-plugin-weekly" classname="pct-report.structs-plugin-weekly" time="52.834"/>
  <testcase name="ssh-credentials-plugin-weekly" classname="pct-report.ssh-credentials-plugin-weekly" time="64.904"/>
  <testcase name="powershell-plugin-2.541.x" classname="pct-report.powershell-plugin-2.541.x" time="41.305"/>
  <testcase name="parameterized-trigger-plugin-weekly" classname="pct-report.parameterized-trigger-plugin-weekly" time="296.167"/>
  <testcase name="woodstox-core-api-plugin-weekly" classname="pct-report.woodstox-core-api-plugin-weekly" time="30.074"/>
  <testcase name="parameterized-trigger-plugin-2.541.x" classname="pct-report.parameterized-trigger-plugin-2.541.x" time="295.497"/>
  <testcase name="pipeline-utility-steps-plugin-2.541.x" classname="pct-report.pipeline-utility-steps-plugin-2.541.x" time="400.206"/>
  <testcase name="workflow-cps-plugin-2.541.x" classname="pct-report.workflow-cps-plugin-2.541.x" time="533.018"/>
  <testcase name="prism-api-plugin-weekly" classname="pct-report.prism-api-plugin-weekly" time="54.317"/>
  <testcase name="prism-api-plugin-2.541.x" classname="pct-report.prism-api-plugin-2.541.x" time="51.201"/>
  <testcase name="snakeyaml-api-plugin-weekly" classname="pct-report.snakeyaml-api-plugin-weekly" time="30.534"/>
  <testcase name="snakeyaml-api-plugin-2.541.x" classname="pct-report.snakeyaml-api-plugin-2.541.x" time="30.512"/>
  <testcase name="scmskip-plugin-2.541.x" classname="pct-report.scmskip-plugin-2.541.x" time="87.984"/>
  <testcase name="slack-plugin-2.541.x" classname="pct-report.slack-plugin-2.541.x" time="114.323"/>
  <testcase name="support-core-plugin-weekly" classname="pct-report.support-core-plugin-weekly" time="348.452"/>
  <testcase name="subversion-plugin-weekly" classname="pct-report.subversion-plugin-weekly" time="264.894"/>
  <testcase name="unique-id-plugin-weekly" classname="pct-report.unique-id-plugin-weekly" time="35.737"/>
  <testcase name="unique-id-plugin-2.541.x" classname="pct-report.unique-id-plugin-2.541.x" time="33.811"/>
  <testcase name="trilead-api-plugin-2.541.x" classname="pct-report.trilead-api-plugin-2.541.x" time="33.165"/>
  <testcase name="theme-manager-plugin-2.541.x" classname="pct-report.theme-manager-plugin-2.541.x" time="39.737"/>
  <testcase name="warnings-ng-plugin-weekly" classname="pct-report.warnings-ng-plugin-weekly" time="895.666"/>
  <testcase name="workflow-step-api-plugin-2.541.x" classname="pct-report.workflow-step-api-plugin-2.541.x" time="53.992"/>
  <testcase name="workflow-job-plugin-weekly" classname="pct-report.workflow-job-plugin-weekly" time="140.537"/>
  <testcase name="pipeline-model-definition-plugin-2.541.x" classname="pct-report.pipeline-model-definition-plugin-2.541.x" time="720.323"/>
  <testcase name="saml-plugin-2.541.x" classname="pct-report.saml-plugin-2.541.x" time="98.192"/>
  <testcase name="workflow-cps-plugin-weekly" classname="pct-report.workflow-cps-plugin-weekly" time="491.656"/>
  <testcase name="lockable-resources-plugin-2.541.x" classname="pct-report.lockable-resources-plugin-2.541.x" time="1105.506"/>
  <testcase name="next-executions-plugin-2.541.x" classname="pct-report.next-executions-plugin-2.541.x" time="45.101"/>
  <testcase name="workflow-durable-task-step-plugin-2.541.x" classname="pct-report.workflow-durable-task-step-plugin-2.541.x" time="764.579"/>
  <testcase name="lockable-resources-plugin-weekly" classname="pct-report.lockable-resources-plugin-weekly" time="1067.371"/>
  <testcase name="next-executions-plugin-weekly" classname="pct-report.next-executions-plugin-weekly" time="44.88"/>
  <testcase name="pipeline-build-step-plugin-2.541.x" classname="pct-report.pipeline-build-step-plugin-2.541.x" time="162.65"/>
  <testcase name="pipeline-build-step-plugin-weekly" classname="pct-report.pipeline-build-step-plugin-weekly" time="160.009"/>
  <testcase name="support-core-plugin-2.541.x" classname="pct-report.support-core-plugin-2.541.x" time="415.885"/>
  <testcase name="workflow-durable-task-step-plugin-weekly" classname="pct-report.workflow-durable-task-step-plugin-weekly" time="725.385"/>
  <testcase name="promoted-builds-plugin-2.541.x" classname="pct-report.promoted-builds-plugin-2.541.x" time="188.896"/>
  <testcase name="promoted-builds-plugin-weekly" classname="pct-report.promoted-builds-plugin-weekly" time="186.166"/>
  <testcase name="workflow-job-plugin-2.541.x" classname="pct-report.workflow-job-plugin-2.541.x" time="167.412"/>
  <testcase name="sonarqube-plugin-2.541.x" classname="pct-report.sonarqube-plugin-2.541.x" time="299.58"/>
  <testcase name="variant-plugin-2.541.x" classname="pct-report.variant-plugin-2.541.x" time="30.763"/>
  <testcase name="sonarqube-plugin-weekly" classname="pct-report.sonarqube-plugin-weekly" time="296.443"/>
  <testcase name="variant-plugin-weekly" classname="pct-report.variant-plugin-weekly" time="30.528"/>
</testsuite>
```

</details>

</details>

<details><summary>After</summary><hr>

1) > <img width="1558" height="1235" alt="image" src="https://github.com/user-attachments/assets/006605b5-6ff3-4cca-bad0-d9dca29b0f65" />

2) > <img width="2191" height="425" alt="image" src="https://github.com/user-attachments/assets/0ba11c6e-2fdc-402f-91fb-e7bd3818219d" />

<details><summary>bom-report_weekly.xml</summary>

```xml
<testsuite name="bom-report_weekly" line="weekly" pctduration="5483.294" commit="1143047" build="https://ci.jenkins.io/job/Tools/job/bom/job/PR-7296/2/">
  <testcase split="split-10:weekly" name="apache-httpcomponents-client-5-api-plugin" classname="pct-report.apache-httpcomponents-client-5-api-plugin" time="38.217" readyin="203.737" attempt="1"/>
  <testcase split="split-10:weekly" name="bouncycastle-api-plugin" classname="pct-report.bouncycastle-api-plugin" time="41.515" readyin="203.737" attempt="1"/>
  <testcase split="split-10:weekly" name="commons-collections4-api-plugin" classname="pct-report.commons-collections4-api-plugin" time="36.172" readyin="203.737" attempt="1"/>
  <testcase split="split-10:weekly" name="database-mariadb-plugin" classname="pct-report.database-mariadb-plugin" time="39.934" readyin="203.737" attempt="1"/>
  <testcase split="split-10:weekly" name="email-ext-plugin" classname="pct-report.email-ext-plugin" time="429.337" readyin="199.785" attempt="2"/>
  <testcase split="split-10:weekly" name="generic-tool-plugin" classname="pct-report.generic-tool-plugin" time="44.282" readyin="199.785" attempt="2"/>
  <testcase split="split-10:weekly" name="google-compute-engine-plugin" classname="pct-report.google-compute-engine-plugin" time="152.915" readyin="199.785" attempt="2"/>
  <testcase split="split-10:weekly" name="jakarta-mail-api-plugin" classname="pct-report.jakarta-mail-api-plugin" time="48.706" readyin="199.785" attempt="2"/>
  <testcase split="split-10:weekly" name="json-path-api-plugin" classname="pct-report.json-path-api-plugin" time="60.785" readyin="199.785" attempt="2"/>
  <testcase split="split-10:weekly" name="maven-plugin" classname="pct-report.maven-plugin" time="850.706" readyin="199.785" attempt="2"/>
  <testcase split="split-10:weekly" name="oidc-provider-plugin" classname="pct-report.oidc-provider-plugin" time="128.397" readyin="199.785" attempt="2"/>
  <testcase split="split-10:weekly" name="pipeline-milestone-step-plugin" classname="pct-report.pipeline-milestone-step-plugin" time="79.826" readyin="199.785" attempt="2"/>
  <testcase split="split-10:weekly" name="saferestart-plugin" classname="pct-report.saferestart-plugin" time="41.067" readyin="199.785" attempt="2"/>
  <testcase split="split-10:weekly" name="subversion-plugin" classname="pct-report.subversion-plugin" time="293.863" readyin="199.785" attempt="2"/>
  <testcase split="split-10:weekly" name="workflow-durable-task-step-plugin" classname="pct-report.workflow-durable-task-step-plugin" time="752.896" readyin="199.785" attempt="2"/>
  <testcase split="split-11:weekly" name="artifact-manager-s3-plugin" classname="pct-report.artifact-manager-s3-plugin" time="180.365" readyin="203.791" attempt="1"/>
  <testcase split="split-11:weekly" name="branch-api-plugin" classname="pct-report.branch-api-plugin" time="406.567" readyin="201.317" attempt="2"/>
  <testcase split="split-11:weekly" name="commons-compress-api-plugin" classname="pct-report.commons-compress-api-plugin" time="50.125" readyin="201.317" attempt="2"/>
  <testcase split="split-11:weekly" name="database-mysql-plugin" classname="pct-report.database-mysql-plugin" time="61.255" readyin="201.317" attempt="2"/>
  <testcase split="split-11:weekly" name="emailext-template-plugin" classname="pct-report.emailext-template-plugin" time="82.614" readyin="201.317" attempt="2"/>
  <testcase split="split-11:weekly" name="git-client-plugin" classname="pct-report.git-client-plugin" time="403.827" readyin="201.317" attempt="2"/>
  <testcase split="split-11:weekly" name="google-kubernetes-engine-plugin" classname="pct-report.google-kubernetes-engine-plugin" time="73.419" readyin="201.317" attempt="2"/>
  <testcase split="split-11:weekly" name="jakarta-xml-bind-api-plugin" classname="pct-report.jakarta-xml-bind-api-plugin" time="58.629" readyin="201.317" attempt="2"/>
  <testcase split="split-11:weekly" name="jsoup-plugin" classname="pct-report.jsoup-plugin" time="76.82" readyin="201.317" attempt="2"/>
  <testcase split="split-11:weekly" name="mcp-server-plugin" classname="pct-report.mcp-server-plugin" time="576.573" readyin="201.317" attempt="2"/>
  <testcase split="split-11:weekly" name="okhttp-api-plugin" classname="pct-report.okhttp-api-plugin" time="41.761" readyin="201.317" attempt="2"/>
  <testcase split="split-11:weekly" name="pipeline-model-definition-plugin" classname="pct-report.pipeline-model-definition-plugin" time="764.378" readyin="201.317" attempt="2"/>
  <testcase split="split-11:weekly" name="saml-plugin" classname="pct-report.saml-plugin" time="102.665" readyin="201.317" attempt="2"/>
  <testcase split="split-11:weekly" name="support-core-plugin" classname="pct-report.support-core-plugin" time="405.305" readyin="201.317" attempt="2"/>
  <testcase split="split-11:weekly" name="workflow-job-plugin" classname="pct-report.workflow-job-plugin" time="168.637" readyin="201.317" attempt="2"/>
  <testcase split="split-12:weekly" name="artifactory-artifact-manager-plugin" classname="pct-report.artifactory-artifact-manager-plugin" time="239.323" readyin="203.743" attempt="1"/>
  <testcase split="split-12:weekly" name="build-failure-analyzer-plugin" classname="pct-report.build-failure-analyzer-plugin" time="491.701" readyin="201.332" attempt="2"/>
  <testcase split="split-12:weekly" name="commons-lang3-api-plugin" classname="pct-report.commons-lang3-api-plugin" time="53.488" readyin="201.332" attempt="2"/>
  <testcase split="split-12:weekly" name="database-plugin" classname="pct-report.database-plugin" time="50.361" readyin="201.332" attempt="2"/>
  <testcase split="split-12:weekly" name="embeddable-build-status-plugin" classname="pct-report.embeddable-build-status-plugin" time="83.89" readyin="201.332" attempt="2"/>
  <testcase split="split-12:weekly" name="git-forensics-plugin" classname="pct-report.git-forensics-plugin" time="86.998" readyin="201.332" attempt="2"/>
  <testcase split="split-12:weekly" name="google-metadata-plugin" classname="pct-report.google-metadata-plugin" time="56.834" readyin="201.332" attempt="2"/>
  <testcase split="split-12:weekly" name="javadoc-plugin" classname="pct-report.javadoc-plugin" time="132.32" readyin="201.332" attempt="2"/>
  <testcase split="split-12:weekly" name="jspecify-api-plugin" classname="pct-report.jspecify-api-plugin" time="56.117" readyin="201.332" attempt="2"/>
  <testcase split="split-12:weekly" name="mercurial-plugin" classname="pct-report.mercurial-plugin" time="158.55" readyin="201.332" attempt="2"/>
  <testcase split="split-12:weekly" name="opentelemetry-api-plugin" classname="pct-report.opentelemetry-api-plugin" time="88.466" readyin="201.332" attempt="2"/>
  <testcase split="split-12:weekly" name="pipeline-stage-step-plugin" classname="pct-report.pipeline-stage-step-plugin" time="55.833" readyin="201.332" attempt="2"/>
  <testcase split="split-12:weekly" name="sbt-plugin" classname="pct-report.sbt-plugin" time="91.436" readyin="201.332" attempt="2"/>
  <testcase split="split-12:weekly" name="swarm-plugin" classname="pct-report.swarm-plugin" time="233.484" readyin="201.332" attempt="2"/>
  <testcase split="split-12:weekly" name="workflow-multibranch-plugin" classname="pct-report.workflow-multibranch-plugin" time="316.796" readyin="201.332" attempt="2"/>
  <testcase split="split-13:weekly" name="artifactory-client-api-plugin" classname="pct-report.artifactory-client-api-plugin" time="48.649" readyin="203.735" attempt="1"/>
  <testcase split="split-13:weekly" name="build-monitor-plugin" classname="pct-report.build-monitor-plugin" time="163.653" readyin="203.735" attempt="1"/>
  <testcase split="split-13:weekly" name="commons-math3-api-plugin" classname="pct-report.commons-math3-api-plugin" time="34.425" readyin="203.735" attempt="1"/>
  <testcase split="split-13:weekly" name="database-postgresql-plugin" classname="pct-report.database-postgresql-plugin" time="59.144" readyin="201.316" attempt="2"/>
  <testcase split="split-13:weekly" name="emoji-symbols-api-plugin" classname="pct-report.emoji-symbols-api-plugin" time="48.099" readyin="201.316" attempt="2"/>
  <testcase split="split-13:weekly" name="git-parameter-plugin" classname="pct-report.git-parameter-plugin" time="170.457" readyin="201.316" attempt="2"/>
  <testcase split="split-13:weekly" name="google-oauth-plugin" classname="pct-report.google-oauth-plugin" time="97.677" readyin="201.316" attempt="2"/>
  <testcase split="split-13:weekly" name="javax-activation-api-plugin" classname="pct-report.javax-activation-api-plugin" time="43.399" readyin="201.316" attempt="2"/>
  <testcase split="split-13:weekly" name="junit-attachments-plugin" classname="pct-report.junit-attachments-plugin" time="94.087" readyin="201.316" attempt="2"/>
  <testcase split="split-13:weekly" name="metrics-plugin" classname="pct-report.metrics-plugin" time="124.108" readyin="201.316" attempt="2"/>
  <testcase split="split-13:weekly" name="opentelemetry-plugin" classname="pct-report.opentelemetry-plugin" time="576.851" readyin="201.316" attempt="2"/>
  <testcase split="split-13:weekly" name="pipeline-stage-view-plugin" classname="pct-report.pipeline-stage-view-plugin" time="215.985" readyin="201.316" attempt="2"/>
  <testcase split="split-13:weekly" name="scm-api-plugin" classname="pct-report.scm-api-plugin" time="88.624" readyin="201.316" attempt="2"/>
  <testcase split="split-13:weekly" name="text-finder-plugin" classname="pct-report.text-finder-plugin" time="144.821" readyin="201.316" attempt="2"/>
  <testcase split="split-13:weekly" name="workflow-scm-step-plugin" classname="pct-report.workflow-scm-step-plugin" time="106.092" readyin="201.316" attempt="2"/>
  <testcase split="split-14:weekly" name="asm-api-plugin" classname="pct-report.asm-api-plugin" time="41.908" readyin="203.72" attempt="1"/>
  <testcase split="split-14:weekly" name="build-name-setter-plugin" classname="pct-report.build-name-setter-plugin" time="44.397" readyin="203.72" attempt="1"/>
  <testcase split="split-14:weekly" name="commons-text-api-plugin" classname="pct-report.commons-text-api-plugin" time="34.595" readyin="203.72" attempt="1"/>
  <testcase split="split-14:weekly" name="database-sqlite-plugin" classname="pct-report.database-sqlite-plugin" time="37.838" readyin="203.72" attempt="1"/>
  <testcase split="split-14:weekly" name="envinject-api-plugin" classname="pct-report.envinject-api-plugin" time="35.813" readyin="203.72" attempt="1"/>
  <testcase split="split-14:weekly" name="git-plugin" classname="pct-report.git-plugin" time="1146.684" readyin="201.332" attempt="2"/>
  <testcase split="split-14:weekly" name="google-storage-plugin" classname="pct-report.google-storage-plugin" time="230.944" readyin="201.332" attempt="2"/>
  <testcase split="split-14:weekly" name="javax-mail-api-plugin" classname="pct-report.javax-mail-api-plugin" time="55.78" readyin="201.332" attempt="2"/>
  <testcase split="split-14:weekly" name="junit-plugin" classname="pct-report.junit-plugin" time="287.268" readyin="201.332" attempt="2"/>
  <testcase split="split-14:weekly" name="micrometer-core-api-plugin" classname="pct-report.micrometer-core-api-plugin" time="41.836" readyin="201.332" attempt="2"/>
  <testcase split="split-14:weekly" name="oras-java-api-plugin" classname="pct-report.oras-java-api-plugin" time="45.003" readyin="201.332" attempt="2"/>
  <testcase split="split-14:weekly" name="pipeline-utility-steps-plugin" classname="pct-report.pipeline-utility-steps-plugin" time="420.008" readyin="201.332" attempt="2"/>
  <testcase split="split-14:weekly" name="scmskip-plugin" classname="pct-report.scmskip-plugin" time="86.399" readyin="201.332" attempt="2"/>
  <testcase split="split-14:weekly" name="theme-manager-plugin" classname="pct-report.theme-manager-plugin" time="41.587" readyin="201.332" attempt="2"/>
  <testcase split="split-14:weekly" name="workflow-step-api-plugin" classname="pct-report.workflow-step-api-plugin" time="53.235" readyin="201.332" attempt="2"/>
  <testcase split="split-15:weekly" name="authentication-tokens-plugin" classname="pct-report.authentication-tokens-plugin" time="45.481" readyin="203.766" attempt="1"/>
  <testcase split="split-15:weekly" name="build-timeout-plugin" classname="pct-report.build-timeout-plugin" time="200.841" readyin="203.766" attempt="1"/>
  <testcase split="split-15:weekly" name="conditional-buildstep-plugin" classname="pct-report.conditional-buildstep-plugin" time="64.088" readyin="201.335" attempt="2"/>
  <testcase split="split-15:weekly" name="database-sqlserver-plugin" classname="pct-report.database-sqlserver-plugin" time="49.4" readyin="201.335" attempt="2"/>
  <testcase split="split-15:weekly" name="envinject-plugin" classname="pct-report.envinject-plugin" time="144.615" readyin="201.335" attempt="2"/>
  <testcase split="split-15:weekly" name="git-server-plugin" classname="pct-report.git-server-plugin" time="58.089" readyin="201.335" attempt="2"/>
  <testcase split="split-15:weekly" name="groovy-postbuild-plugin" classname="pct-report.groovy-postbuild-plugin" time="128.121" readyin="201.335" attempt="2"/>
  <testcase split="split-15:weekly" name="jaxb-plugin" classname="pct-report.jaxb-plugin" time="54.824" readyin="201.335" attempt="2"/>
  <testcase split="split-15:weekly" name="junit-realtime-test-reporter-plugin" classname="pct-report.junit-realtime-test-reporter-plugin" time="149.781" readyin="201.335" attempt="2"/>
  <testcase split="split-15:weekly" name="mina-sshd-api-plugin" classname="pct-report.mina-sshd-api-plugin" time="189.722" readyin="201.335" attempt="2"/>
  <testcase split="split-15:weekly" name="oss-symbols-api-plugin" classname="pct-report.oss-symbols-api-plugin" time="47.23" readyin="201.335" attempt="2"/>
  <testcase split="split-15:weekly" name="plain-credentials-plugin" classname="pct-report.plain-credentials-plugin" time="64.206" readyin="201.335" attempt="2"/>
  <testcase split="split-15:weekly" name="script-security-plugin" classname="pct-report.script-security-plugin" time="215.832" readyin="201.335" attempt="2"/>
  <testcase split="split-15:weekly" name="thin-backup-plugin" classname="pct-report.thin-backup-plugin" time="99.512" readyin="201.335" attempt="2"/>
  <testcase split="split-15:weekly" name="workflow-support-plugin" classname="pct-report.workflow-support-plugin" time="165.968" readyin="201.335" attempt="2"/>
  <testcase split="split-16:weekly" name="authorize-project-plugin" classname="pct-report.authorize-project-plugin" time="203.544" readyin="203.751" attempt="1"/>
  <testcase split="split-16:weekly" name="build-timestamp-plugin" classname="pct-report.build-timestamp-plugin" time="36.303" readyin="203.751" attempt="1"/>
  <testcase split="split-16:weekly" name="config-file-provider-plugin" classname="pct-report.config-file-provider-plugin" time="271.83" readyin="201.346" attempt="2"/>
  <testcase split="split-16:weekly" name="declarative-pipeline-migration-assistant-plugin" classname="pct-report.declarative-pipeline-migration-assistant-plugin" time="247.516" readyin="201.346" attempt="2"/>
  <testcase split="split-16:weekly" name="extended-timer-trigger-plugin" classname="pct-report.extended-timer-trigger-plugin" time="56.637" readyin="201.346" attempt="2"/>
  <testcase split="split-16:weekly" name="gitea-checks-plugin" classname="pct-report.gitea-checks-plugin" time="91.772" readyin="201.346" attempt="2"/>
  <testcase split="split-16:weekly" name="gson-api-plugin" classname="pct-report.gson-api-plugin" time="62.42" readyin="201.346" attempt="2"/>
  <testcase split="split-16:weekly" name="jdk-tool-plugin" classname="pct-report.jdk-tool-plugin" time="70.826" readyin="201.346" attempt="2"/>
  <testcase split="split-16:weekly" name="kubernetes-client-api-plugin" classname="pct-report.kubernetes-client-api-plugin" time="55.587" readyin="201.346" attempt="2"/>
  <testcase split="split-16:weekly" name="mock-slave-plugin" classname="pct-report.mock-slave-plugin" time="257.93" readyin="201.346" attempt="2"/>
  <testcase split="split-16:weekly" name="pam-auth-plugin" classname="pct-report.pam-auth-plugin" time="64.046" readyin="201.346" attempt="2"/>
  <testcase split="split-16:weekly" name="plugin-util-api-plugin" classname="pct-report.plugin-util-api-plugin" time="72.842" readyin="201.346" attempt="2"/>
  <testcase split="split-16:weekly" name="secure-requester-whitelist-plugin" classname="pct-report.secure-requester-whitelist-plugin" time="69.735" readyin="201.346" attempt="2"/>
  <testcase split="split-16:weekly" name="throttle-concurrent-builds-plugin" classname="pct-report.throttle-concurrent-builds-plugin" time="243.936" readyin="201.346" attempt="2"/>
  <testcase split="split-16:weekly" name="ws-cleanup-plugin" classname="pct-report.ws-cleanup-plugin" time="141.493" readyin="201.346" attempt="2"/>
  <testcase split="split-17:weekly" name="aws-credentials-plugin" classname="pct-report.aws-credentials-plugin" time="57.761" readyin="203.735" attempt="1"/>
  <testcase split="split-17:weekly" name="build-token-root-plugin" classname="pct-report.build-token-root-plugin" time="53.649" readyin="203.735" attempt="1"/>
  <testcase split="split-17:weekly" name="configuration-as-code-plugin" classname="pct-report.configuration-as-code-plugin" time="105.477" readyin="203.735" attempt="1"/>
  <testcase split="split-17:weekly" name="description-setter-plugin" classname="pct-report.description-setter-plugin" time="49.485" readyin="203.735" attempt="1"/>
  <testcase split="split-17:weekly" name="extensible-choice-parameter-plugin" classname="pct-report.extensible-choice-parameter-plugin" time="321.443" readyin="42.133" attempt="2"/>
  <testcase split="split-17:weekly" name="gitea-plugin" classname="pct-report.gitea-plugin" time="150.189" readyin="42.133" attempt="2"/>
  <testcase split="split-17:weekly" name="h2-api-plugin" classname="pct-report.h2-api-plugin" time="65.841" readyin="42.133" attempt="2"/>
  <testcase split="split-17:weekly" name="jersey2-api-plugin" classname="pct-report.jersey2-api-plugin" time="95.545" readyin="42.133" attempt="2"/>
  <testcase split="split-17:weekly" name="kubernetes-credentials-plugin" classname="pct-report.kubernetes-credentials-plugin" time="120.884" readyin="42.133" attempt="2"/>
  <testcase split="split-17:weekly" name="msbuild-plugin" classname="pct-report.msbuild-plugin" time="71.227" readyin="42.133" attempt="2"/>
  <testcase split="split-17:weekly" name="parallel-test-executor-plugin" classname="pct-report.parallel-test-executor-plugin" time="122.17" readyin="42.133" attempt="2"/>
  <testcase split="split-17:weekly" name="postbuild-task-plugin" classname="pct-report.postbuild-task-plugin" time="60.007" readyin="42.133" attempt="2"/>
  <testcase split="split-17:weekly" name="simple-theme-plugin" classname="pct-report.simple-theme-plugin" time="108.002" readyin="42.133" attempt="2"/>
  <testcase split="split-17:weekly" name="timestamper-plugin" classname="pct-report.timestamper-plugin" time="160.13" readyin="42.133" attempt="2"/>
  <testcase split="split-17:weekly" name="xtrigger-api-plugin" classname="pct-report.xtrigger-api-plugin" time="131.748" readyin="42.133" attempt="2"/>
  <testcase split="split-18:weekly" name="aws-global-configuration-plugin" classname="pct-report.aws-global-configuration-plugin" time="70.885" readyin="203.739" attempt="1"/>
  <testcase split="split-18:weekly" name="build-user-vars-plugin" classname="pct-report.build-user-vars-plugin" time="88.066" readyin="203.739" attempt="1"/>
  <testcase split="split-18:weekly" name="copyartifact-plugin" classname="pct-report.copyartifact-plugin" time="579.059" readyin="201.336" attempt="2"/>
  <testcase split="split-18:weekly" name="design-library-plugin" classname="pct-report.design-library-plugin" time="95.7" readyin="201.336" attempt="2"/>
  <testcase split="split-18:weekly" name="external-monitor-job-plugin" classname="pct-report.external-monitor-job-plugin" time="59.302" readyin="201.336" attempt="2"/>
  <testcase split="split-18:weekly" name="github-api-plugin" classname="pct-report.github-api-plugin" time="48.632" readyin="201.336" attempt="2"/>
  <testcase split="split-18:weekly" name="handy-uri-templates-2-api-plugin" classname="pct-report.handy-uri-templates-2-api-plugin" time="52.618" readyin="201.336" attempt="2"/>
  <testcase split="split-18:weekly" name="jersey3-api-plugin" classname="pct-report.jersey3-api-plugin" time="55.479" readyin="201.336" attempt="2"/>
  <testcase split="split-18:weekly" name="kubernetes-credentials-provider-plugin" classname="pct-report.kubernetes-credentials-provider-plugin" time="86.841" readyin="201.336" attempt="2"/>
  <testcase split="split-18:weekly" name="multibranch-build-strategy-extension-plugin" classname="pct-report.multibranch-build-strategy-extension-plugin" time="108.931" readyin="201.336" attempt="2"/>
  <testcase split="split-18:weekly" name="parameter-separator-plugin" classname="pct-report.parameter-separator-plugin" time="92.971" readyin="201.336" attempt="2"/>
  <testcase split="split-18:weekly" name="postgresql-api-plugin" classname="pct-report.postgresql-api-plugin" time="49.657" readyin="201.336" attempt="2"/>
  <testcase split="split-18:weekly" name="skip-notifications-trait-plugin" classname="pct-report.skip-notifications-trait-plugin" time="61.458" readyin="201.336" attempt="2"/>
  <testcase split="split-18:weekly" name="token-macro-plugin" classname="pct-report.token-macro-plugin" time="163.327" readyin="201.336" attempt="2"/>
  <testcase split="split-19:weekly" name="aws-java-sdk-plugin" classname="pct-report.aws-java-sdk-plugin" time="989.231" readyin="224.088" attempt="2"/>
  <testcase split="split-19:weekly" name="built-on-column-plugin" classname="pct-report.built-on-column-plugin" time="52.637" readyin="224.088" attempt="2"/>
  <testcase split="split-19:weekly" name="coverage-badges-extension-plugin" classname="pct-report.coverage-badges-extension-plugin" time="76.394" readyin="224.088" attempt="2"/>
  <testcase split="split-19:weekly" name="display-url-api-plugin" classname="pct-report.display-url-api-plugin" time="83.773" readyin="224.088" attempt="2"/>
  <testcase split="split-19:weekly" name="extra-columns-plugin" classname="pct-report.extra-columns-plugin" time="61.589" readyin="224.088" attempt="2"/>
  <testcase split="split-19:weekly" name="github-branch-source-plugin" classname="pct-report.github-branch-source-plugin" time="327.622" readyin="224.088" attempt="2"/>
  <testcase split="split-19:weekly" name="hidden-parameter-plugin" classname="pct-report.hidden-parameter-plugin" time="62.941" readyin="224.088" attempt="2"/>
  <testcase split="split-19:weekly" name="jjwt-api-plugin" classname="pct-report.jjwt-api-plugin" time="37.089" readyin="224.088" attempt="2"/>
  <testcase split="split-19:weekly" name="kubernetes-plugin" classname="pct-report.kubernetes-plugin" time="473.295" readyin="224.088" attempt="2"/>
  <testcase split="split-19:weekly" name="mysql-api-plugin" classname="pct-report.mysql-api-plugin" time="34.005" readyin="224.088" attempt="2"/>
  <testcase split="split-19:weekly" name="parameterized-scheduler-plugin" classname="pct-report.parameterized-scheduler-plugin" time="52.587" readyin="224.088" attempt="2"/>
  <testcase split="split-19:weekly" name="powershell-plugin" classname="pct-report.powershell-plugin" time="44.313" readyin="224.088" attempt="2"/>
  <testcase split="split-19:weekly" name="slack-plugin" classname="pct-report.slack-plugin" time="108.291" readyin="224.088" attempt="2"/>
  <testcase split="split-19:weekly" name="trilead-api-plugin" classname="pct-report.trilead-api-plugin" time="35.189" readyin="224.088" attempt="2"/>
  <testcase split="split-1:weekly" name="JiraTestResultReporter-plugin" classname="pct-report.JiraTestResultReporter-plugin" time="40.708" readyin="17.957" attempt="1"/>
  <testcase split="split-1:weekly" name="azure-credentials-plugin" classname="pct-report.azure-credentials-plugin" time="46.848" readyin="17.957" attempt="1"/>
  <testcase split="split-1:weekly" name="caffeine-api-plugin" classname="pct-report.caffeine-api-plugin" time="65.816" readyin="17.957" attempt="1"/>
  <testcase split="split-1:weekly" name="credentials-binding-plugin" classname="pct-report.credentials-binding-plugin" time="153.252" readyin="17.957" attempt="1"/>
  <testcase split="split-1:weekly" name="docker-java-api-plugin" classname="pct-report.docker-java-api-plugin" time="32.356" readyin="17.957" attempt="1"/>
  <testcase split="split-1:weekly" name="favorite-plugin" classname="pct-report.favorite-plugin" time="52.647" readyin="17.957" attempt="1"/>
  <testcase split="split-1:weekly" name="github-oauth-plugin" classname="pct-report.github-oauth-plugin" time="85.165" readyin="17.957" attempt="1"/>
  <testcase split="split-1:weekly" name="http-request-plugin" classname="pct-report.http-request-plugin" time="188.637" readyin="17.957" attempt="1"/>
  <testcase split="split-1:weekly" name="job-config-history-plugin" classname="pct-report.job-config-history-plugin" time="224.242" readyin="17.957" attempt="1"/>
  <testcase split="split-1:weekly" name="locale-plugin" classname="pct-report.locale-plugin" time="46.956" readyin="17.957" attempt="1"/>
  <testcase split="split-1:weekly" name="netty-api-plugin" classname="pct-report.netty-api-plugin" time="28.248" readyin="17.957" attempt="1"/>
  <testcase split="split-1:weekly" name="pipeline-aggregator-view-plugin" classname="pct-report.pipeline-aggregator-view-plugin" time="28.531" readyin="17.957" attempt="1"/>
  <testcase split="split-1:weekly" name="prometheus-plugin" classname="pct-report.prometheus-plugin" time="84.741" readyin="17.957" attempt="1"/>
  <testcase split="split-1:weekly" name="snakeyaml-engine-api-plugin" classname="pct-report.snakeyaml-engine-api-plugin" time="34.355" readyin="17.957" attempt="1"/>
  <testcase split="split-1:weekly" name="urltrigger-plugin" classname="pct-report.urltrigger-plugin" time="44.212" readyin="17.957" attempt="1"/>
  <testcase split="split-20:weekly" name="aws-java-sdk2-plugin" classname="pct-report.aws-java-sdk2-plugin" time="1076.438" readyin="201.347" attempt="2"/>
  <testcase split="split-20:weekly" name="byte-buddy-api-plugin" classname="pct-report.byte-buddy-api-plugin" time="40.761" readyin="201.347" attempt="2"/>
  <testcase split="split-20:weekly" name="coverage-plugin" classname="pct-report.coverage-plugin" time="87.941" readyin="201.347" attempt="2"/>
  <testcase split="split-20:weekly" name="docker-commons-plugin" classname="pct-report.docker-commons-plugin" time="154.255" readyin="201.347" attempt="2"/>
  <testcase split="split-20:weekly" name="extra-tool-installers-plugin" classname="pct-report.extra-tool-installers-plugin" time="64.797" readyin="201.347" attempt="2"/>
  <testcase split="split-20:weekly" name="github-checks-plugin" classname="pct-report.github-checks-plugin" time="102.024" readyin="201.347" attempt="2"/>
  <testcase split="split-20:weekly" name="htmlpublisher-plugin" classname="pct-report.htmlpublisher-plugin" time="94.27" readyin="201.347" attempt="2"/>
  <testcase split="split-20:weekly" name="jnr-posix-api-plugin" classname="pct-report.jnr-posix-api-plugin" time="38.433" readyin="201.347" attempt="2"/>
  <testcase split="split-20:weekly" name="ldap-plugin" classname="pct-report.ldap-plugin" time="265.829" readyin="201.347" attempt="2"/>
  <testcase split="split-20:weekly" name="naginator-plugin" classname="pct-report.naginator-plugin" time="109.852" readyin="201.347" attempt="2"/>
  <testcase split="split-20:weekly" name="parameterized-trigger-plugin" classname="pct-report.parameterized-trigger-plugin" time="294.1" readyin="201.347" attempt="2"/>
  <testcase split="split-20:weekly" name="prism-api-plugin" classname="pct-report.prism-api-plugin" time="53.527" readyin="201.347" attempt="2"/>
  <testcase split="split-20:weekly" name="snakeyaml-api-plugin" classname="pct-report.snakeyaml-api-plugin" time="30.935" readyin="201.347" attempt="2"/>
  <testcase split="split-20:weekly" name="unique-id-plugin" classname="pct-report.unique-id-plugin" time="35.946" readyin="201.347" attempt="2"/>
  <testcase split="split-2:weekly" name="active-directory-plugin" classname="pct-report.active-directory-plugin" time="131.342" readyin="186.33" attempt="1"/>
  <testcase split="split-2:weekly" name="azure-keyvault-plugin" classname="pct-report.azure-keyvault-plugin" time="93.284" readyin="186.33" attempt="1"/>
  <testcase split="split-2:weekly" name="calendar-view-plugin" classname="pct-report.calendar-view-plugin" time="264.901" readyin="36.666" attempt="2"/>
  <testcase split="split-2:weekly" name="credentials-plugin" classname="pct-report.credentials-plugin" time="404.255" readyin="36.666" attempt="2"/>
  <testcase split="split-2:weekly" name="docker-plugin" classname="pct-report.docker-plugin" time="194.331" readyin="36.666" attempt="2"/>
  <testcase split="split-2:weekly" name="file-leak-detector-plugin" classname="pct-report.file-leak-detector-plugin" time="74.701" readyin="36.666" attempt="2"/>
  <testcase split="split-2:weekly" name="github-plugin" classname="pct-report.github-plugin" time="403.62" readyin="36.666" attempt="2"/>
  <testcase split="split-2:weekly" name="ignore-committer-strategy-plugin" classname="pct-report.ignore-committer-strategy-plugin" time="98.135" readyin="36.666" attempt="2"/>
  <testcase split="split-2:weekly" name="job-dsl-plugin" classname="pct-report.job-dsl-plugin" time="580.128" readyin="36.666" attempt="2"/>
  <testcase split="split-2:weekly" name="lockable-resources-plugin" classname="pct-report.lockable-resources-plugin" time="1463.229" readyin="36.666" attempt="2"/>
  <testcase split="split-2:weekly" name="next-executions-plugin" classname="pct-report.next-executions-plugin" time="69.596" readyin="36.666" attempt="2"/>
  <testcase split="split-2:weekly" name="pipeline-build-step-plugin" classname="pct-report.pipeline-build-step-plugin" time="217.841" readyin="36.666" attempt="2"/>
  <testcase split="split-2:weekly" name="promoted-builds-plugin" classname="pct-report.promoted-builds-plugin" time="261.67" readyin="36.666" attempt="2"/>
  <testcase split="split-2:weekly" name="sonarqube-plugin" classname="pct-report.sonarqube-plugin" time="443.431" readyin="36.666" attempt="2"/>
  <testcase split="split-2:weekly" name="variant-plugin" classname="pct-report.variant-plugin" time="45.005" readyin="36.666" attempt="2"/>
  <testcase split="split-3:weekly" name="adoptopenjdk-plugin" classname="pct-report.adoptopenjdk-plugin" time="63.942" readyin="186.34" attempt="1"/>
  <testcase split="split-3:weekly" name="azure-sdk-plugin" classname="pct-report.azure-sdk-plugin" time="43.676" readyin="186.34" attempt="1"/>
  <testcase split="split-3:weekly" name="checks-api-plugin" classname="pct-report.checks-api-plugin" time="85.642" readyin="186.34" attempt="1"/>
  <testcase split="split-3:weekly" name="cron_column-plugin" classname="pct-report.cron_column-plugin" time="37.197" readyin="186.34" attempt="1"/>
  <testcase split="split-3:weekly" name="docker-workflow-plugin" classname="pct-report.docker-workflow-plugin" time="260.356" readyin="34.994" attempt="2"/>
  <testcase split="split-3:weekly" name="file-parameters-plugin" classname="pct-report.file-parameters-plugin" time="134.936" readyin="34.994" attempt="2"/>
  <testcase split="split-3:weekly" name="github-scm-trait-notification-context-plugin" classname="pct-report.github-scm-trait-notification-context-plugin" time="82.834" readyin="34.994" attempt="2"/>
  <testcase split="split-3:weekly" name="instance-identity-plugin" classname="pct-report.instance-identity-plugin" time="68.023" readyin="34.994" attempt="2"/>
  <testcase split="split-3:weekly" name="job-import-plugin" classname="pct-report.job-import-plugin" time="86.094" readyin="34.994" attempt="2"/>
  <testcase split="split-3:weekly" name="mailer-plugin" classname="pct-report.mailer-plugin" time="284.78" readyin="34.994" attempt="2"/>
  <testcase split="split-3:weekly" name="nimbus-jose-jwt-api-plugin" classname="pct-report.nimbus-jose-jwt-api-plugin" time="59.358" readyin="34.994" attempt="2"/>
  <testcase split="split-3:weekly" name="pipeline-github-lib-plugin" classname="pct-report.pipeline-github-lib-plugin" time="68.01" readyin="34.994" attempt="2"/>
  <testcase split="split-3:weekly" name="rebuild-plugin" classname="pct-report.rebuild-plugin" time="465.916" readyin="34.994" attempt="2"/>
  <testcase split="split-3:weekly" name="sqlserver-api-plugin" classname="pct-report.sqlserver-api-plugin" time="78.887" readyin="34.994" attempt="2"/>
  <testcase split="split-3:weekly" name="versioncolumn-plugin" classname="pct-report.versioncolumn-plugin" time="85.208" readyin="34.994" attempt="2"/>
  <testcase split="split-4:weekly" name="analysis-model-api-plugin" classname="pct-report.analysis-model-api-plugin" time="39.553" readyin="203.835" attempt="1"/>
  <testcase split="split-4:weekly" name="azure-storage-plugin" classname="pct-report.azure-storage-plugin" time="66.25" readyin="203.835" attempt="1"/>
  <testcase split="split-4:weekly" name="claim-plugin" classname="pct-report.claim-plugin" time="256.186" readyin="197.948" attempt="2"/>
  <testcase split="split-4:weekly" name="custom-folder-icon-plugin" classname="pct-report.custom-folder-icon-plugin" time="224.088" readyin="197.948" attempt="2"/>
  <testcase split="split-4:weekly" name="dockerhub-notification-plugin" classname="pct-report.dockerhub-notification-plugin" time="185.081" readyin="197.948" attempt="2"/>
  <testcase split="split-4:weekly" name="flaky-test-handler-plugin" classname="pct-report.flaky-test-handler-plugin" time="63.99" readyin="197.948" attempt="2"/>
  <testcase split="split-4:weekly" name="gitlab-api-plugin" classname="pct-report.gitlab-api-plugin" time="56.633" readyin="197.948" attempt="2"/>
  <testcase split="split-4:weekly" name="instant-messaging-plugin" classname="pct-report.instant-messaging-plugin" time="74.714" readyin="197.948" attempt="2"/>
  <testcase split="split-4:weekly" name="job-restrictions-plugin" classname="pct-report.job-restrictions-plugin" time="46.439" readyin="197.948" attempt="2"/>
  <testcase split="split-4:weekly" name="mapdb-api-plugin" classname="pct-report.mapdb-api-plugin" time="43.753" readyin="197.948" attempt="2"/>
  <testcase split="split-4:weekly" name="node-iterator-api-plugin" classname="pct-report.node-iterator-api-plugin" time="48.627" readyin="197.948" attempt="2"/>
  <testcase split="split-4:weekly" name="pipeline-github-plugin" classname="pct-report.pipeline-github-plugin" time="65.295" readyin="197.948" attempt="2"/>
  <testcase split="split-4:weekly" name="resource-disposer-plugin" classname="pct-report.resource-disposer-plugin" time="82.731" readyin="197.948" attempt="2"/>
  <testcase split="split-4:weekly" name="ssh-agent-plugin" classname="pct-report.ssh-agent-plugin" time="115.671" readyin="197.948" attempt="2"/>
  <testcase split="split-4:weekly" name="view-job-filters-plugin" classname="pct-report.view-job-filters-plugin" time="299.936" readyin="197.948" attempt="2"/>
  <testcase split="split-5:weekly" name="ansible-plugin" classname="pct-report.ansible-plugin" time="74.042" readyin="203.82" attempt="1"/>
  <testcase split="split-5:weekly" name="azure-vm-agents-plugin" classname="pct-report.azure-vm-agents-plugin" time="67.141" readyin="203.82" attempt="1"/>
  <testcase split="split-5:weekly" name="cloud-stats-plugin" classname="pct-report.cloud-stats-plugin" time="82.784" readyin="203.82" attempt="1"/>
  <testcase split="split-5:weekly" name="customizable-header-plugin" classname="pct-report.customizable-header-plugin" time="95.444" readyin="201.313" attempt="2"/>
  <testcase split="split-5:weekly" name="durable-task-plugin" classname="pct-report.durable-task-plugin" time="197.696" readyin="201.313" attempt="2"/>
  <testcase split="split-5:weekly" name="flatpickr-api-plugin" classname="pct-report.flatpickr-api-plugin" time="42.601" readyin="201.313" attempt="2"/>
  <testcase split="split-5:weekly" name="gitlab-branch-source-plugin" classname="pct-report.gitlab-branch-source-plugin" time="110.158" readyin="201.313" attempt="2"/>
  <testcase split="split-5:weekly" name="ionicons-api-plugin" classname="pct-report.ionicons-api-plugin" time="49.915" readyin="201.313" attempt="2"/>
  <testcase split="split-5:weekly" name="jobcacher-plugin" classname="pct-report.jobcacher-plugin" time="129.917" readyin="201.313" attempt="2"/>
  <testcase split="split-5:weekly" name="mariadb-api-plugin" classname="pct-report.mariadb-api-plugin" time="60.589" readyin="201.313" attempt="2"/>
  <testcase split="split-5:weekly" name="nodejs-plugin" classname="pct-report.nodejs-plugin" time="132.726" readyin="201.313" attempt="2"/>
  <testcase split="split-5:weekly" name="pipeline-graph-analysis-plugin" classname="pct-report.pipeline-graph-analysis-plugin" time="192.844" readyin="201.313" attempt="2"/>
  <testcase split="split-5:weekly" name="reverse-proxy-auth-plugin" classname="pct-report.reverse-proxy-auth-plugin" time="50.94" readyin="201.313" attempt="2"/>
  <testcase split="split-5:weekly" name="ssh-agents-plugin" classname="pct-report.ssh-agents-plugin" time="166.574" readyin="201.313" attempt="2"/>
  <testcase split="split-5:weekly" name="warnings-ng-plugin" classname="pct-report.warnings-ng-plugin" time="979.483" readyin="201.313" attempt="2"/>
  <testcase split="split-6:weekly" name="ansicolor-plugin" classname="pct-report.ansicolor-plugin" time="91.241" readyin="185.363" attempt="1"/>
  <testcase split="split-6:weekly" name="badge-plugin" classname="pct-report.badge-plugin" time="114.628" readyin="185.363" attempt="1"/>
  <testcase split="split-6:weekly" name="cloudbees-disk-usage-simple-plugin" classname="pct-report.cloudbees-disk-usage-simple-plugin" time="38.778" readyin="185.363" attempt="1"/>
  <testcase split="split-6:weekly" name="dark-theme-plugin" classname="pct-report.dark-theme-plugin" time="48.059" readyin="185.363" attempt="1"/>
  <testcase split="split-6:weekly" name="ec2-plugin" classname="pct-report.ec2-plugin" time="365.538" readyin="201.343" attempt="2"/>
  <testcase split="split-6:weekly" name="flyway-api-plugin" classname="pct-report.flyway-api-plugin" time="43.624" readyin="201.343" attempt="2"/>
  <testcase split="split-6:weekly" name="gitlab-kubernetes-credentials-plugin" classname="pct-report.gitlab-kubernetes-credentials-plugin" time="64.986" readyin="201.343" attempt="2"/>
  <testcase split="split-6:weekly" name="jackson-annotations2-api-plugin" classname="pct-report.jackson-annotations2-api-plugin" time="51.552" readyin="201.343" attempt="2"/>
  <testcase split="split-6:weekly" name="joda-time-api-plugin" classname="pct-report.joda-time-api-plugin" time="48.858" readyin="201.343" attempt="2"/>
  <testcase split="split-6:weekly" name="markdown-formatter-plugin" classname="pct-report.markdown-formatter-plugin" time="67.089" readyin="201.343" attempt="2"/>
  <testcase split="split-6:weekly" name="nodelabelparameter-plugin" classname="pct-report.nodelabelparameter-plugin" time="146.006" readyin="201.343" attempt="2"/>
  <testcase split="split-6:weekly" name="pipeline-graph-view-plugin" classname="pct-report.pipeline-graph-view-plugin" time="497.926" readyin="201.343" attempt="2"/>
  <testcase split="split-6:weekly" name="role-strategy-plugin" classname="pct-report.role-strategy-plugin" time="449.98" readyin="201.343" attempt="2"/>
  <testcase split="split-6:weekly" name="ssh-credentials-plugin" classname="pct-report.ssh-credentials-plugin" time="74.337" readyin="201.343" attempt="2"/>
  <testcase split="split-6:weekly" name="woodstox-core-api-plugin" classname="pct-report.woodstox-core-api-plugin" time="36.539" readyin="201.343" attempt="2"/>
  <testcase split="split-7:weekly" name="ant-plugin" classname="pct-report.ant-plugin" time="130.087" readyin="203.697" attempt="1"/>
  <testcase split="split-7:weekly" name="basic-branch-build-strategies-plugin" classname="pct-report.basic-branch-build-strategies-plugin" time="82.62" readyin="203.697" attempt="1"/>
  <testcase split="split-7:weekly" name="cloudbees-folder-plugin" classname="pct-report.cloudbees-folder-plugin" time="204.432" readyin="201.319" attempt="2"/>
  <testcase split="split-7:weekly" name="dashboard-view-plugin" classname="pct-report.dashboard-view-plugin" time="134.174" readyin="201.319" attempt="2"/>
  <testcase split="split-7:weekly" name="echarts-api-plugin" classname="pct-report.echarts-api-plugin" time="72.773" readyin="201.319" attempt="2"/>
  <testcase split="split-7:weekly" name="font-awesome-api-plugin" classname="pct-report.font-awesome-api-plugin" time="67.675" readyin="201.319" attempt="2"/>
  <testcase split="split-7:weekly" name="gitlab-logo-plugin" classname="pct-report.gitlab-logo-plugin" time="57.974" readyin="201.319" attempt="2"/>
  <testcase split="split-7:weekly" name="jackson2-api-plugin" classname="pct-report.jackson2-api-plugin" time="60.273" readyin="201.319" attempt="2"/>
  <testcase split="split-7:weekly" name="jquery3-api-plugin" classname="pct-report.jquery3-api-plugin" time="75.69" readyin="201.319" attempt="2"/>
  <testcase split="split-7:weekly" name="mask-passwords-plugin" classname="pct-report.mask-passwords-plugin" time="115.639" readyin="201.319" attempt="2"/>
  <testcase split="split-7:weekly" name="oauth-credentials-plugin" classname="pct-report.oauth-credentials-plugin" time="53.896" readyin="201.319" attempt="2"/>
  <testcase split="split-7:weekly" name="pipeline-groovy-lib-plugin" classname="pct-report.pipeline-groovy-lib-plugin" time="314.597" readyin="201.319" attempt="2"/>
  <testcase split="split-7:weekly" name="run-condition-plugin" classname="pct-report.run-condition-plugin" time="169.497" readyin="201.319" attempt="2"/>
  <testcase split="split-7:weekly" name="ssh-steps-plugin" classname="pct-report.ssh-steps-plugin" time="66.51" readyin="201.319" attempt="2"/>
  <testcase split="split-7:weekly" name="workflow-api-plugin" classname="pct-report.workflow-api-plugin" time="185.863" readyin="201.319" attempt="2"/>
  <testcase split="split-8:weekly" name="antisamy-markup-formatter-plugin" classname="pct-report.antisamy-markup-formatter-plugin" time="63.964" readyin="186.32" attempt="1"/>
  <testcase split="split-8:weekly" name="bitbucket-branch-source-plugin" classname="pct-report.bitbucket-branch-source-plugin" time="309.162" readyin="320.648" attempt="2"/>
  <testcase split="split-8:weekly" name="cloudbees-jenkins-advisor-plugin" classname="pct-report.cloudbees-jenkins-advisor-plugin" time="88.411" readyin="320.648" attempt="2"/>
  <testcase split="split-8:weekly" name="data-tables-api-plugin" classname="pct-report.data-tables-api-plugin" time="52.114" readyin="320.648" attempt="2"/>
  <testcase split="split-8:weekly" name="eddsa-api-plugin" classname="pct-report.eddsa-api-plugin" time="64.33" readyin="320.648" attempt="2"/>
  <testcase split="split-8:weekly" name="forensics-api-plugin" classname="pct-report.forensics-api-plugin" time="111.084" readyin="320.648" attempt="2"/>
  <testcase split="split-8:weekly" name="gitlab-oauth-plugin" classname="pct-report.gitlab-oauth-plugin" time="43.251" readyin="320.648" attempt="2"/>
  <testcase split="split-8:weekly" name="jackson3-api-plugin" classname="pct-report.jackson3-api-plugin" time="47.194" readyin="320.648" attempt="2"/>
  <testcase split="split-8:weekly" name="jsch-plugin" classname="pct-report.jsch-plugin" time="66.779" readyin="320.648" attempt="2"/>
  <testcase split="split-8:weekly" name="matrix-auth-plugin" classname="pct-report.matrix-auth-plugin" time="213.58" readyin="320.648" attempt="2"/>
  <testcase split="split-8:weekly" name="office-365-connector-plugin" classname="pct-report.office-365-connector-plugin" time="76.537" readyin="320.648" attempt="2"/>
  <testcase split="split-8:weekly" name="pipeline-input-step-plugin" classname="pct-report.pipeline-input-step-plugin" time="169.825" readyin="320.648" attempt="2"/>
  <testcase split="split-8:weekly" name="s3-jobcacher-storage-plugin" classname="pct-report.s3-jobcacher-storage-plugin" time="61.621" readyin="320.648" attempt="2"/>
  <testcase split="split-8:weekly" name="sshd-plugin" classname="pct-report.sshd-plugin" time="167.814" readyin="320.648" attempt="2"/>
  <testcase split="split-8:weekly" name="workflow-basic-steps-plugin" classname="pct-report.workflow-basic-steps-plugin" time="283.946" readyin="320.648" attempt="2"/>
  <testcase split="split-9:weekly" name="apache-httpcomponents-client-4-api-plugin" classname="pct-report.apache-httpcomponents-client-4-api-plugin" time="54.794" readyin="203.703" attempt="1"/>
  <testcase split="split-9:weekly" name="bootstrap5-api-plugin" classname="pct-report.bootstrap5-api-plugin" time="64.646" readyin="203.703" attempt="1"/>
  <testcase split="split-9:weekly" name="command-launcher-plugin" classname="pct-report.command-launcher-plugin" time="75.282" readyin="203.703" attempt="1"/>
  <testcase split="split-9:weekly" name="database-h2-plugin" classname="pct-report.database-h2-plugin" time="35.988" readyin="203.703" attempt="1"/>
  <testcase split="split-9:weekly" name="electricflow-plugin" classname="pct-report.electricflow-plugin" time="129.062" readyin="201.31" attempt="2"/>
  <testcase split="split-9:weekly" name="gcp-java-sdk-plugin" classname="pct-report.gcp-java-sdk-plugin" time="97.835" readyin="201.31" attempt="2"/>
  <testcase split="split-9:weekly" name="gitlab-plugin" classname="pct-report.gitlab-plugin" time="384.713" readyin="201.31" attempt="2"/>
  <testcase split="split-9:weekly" name="jakarta-activation-api-plugin" classname="pct-report.jakarta-activation-api-plugin" time="48.661" readyin="201.31" attempt="2"/>
  <testcase split="split-9:weekly" name="json-api-plugin" classname="pct-report.json-api-plugin" time="60.833" readyin="201.31" attempt="2"/>
  <testcase split="split-9:weekly" name="matrix-project-plugin" classname="pct-report.matrix-project-plugin" time="173.93" readyin="201.31" attempt="2"/>
  <testcase split="split-9:weekly" name="oic-auth-plugin" classname="pct-report.oic-auth-plugin" time="390.416" readyin="201.31" attempt="2"/>
  <testcase split="split-9:weekly" name="pipeline-maven-plugin" classname="pct-report.pipeline-maven-plugin" time="326.778" readyin="201.31" attempt="2"/>
  <testcase split="split-9:weekly" name="s3-plugin" classname="pct-report.s3-plugin" time="95.762" readyin="201.31" attempt="2"/>
  <testcase split="split-9:weekly" name="structs-plugin" classname="pct-report.structs-plugin" time="62.583" readyin="201.31" attempt="2"/>
  <testcase split="split-9:weekly" name="workflow-cps-plugin" classname="pct-report.workflow-cps-plugin" time="558.771" readyin="201.31" attempt="2"/>
</testsuite>
```
</details>

<details><summary>bom-report_2.541.x.xml</summary>

```xml
  <testsuite name="bom-report_2.541.x" line="2.541.x" pctduration="5483.294" commit="1143047" build="https://ci.jenkins.io/job/Tools/job/bom/job/PR-7296/2/">
  <testcase split="split-10:2.541.x" name="apache-httpcomponents-client-5-api-plugin" classname="pct-report.apache-httpcomponents-client-5-api-plugin" time="62.371" readyin="300.377" attempt="1"/>
  <testcase split="split-10:2.541.x" name="bouncycastle-api-plugin" classname="pct-report.bouncycastle-api-plugin" time="61.112" readyin="300.377" attempt="1"/>
  <testcase split="split-10:2.541.x" name="commons-collections4-api-plugin" classname="pct-report.commons-collections4-api-plugin" time="55.191" readyin="300.377" attempt="1"/>
  <testcase split="split-10:2.541.x" name="database-mariadb-plugin" classname="pct-report.database-mariadb-plugin" time="57.174" readyin="300.377" attempt="1"/>
  <testcase split="split-10:2.541.x" name="email-ext-plugin" classname="pct-report.email-ext-plugin" time="542.041" readyin="300.377" attempt="1"/>
  <testcase split="split-10:2.541.x" name="generic-tool-plugin" classname="pct-report.generic-tool-plugin" time="62.838" readyin="300.377" attempt="1"/>
  <testcase split="split-10:2.541.x" name="google-compute-engine-plugin" classname="pct-report.google-compute-engine-plugin" time="208.48" readyin="300.377" attempt="1"/>
  <testcase split="split-10:2.541.x" name="jakarta-mail-api-plugin" classname="pct-report.jakarta-mail-api-plugin" time="70.495" readyin="300.377" attempt="1"/>
  <testcase split="split-10:2.541.x" name="json-path-api-plugin" classname="pct-report.json-path-api-plugin" time="62.12" readyin="300.377" attempt="1"/>
  <testcase split="split-10:2.541.x" name="maven-plugin" classname="pct-report.maven-plugin" time="1199.185" readyin="300.377" attempt="1"/>
  <testcase split="split-10:2.541.x" name="oidc-provider-plugin" classname="pct-report.oidc-provider-plugin" time="143.483" readyin="300.377" attempt="1"/>
  <testcase split="split-10:2.541.x" name="pipeline-milestone-step-plugin" classname="pct-report.pipeline-milestone-step-plugin" time="94.745" readyin="300.377" attempt="1"/>
  <testcase split="split-10:2.541.x" name="saferestart-plugin" classname="pct-report.saferestart-plugin" time="48.203" readyin="300.377" attempt="1"/>
  <testcase split="split-10:2.541.x" name="subversion-plugin" classname="pct-report.subversion-plugin" time="362.224" readyin="300.377" attempt="1"/>
  <testcase split="split-10:2.541.x" name="workflow-durable-task-step-plugin" classname="pct-report.workflow-durable-task-step-plugin" time="937.265" readyin="300.377" attempt="1"/>
  <testcase split="split-11:2.541.x" name="artifact-manager-s3-plugin" classname="pct-report.artifact-manager-s3-plugin" time="182.896" readyin="203.635" attempt="1"/>
  <testcase split="split-11:2.541.x" name="branch-api-plugin" classname="pct-report.branch-api-plugin" time="403.095" readyin="201.36" attempt="2"/>
  <testcase split="split-11:2.541.x" name="commons-compress-api-plugin" classname="pct-report.commons-compress-api-plugin" time="45.265" readyin="201.36" attempt="2"/>
  <testcase split="split-11:2.541.x" name="database-mysql-plugin" classname="pct-report.database-mysql-plugin" time="55.135" readyin="201.36" attempt="2"/>
  <testcase split="split-11:2.541.x" name="emailext-template-plugin" classname="pct-report.emailext-template-plugin" time="79.871" readyin="201.36" attempt="2"/>
  <testcase split="split-11:2.541.x" name="git-client-plugin" classname="pct-report.git-client-plugin" time="423.827" readyin="201.36" attempt="2"/>
  <testcase split="split-11:2.541.x" name="google-kubernetes-engine-plugin" classname="pct-report.google-kubernetes-engine-plugin" time="79.913" readyin="201.36" attempt="2"/>
  <testcase split="split-11:2.541.x" name="jakarta-xml-bind-api-plugin" classname="pct-report.jakarta-xml-bind-api-plugin" time="64.144" readyin="201.36" attempt="2"/>
  <testcase split="split-11:2.541.x" name="jsoup-plugin" classname="pct-report.jsoup-plugin" time="82.433" readyin="201.36" attempt="2"/>
  <testcase split="split-11:2.541.x" name="mcp-server-plugin" classname="pct-report.mcp-server-plugin" time="581.672" readyin="201.36" attempt="2"/>
  <testcase split="split-11:2.541.x" name="okhttp-api-plugin" classname="pct-report.okhttp-api-plugin" time="44.313" readyin="201.36" attempt="2"/>
  <testcase split="split-11:2.541.x" name="pipeline-model-definition-plugin" classname="pct-report.pipeline-model-definition-plugin" time="758.607" readyin="201.36" attempt="2"/>
  <testcase split="split-11:2.541.x" name="saml-plugin" classname="pct-report.saml-plugin" time="101.747" readyin="201.36" attempt="2"/>
  <testcase split="split-11:2.541.x" name="support-core-plugin" classname="pct-report.support-core-plugin" time="435.12" readyin="201.36" attempt="2"/>
  <testcase split="split-11:2.541.x" name="workflow-job-plugin" classname="pct-report.workflow-job-plugin" time="172.266" readyin="201.36" attempt="2"/>
  <testcase split="split-12:2.541.x" name="artifactory-artifact-manager-plugin" classname="pct-report.artifactory-artifact-manager-plugin" time="264.079" readyin="203.725" attempt="1"/>
  <testcase split="split-12:2.541.x" name="build-failure-analyzer-plugin" classname="pct-report.build-failure-analyzer-plugin" time="491.63" readyin="201.376" attempt="2"/>
  <testcase split="split-12:2.541.x" name="commons-lang3-api-plugin" classname="pct-report.commons-lang3-api-plugin" time="53.52" readyin="201.376" attempt="2"/>
  <testcase split="split-12:2.541.x" name="database-plugin" classname="pct-report.database-plugin" time="50.329" readyin="201.376" attempt="2"/>
  <testcase split="split-12:2.541.x" name="embeddable-build-status-plugin" classname="pct-report.embeddable-build-status-plugin" time="83.831" readyin="201.376" attempt="2"/>
  <testcase split="split-12:2.541.x" name="git-forensics-plugin" classname="pct-report.git-forensics-plugin" time="88.692" readyin="201.376" attempt="2"/>
  <testcase split="split-12:2.541.x" name="google-metadata-plugin" classname="pct-report.google-metadata-plugin" time="56.789" readyin="201.376" attempt="2"/>
  <testcase split="split-12:2.541.x" name="javadoc-plugin" classname="pct-report.javadoc-plugin" time="132.27" readyin="201.376" attempt="2"/>
  <testcase split="split-12:2.541.x" name="jspecify-api-plugin" classname="pct-report.jspecify-api-plugin" time="56.104" readyin="201.376" attempt="2"/>
  <testcase split="split-12:2.541.x" name="mercurial-plugin" classname="pct-report.mercurial-plugin" time="178.541" readyin="201.376" attempt="2"/>
  <testcase split="split-12:2.541.x" name="opentelemetry-api-plugin" classname="pct-report.opentelemetry-api-plugin" time="91.386" readyin="201.376" attempt="2"/>
  <testcase split="split-12:2.541.x" name="pipeline-stage-step-plugin" classname="pct-report.pipeline-stage-step-plugin" time="59.677" readyin="201.376" attempt="2"/>
  <testcase split="split-12:2.541.x" name="sbt-plugin" classname="pct-report.sbt-plugin" time="82.574" readyin="201.376" attempt="2"/>
  <testcase split="split-12:2.541.x" name="swarm-plugin" classname="pct-report.swarm-plugin" time="227.141" readyin="201.376" attempt="2"/>
  <testcase split="split-12:2.541.x" name="workflow-multibranch-plugin" classname="pct-report.workflow-multibranch-plugin" time="310.91" readyin="201.376" attempt="2"/>
  <testcase split="split-13:2.541.x" name="artifactory-client-api-plugin" classname="pct-report.artifactory-client-api-plugin" time="48.721" readyin="203.661" attempt="1"/>
  <testcase split="split-13:2.541.x" name="build-monitor-plugin" classname="pct-report.build-monitor-plugin" time="161.838" readyin="203.661" attempt="1"/>
  <testcase split="split-13:2.541.x" name="commons-math3-api-plugin" classname="pct-report.commons-math3-api-plugin" time="34.47" readyin="203.661" attempt="1"/>
  <testcase split="split-13:2.541.x" name="database-postgresql-plugin" classname="pct-report.database-postgresql-plugin" time="37.044" readyin="320.668" attempt="2"/>
  <testcase split="split-13:2.541.x" name="emoji-symbols-api-plugin" classname="pct-report.emoji-symbols-api-plugin" time="35.538" readyin="320.668" attempt="2"/>
  <testcase split="split-13:2.541.x" name="git-parameter-plugin" classname="pct-report.git-parameter-plugin" time="127.161" readyin="320.668" attempt="2"/>
  <testcase split="split-13:2.541.x" name="google-oauth-plugin" classname="pct-report.google-oauth-plugin" time="60.664" readyin="320.668" attempt="2"/>
  <testcase split="split-13:2.541.x" name="javax-activation-api-plugin" classname="pct-report.javax-activation-api-plugin" time="32.014" readyin="320.668" attempt="2"/>
  <testcase split="split-13:2.541.x" name="junit-attachments-plugin" classname="pct-report.junit-attachments-plugin" time="64.578" readyin="320.668" attempt="2"/>
  <testcase split="split-13:2.541.x" name="metrics-plugin" classname="pct-report.metrics-plugin" time="79.989" readyin="320.668" attempt="2"/>
  <testcase split="split-13:2.541.x" name="opentelemetry-plugin" classname="pct-report.opentelemetry-plugin" time="424.254" readyin="320.668" attempt="2"/>
  <testcase split="split-13:2.541.x" name="pipeline-stage-view-plugin" classname="pct-report.pipeline-stage-view-plugin" time="177.659" readyin="320.668" attempt="2"/>
  <testcase split="split-13:2.541.x" name="scm-api-plugin" classname="pct-report.scm-api-plugin" time="80.926" readyin="320.668" attempt="2"/>
  <testcase split="split-13:2.541.x" name="text-finder-plugin" classname="pct-report.text-finder-plugin" time="115.221" readyin="320.668" attempt="2"/>
  <testcase split="split-13:2.541.x" name="workflow-scm-step-plugin" classname="pct-report.workflow-scm-step-plugin" time="112.028" readyin="320.668" attempt="2"/>
  <testcase split="split-14:2.541.x" name="asm-api-plugin" classname="pct-report.asm-api-plugin" time="56.427" readyin="300.36" attempt="1"/>
  <testcase split="split-14:2.541.x" name="build-name-setter-plugin" classname="pct-report.build-name-setter-plugin" time="62.507" readyin="300.36" attempt="1"/>
  <testcase split="split-14:2.541.x" name="commons-text-api-plugin" classname="pct-report.commons-text-api-plugin" time="52.005" readyin="300.36" attempt="1"/>
  <testcase split="split-14:2.541.x" name="database-sqlite-plugin" classname="pct-report.database-sqlite-plugin" time="53.828" readyin="300.36" attempt="1"/>
  <testcase split="split-14:2.541.x" name="envinject-api-plugin" classname="pct-report.envinject-api-plugin" time="64.024" readyin="300.36" attempt="1"/>
  <testcase split="split-14:2.541.x" name="git-plugin" classname="pct-report.git-plugin" time="1531.014" readyin="300.36" attempt="1"/>
  <testcase split="split-14:2.541.x" name="google-storage-plugin" classname="pct-report.google-storage-plugin" time="269.201" readyin="300.36" attempt="1"/>
  <testcase split="split-14:2.541.x" name="javax-mail-api-plugin" classname="pct-report.javax-mail-api-plugin" time="66.139" readyin="300.36" attempt="1"/>
  <testcase split="split-14:2.541.x" name="junit-plugin" classname="pct-report.junit-plugin" time="366.198" readyin="300.36" attempt="1"/>
  <testcase split="split-14:2.541.x" name="micrometer-core-api-plugin" classname="pct-report.micrometer-core-api-plugin" time="50.373" readyin="300.36" attempt="1"/>
  <testcase split="split-14:2.541.x" name="oras-java-api-plugin" classname="pct-report.oras-java-api-plugin" time="56.028" readyin="300.36" attempt="1"/>
  <testcase split="split-14:2.541.x" name="pipeline-utility-steps-plugin" classname="pct-report.pipeline-utility-steps-plugin" time="579.661" readyin="300.36" attempt="1"/>
  <testcase split="split-14:2.541.x" name="scmskip-plugin" classname="pct-report.scmskip-plugin" time="119.451" readyin="300.36" attempt="1"/>
  <testcase split="split-14:2.541.x" name="theme-manager-plugin" classname="pct-report.theme-manager-plugin" time="58.007" readyin="300.36" attempt="1"/>
  <testcase split="split-14:2.541.x" name="workflow-step-api-plugin" classname="pct-report.workflow-step-api-plugin" time="70.025" readyin="300.36" attempt="1"/>
  <testcase split="split-15:2.541.x" name="authentication-tokens-plugin" classname="pct-report.authentication-tokens-plugin" time="63.893" readyin="300.376" attempt="1"/>
  <testcase split="split-15:2.541.x" name="build-timeout-plugin" classname="pct-report.build-timeout-plugin" time="246.239" readyin="300.376" attempt="1"/>
  <testcase split="split-15:2.541.x" name="conditional-buildstep-plugin" classname="pct-report.conditional-buildstep-plugin" time="80.678" readyin="300.376" attempt="1"/>
  <testcase split="split-15:2.541.x" name="database-sqlserver-plugin" classname="pct-report.database-sqlserver-plugin" time="92.646" readyin="300.376" attempt="1"/>
  <testcase split="split-15:2.541.x" name="envinject-plugin" classname="pct-report.envinject-plugin" time="210.497" readyin="300.376" attempt="1"/>
  <testcase split="split-15:2.541.x" name="git-server-plugin" classname="pct-report.git-server-plugin" time="81.081" readyin="300.376" attempt="1"/>
  <testcase split="split-15:2.541.x" name="groovy-postbuild-plugin" classname="pct-report.groovy-postbuild-plugin" time="167.331" readyin="300.376" attempt="1"/>
  <testcase split="split-15:2.541.x" name="jaxb-plugin" classname="pct-report.jaxb-plugin" time="61.823" readyin="300.376" attempt="1"/>
  <testcase split="split-15:2.541.x" name="junit-realtime-test-reporter-plugin" classname="pct-report.junit-realtime-test-reporter-plugin" time="210.959" readyin="300.376" attempt="1"/>
  <testcase split="split-15:2.541.x" name="mina-sshd-api-plugin" classname="pct-report.mina-sshd-api-plugin" time="254.476" readyin="300.376" attempt="1"/>
  <testcase split="split-15:2.541.x" name="oss-symbols-api-plugin" classname="pct-report.oss-symbols-api-plugin" time="62.605" readyin="300.376" attempt="1"/>
  <testcase split="split-15:2.541.x" name="plain-credentials-plugin" classname="pct-report.plain-credentials-plugin" time="97.994" readyin="300.376" attempt="1"/>
  <testcase split="split-15:2.541.x" name="script-security-plugin" classname="pct-report.script-security-plugin" time="288.168" readyin="300.376" attempt="1"/>
  <testcase split="split-15:2.541.x" name="thin-backup-plugin" classname="pct-report.thin-backup-plugin" time="109.105" readyin="300.376" attempt="1"/>
  <testcase split="split-15:2.541.x" name="workflow-support-plugin" classname="pct-report.workflow-support-plugin" time="178.64" readyin="300.376" attempt="1"/>
  <testcase split="split-16:2.541.x" name="authorize-project-plugin" classname="pct-report.authorize-project-plugin" time="321.523" readyin="300.347" attempt="1"/>
  <testcase split="split-16:2.541.x" name="build-timestamp-plugin" classname="pct-report.build-timestamp-plugin" time="59.079" readyin="300.347" attempt="1"/>
  <testcase split="split-16:2.541.x" name="config-file-provider-plugin" classname="pct-report.config-file-provider-plugin" time="358.497" readyin="300.347" attempt="1"/>
  <testcase split="split-16:2.541.x" name="declarative-pipeline-migration-assistant-plugin" classname="pct-report.declarative-pipeline-migration-assistant-plugin" time="352.605" readyin="300.347" attempt="1"/>
  <testcase split="split-16:2.541.x" name="extended-timer-trigger-plugin" classname="pct-report.extended-timer-trigger-plugin" time="71.465" readyin="300.347" attempt="1"/>
  <testcase split="split-16:2.541.x" name="gitea-checks-plugin" classname="pct-report.gitea-checks-plugin" time="114.277" readyin="300.347" attempt="1"/>
  <testcase split="split-16:2.541.x" name="gson-api-plugin" classname="pct-report.gson-api-plugin" time="67.382" readyin="300.347" attempt="1"/>
  <testcase split="split-16:2.541.x" name="jdk-tool-plugin" classname="pct-report.jdk-tool-plugin" time="93.02" readyin="300.347" attempt="1"/>
  <testcase split="split-16:2.541.x" name="kubernetes-client-api-plugin" classname="pct-report.kubernetes-client-api-plugin" time="80.32" readyin="300.347" attempt="1"/>
  <testcase split="split-16:2.541.x" name="mock-slave-plugin" classname="pct-report.mock-slave-plugin" time="288.86" readyin="300.347" attempt="1"/>
  <testcase split="split-16:2.541.x" name="pam-auth-plugin" classname="pct-report.pam-auth-plugin" time="80.511" readyin="300.347" attempt="1"/>
  <testcase split="split-16:2.541.x" name="plugin-util-api-plugin" classname="pct-report.plugin-util-api-plugin" time="98.87" readyin="300.347" attempt="1"/>
  <testcase split="split-16:2.541.x" name="secure-requester-whitelist-plugin" classname="pct-report.secure-requester-whitelist-plugin" time="81.301" readyin="300.347" attempt="1"/>
  <testcase split="split-16:2.541.x" name="throttle-concurrent-builds-plugin" classname="pct-report.throttle-concurrent-builds-plugin" time="268.464" readyin="300.347" attempt="1"/>
  <testcase split="split-16:2.541.x" name="ws-cleanup-plugin" classname="pct-report.ws-cleanup-plugin" time="159.962" readyin="300.347" attempt="1"/>
  <testcase split="split-17:2.541.x" name="aws-credentials-plugin" classname="pct-report.aws-credentials-plugin" time="79.49" readyin="300.364" attempt="1"/>
  <testcase split="split-17:2.541.x" name="build-token-root-plugin" classname="pct-report.build-token-root-plugin" time="71.973" readyin="300.364" attempt="1"/>
  <testcase split="split-17:2.541.x" name="configuration-as-code-plugin" classname="pct-report.configuration-as-code-plugin" time="156.33" readyin="300.364" attempt="1"/>
  <testcase split="split-17:2.541.x" name="description-setter-plugin" classname="pct-report.description-setter-plugin" time="81.987" readyin="300.364" attempt="1"/>
  <testcase split="split-17:2.541.x" name="extensible-choice-parameter-plugin" classname="pct-report.extensible-choice-parameter-plugin" time="321.879" readyin="300.364" attempt="1"/>
  <testcase split="split-17:2.541.x" name="gitea-plugin" classname="pct-report.gitea-plugin" time="161.877" readyin="300.364" attempt="1"/>
  <testcase split="split-17:2.541.x" name="h2-api-plugin" classname="pct-report.h2-api-plugin" time="55.199" readyin="300.364" attempt="1"/>
  <testcase split="split-17:2.541.x" name="jersey2-api-plugin" classname="pct-report.jersey2-api-plugin" time="87.583" readyin="300.364" attempt="1"/>
  <testcase split="split-17:2.541.x" name="kubernetes-credentials-plugin" classname="pct-report.kubernetes-credentials-plugin" time="121.614" readyin="300.364" attempt="1"/>
  <testcase split="split-17:2.541.x" name="msbuild-plugin" classname="pct-report.msbuild-plugin" time="71.269" readyin="300.364" attempt="1"/>
  <testcase split="split-17:2.541.x" name="parallel-test-executor-plugin" classname="pct-report.parallel-test-executor-plugin" time="93.459" readyin="300.364" attempt="1"/>
  <testcase split="split-17:2.541.x" name="postbuild-task-plugin" classname="pct-report.postbuild-task-plugin" time="61.08" readyin="300.364" attempt="1"/>
  <testcase split="split-17:2.541.x" name="simple-theme-plugin" classname="pct-report.simple-theme-plugin" time="115.7" readyin="300.364" attempt="1"/>
  <testcase split="split-17:2.541.x" name="timestamper-plugin" classname="pct-report.timestamper-plugin" time="171.934" readyin="300.364" attempt="1"/>
  <testcase split="split-17:2.541.x" name="xtrigger-api-plugin" classname="pct-report.xtrigger-api-plugin" time="151.351" readyin="300.364" attempt="1"/>
  <testcase split="split-18:2.541.x" name="aws-global-configuration-plugin" classname="pct-report.aws-global-configuration-plugin" time="85.023" readyin="300.374" attempt="1"/>
  <testcase split="split-18:2.541.x" name="build-user-vars-plugin" classname="pct-report.build-user-vars-plugin" time="123.857" readyin="300.374" attempt="1"/>
  <testcase split="split-18:2.541.x" name="copyartifact-plugin" classname="pct-report.copyartifact-plugin" time="715.053" readyin="300.374" attempt="1"/>
  <testcase split="split-18:2.541.x" name="design-library-plugin" classname="pct-report.design-library-plugin" time="123.097" readyin="300.374" attempt="1"/>
  <testcase split="split-18:2.541.x" name="external-monitor-job-plugin" classname="pct-report.external-monitor-job-plugin" time="82.415" readyin="300.374" attempt="1"/>
  <testcase split="split-18:2.541.x" name="github-api-plugin" classname="pct-report.github-api-plugin" time="71.254" readyin="300.374" attempt="1"/>
  <testcase split="split-18:2.541.x" name="handy-uri-templates-2-api-plugin" classname="pct-report.handy-uri-templates-2-api-plugin" time="74.758" readyin="300.374" attempt="1"/>
  <testcase split="split-18:2.541.x" name="jersey3-api-plugin" classname="pct-report.jersey3-api-plugin" time="76.149" readyin="300.374" attempt="1"/>
  <testcase split="split-18:2.541.x" name="kubernetes-credentials-provider-plugin" classname="pct-report.kubernetes-credentials-provider-plugin" time="115.666" readyin="300.374" attempt="1"/>
  <testcase split="split-18:2.541.x" name="multibranch-build-strategy-extension-plugin" classname="pct-report.multibranch-build-strategy-extension-plugin" time="133.82" readyin="300.374" attempt="1"/>
  <testcase split="split-18:2.541.x" name="parameter-separator-plugin" classname="pct-report.parameter-separator-plugin" time="99.99" readyin="300.374" attempt="1"/>
  <testcase split="split-18:2.541.x" name="postgresql-api-plugin" classname="pct-report.postgresql-api-plugin" time="76.566" readyin="300.374" attempt="1"/>
  <testcase split="split-18:2.541.x" name="skip-notifications-trait-plugin" classname="pct-report.skip-notifications-trait-plugin" time="88.493" readyin="300.374" attempt="1"/>
  <testcase split="split-18:2.541.x" name="token-macro-plugin" classname="pct-report.token-macro-plugin" time="211.499" readyin="300.374" attempt="1"/>
  <testcase split="split-19:2.541.x" name="aws-java-sdk-plugin" classname="pct-report.aws-java-sdk-plugin" time="1399.039" readyin="330.787" attempt="1"/>
  <testcase split="split-19:2.541.x" name="built-on-column-plugin" classname="pct-report.built-on-column-plugin" time="65.022" readyin="330.787" attempt="1"/>
  <testcase split="split-19:2.541.x" name="coverage-badges-extension-plugin" classname="pct-report.coverage-badges-extension-plugin" time="111.265" readyin="330.787" attempt="1"/>
  <testcase split="split-19:2.541.x" name="display-url-api-plugin" classname="pct-report.display-url-api-plugin" time="108.997" readyin="330.787" attempt="1"/>
  <testcase split="split-19:2.541.x" name="extra-columns-plugin" classname="pct-report.extra-columns-plugin" time="66.038" readyin="330.787" attempt="1"/>
  <testcase split="split-19:2.541.x" name="github-branch-source-plugin" classname="pct-report.github-branch-source-plugin" time="373.669" readyin="330.787" attempt="1"/>
  <testcase split="split-19:2.541.x" name="hidden-parameter-plugin" classname="pct-report.hidden-parameter-plugin" time="75.444" readyin="330.787" attempt="1"/>
  <testcase split="split-19:2.541.x" name="jjwt-api-plugin" classname="pct-report.jjwt-api-plugin" time="50.636" readyin="330.787" attempt="1"/>
  <testcase split="split-19:2.541.x" name="kubernetes-plugin" classname="pct-report.kubernetes-plugin" time="582.139" readyin="330.787" attempt="1"/>
  <testcase split="split-19:2.541.x" name="mysql-api-plugin" classname="pct-report.mysql-api-plugin" time="48.502" readyin="330.787" attempt="1"/>
  <testcase split="split-19:2.541.x" name="parameterized-scheduler-plugin" classname="pct-report.parameterized-scheduler-plugin" time="69.394" readyin="330.787" attempt="1"/>
  <testcase split="split-19:2.541.x" name="powershell-plugin" classname="pct-report.powershell-plugin" time="62.193" readyin="330.787" attempt="1"/>
  <testcase split="split-19:2.541.x" name="slack-plugin" classname="pct-report.slack-plugin" time="149.138" readyin="330.787" attempt="1"/>
  <testcase split="split-19:2.541.x" name="trilead-api-plugin" classname="pct-report.trilead-api-plugin" time="48.439" readyin="330.787" attempt="1"/>
  <testcase split="split-1:2.541.x" name="JiraTestResultReporter-plugin" classname="pct-report.JiraTestResultReporter-plugin" time="54.389" readyin="203.769" attempt="1"/>
  <testcase split="split-1:2.541.x" name="azure-credentials-plugin" classname="pct-report.azure-credentials-plugin" time="60.106" readyin="203.769" attempt="1"/>
  <testcase split="split-1:2.541.x" name="caffeine-api-plugin" classname="pct-report.caffeine-api-plugin" time="34.59" readyin="203.769" attempt="1"/>
  <testcase split="split-1:2.541.x" name="credentials-binding-plugin" classname="pct-report.credentials-binding-plugin" time="233.911" readyin="201.357" attempt="2"/>
  <testcase split="split-1:2.541.x" name="docker-java-api-plugin" classname="pct-report.docker-java-api-plugin" time="45.633" readyin="201.357" attempt="2"/>
  <testcase split="split-1:2.541.x" name="favorite-plugin" classname="pct-report.favorite-plugin" time="80.404" readyin="201.357" attempt="2"/>
  <testcase split="split-1:2.541.x" name="github-oauth-plugin" classname="pct-report.github-oauth-plugin" time="111.273" readyin="201.357" attempt="2"/>
  <testcase split="split-1:2.541.x" name="http-request-plugin" classname="pct-report.http-request-plugin" time="219.618" readyin="201.357" attempt="2"/>
  <testcase split="split-1:2.541.x" name="job-config-history-plugin" classname="pct-report.job-config-history-plugin" time="293.656" readyin="201.357" attempt="2"/>
  <testcase split="split-1:2.541.x" name="locale-plugin" classname="pct-report.locale-plugin" time="86.716" readyin="201.357" attempt="2"/>
  <testcase split="split-1:2.541.x" name="netty-api-plugin" classname="pct-report.netty-api-plugin" time="64.171" readyin="201.357" attempt="2"/>
  <testcase split="split-1:2.541.x" name="pipeline-aggregator-view-plugin" classname="pct-report.pipeline-aggregator-view-plugin" time="82.456" readyin="201.357" attempt="2"/>
  <testcase split="split-1:2.541.x" name="prometheus-plugin" classname="pct-report.prometheus-plugin" time="133.169" readyin="201.357" attempt="2"/>
  <testcase split="split-1:2.541.x" name="snakeyaml-engine-api-plugin" classname="pct-report.snakeyaml-engine-api-plugin" time="53.144" readyin="201.357" attempt="2"/>
  <testcase split="split-1:2.541.x" name="urltrigger-plugin" classname="pct-report.urltrigger-plugin" time="59.215" readyin="201.357" attempt="2"/>
  <testcase split="split-20:2.541.x" name="aws-java-sdk2-plugin" classname="pct-report.aws-java-sdk2-plugin" time="1086.581" readyin="201.367" attempt="2"/>
  <testcase split="split-20:2.541.x" name="byte-buddy-api-plugin" classname="pct-report.byte-buddy-api-plugin" time="49.483" readyin="201.367" attempt="2"/>
  <testcase split="split-20:2.541.x" name="coverage-plugin" classname="pct-report.coverage-plugin" time="93" readyin="201.367" attempt="2"/>
  <testcase split="split-20:2.541.x" name="docker-commons-plugin" classname="pct-report.docker-commons-plugin" time="136.713" readyin="201.367" attempt="2"/>
  <testcase split="split-20:2.541.x" name="extra-tool-installers-plugin" classname="pct-report.extra-tool-installers-plugin" time="84.114" readyin="201.367" attempt="2"/>
  <testcase split="split-20:2.541.x" name="github-checks-plugin" classname="pct-report.github-checks-plugin" time="98.371" readyin="201.367" attempt="2"/>
  <testcase split="split-20:2.541.x" name="htmlpublisher-plugin" classname="pct-report.htmlpublisher-plugin" time="96.875" readyin="201.367" attempt="2"/>
  <testcase split="split-20:2.541.x" name="jnr-posix-api-plugin" classname="pct-report.jnr-posix-api-plugin" time="37.386" readyin="201.367" attempt="2"/>
  <testcase split="split-20:2.541.x" name="ldap-plugin" classname="pct-report.ldap-plugin" time="264.351" readyin="201.367" attempt="2"/>
  <testcase split="split-20:2.541.x" name="naginator-plugin" classname="pct-report.naginator-plugin" time="114.875" readyin="201.367" attempt="2"/>
  <testcase split="split-20:2.541.x" name="parameterized-trigger-plugin" classname="pct-report.parameterized-trigger-plugin" time="294.144" readyin="201.367" attempt="2"/>
  <testcase split="split-20:2.541.x" name="prism-api-plugin" classname="pct-report.prism-api-plugin" time="51.208" readyin="201.367" attempt="2"/>
  <testcase split="split-20:2.541.x" name="snakeyaml-api-plugin" classname="pct-report.snakeyaml-api-plugin" time="32.124" readyin="201.367" attempt="2"/>
  <testcase split="split-20:2.541.x" name="unique-id-plugin" classname="pct-report.unique-id-plugin" time="34.921" readyin="201.367" attempt="2"/>
  <testcase split="split-2:2.541.x" name="active-directory-plugin" classname="pct-report.active-directory-plugin" time="174.173" readyin="203.778" attempt="1"/>
  <testcase split="split-2:2.541.x" name="azure-keyvault-plugin" classname="pct-report.azure-keyvault-plugin" time="90.761" readyin="203.778" attempt="1"/>
  <testcase split="split-2:2.541.x" name="calendar-view-plugin" classname="pct-report.calendar-view-plugin" time="176.041" readyin="201.367" attempt="2"/>
  <testcase split="split-2:2.541.x" name="credentials-plugin" classname="pct-report.credentials-plugin" time="277.352" readyin="201.367" attempt="2"/>
  <testcase split="split-2:2.541.x" name="docker-plugin" classname="pct-report.docker-plugin" time="146.875" readyin="201.367" attempt="2"/>
  <testcase split="split-2:2.541.x" name="file-leak-detector-plugin" classname="pct-report.file-leak-detector-plugin" time="53.212" readyin="201.367" attempt="2"/>
  <testcase split="split-2:2.541.x" name="github-plugin" classname="pct-report.github-plugin" time="302.335" readyin="201.367" attempt="2"/>
  <testcase split="split-2:2.541.x" name="ignore-committer-strategy-plugin" classname="pct-report.ignore-committer-strategy-plugin" time="59.306" readyin="201.367" attempt="2"/>
  <testcase split="split-2:2.541.x" name="job-dsl-plugin" classname="pct-report.job-dsl-plugin" time="470.231" readyin="201.367" attempt="2"/>
  <testcase split="split-2:2.541.x" name="lockable-resources-plugin" classname="pct-report.lockable-resources-plugin" time="1184.343" readyin="201.367" attempt="2"/>
  <testcase split="split-2:2.541.x" name="next-executions-plugin" classname="pct-report.next-executions-plugin" time="53.373" readyin="201.367" attempt="2"/>
  <testcase split="split-2:2.541.x" name="pipeline-build-step-plugin" classname="pct-report.pipeline-build-step-plugin" time="166.108" readyin="201.367" attempt="2"/>
  <testcase split="split-2:2.541.x" name="promoted-builds-plugin" classname="pct-report.promoted-builds-plugin" time="192.57" readyin="201.367" attempt="2"/>
  <testcase split="split-2:2.541.x" name="sonarqube-plugin" classname="pct-report.sonarqube-plugin" time="321.745" readyin="201.367" attempt="2"/>
  <testcase split="split-2:2.541.x" name="variant-plugin" classname="pct-report.variant-plugin" time="32.534" readyin="201.367" attempt="2"/>
  <testcase split="split-3:2.541.x" name="adoptopenjdk-plugin" classname="pct-report.adoptopenjdk-plugin" time="54.494" readyin="203.737" attempt="1"/>
  <testcase split="split-3:2.541.x" name="azure-sdk-plugin" classname="pct-report.azure-sdk-plugin" time="39.857" readyin="203.737" attempt="1"/>
  <testcase split="split-3:2.541.x" name="checks-api-plugin" classname="pct-report.checks-api-plugin" time="84.325" readyin="203.737" attempt="1"/>
  <testcase split="split-3:2.541.x" name="cron_column-plugin" classname="pct-report.cron_column-plugin" time="35.889" readyin="203.737" attempt="1"/>
  <testcase split="split-3:2.541.x" name="docker-workflow-plugin" classname="pct-report.docker-workflow-plugin" time="183.411" readyin="201.357" attempt="2"/>
  <testcase split="split-3:2.541.x" name="file-parameters-plugin" classname="pct-report.file-parameters-plugin" time="108.149" readyin="201.357" attempt="2"/>
  <testcase split="split-3:2.541.x" name="github-scm-trait-notification-context-plugin" classname="pct-report.github-scm-trait-notification-context-plugin" time="52.055" readyin="201.357" attempt="2"/>
  <testcase split="split-3:2.541.x" name="instance-identity-plugin" classname="pct-report.instance-identity-plugin" time="50.884" readyin="201.357" attempt="2"/>
  <testcase split="split-3:2.541.x" name="job-import-plugin" classname="pct-report.job-import-plugin" time="61.038" readyin="201.357" attempt="2"/>
  <testcase split="split-3:2.541.x" name="mailer-plugin" classname="pct-report.mailer-plugin" time="193.76" readyin="201.357" attempt="2"/>
  <testcase split="split-3:2.541.x" name="nimbus-jose-jwt-api-plugin" classname="pct-report.nimbus-jose-jwt-api-plugin" time="62.365" readyin="201.357" attempt="2"/>
  <testcase split="split-3:2.541.x" name="pipeline-github-lib-plugin" classname="pct-report.pipeline-github-lib-plugin" time="56.379" readyin="201.357" attempt="2"/>
  <testcase split="split-3:2.541.x" name="rebuild-plugin" classname="pct-report.rebuild-plugin" time="401.905" readyin="201.357" attempt="2"/>
  <testcase split="split-3:2.541.x" name="sqlserver-api-plugin" classname="pct-report.sqlserver-api-plugin" time="56.457" readyin="201.357" attempt="2"/>
  <testcase split="split-3:2.541.x" name="versioncolumn-plugin" classname="pct-report.versioncolumn-plugin" time="92.565" readyin="201.357" attempt="2"/>
  <testcase split="split-4:2.541.x" name="analysis-model-api-plugin" classname="pct-report.analysis-model-api-plugin" time="74.774" readyin="181.464" attempt="1"/>
  <testcase split="split-4:2.541.x" name="azure-storage-plugin" classname="pct-report.azure-storage-plugin" time="66.778" readyin="181.464" attempt="1"/>
  <testcase split="split-4:2.541.x" name="claim-plugin" classname="pct-report.claim-plugin" time="291.221" readyin="201.34" attempt="2"/>
  <testcase split="split-4:2.541.x" name="custom-folder-icon-plugin" classname="pct-report.custom-folder-icon-plugin" time="220.828" readyin="201.34" attempt="2"/>
  <testcase split="split-4:2.541.x" name="dockerhub-notification-plugin" classname="pct-report.dockerhub-notification-plugin" time="179.727" readyin="201.34" attempt="2"/>
  <testcase split="split-4:2.541.x" name="flaky-test-handler-plugin" classname="pct-report.flaky-test-handler-plugin" time="77.318" readyin="201.34" attempt="2"/>
  <testcase split="split-4:2.541.x" name="gitlab-api-plugin" classname="pct-report.gitlab-api-plugin" time="47.536" readyin="201.34" attempt="2"/>
  <testcase split="split-4:2.541.x" name="instant-messaging-plugin" classname="pct-report.instant-messaging-plugin" time="76.985" readyin="201.34" attempt="2"/>
  <testcase split="split-4:2.541.x" name="job-restrictions-plugin" classname="pct-report.job-restrictions-plugin" time="45.54" readyin="201.34" attempt="2"/>
  <testcase split="split-4:2.541.x" name="mapdb-api-plugin" classname="pct-report.mapdb-api-plugin" time="36.523" readyin="201.34" attempt="2"/>
  <testcase split="split-4:2.541.x" name="node-iterator-api-plugin" classname="pct-report.node-iterator-api-plugin" time="46.363" readyin="201.34" attempt="2"/>
  <testcase split="split-4:2.541.x" name="pipeline-github-plugin" classname="pct-report.pipeline-github-plugin" time="82.672" readyin="201.34" attempt="2"/>
  <testcase split="split-4:2.541.x" name="resource-disposer-plugin" classname="pct-report.resource-disposer-plugin" time="80.589" readyin="201.34" attempt="2"/>
  <testcase split="split-4:2.541.x" name="ssh-agent-plugin" classname="pct-report.ssh-agent-plugin" time="106.327" readyin="201.34" attempt="2"/>
  <testcase split="split-4:2.541.x" name="view-job-filters-plugin" classname="pct-report.view-job-filters-plugin" time="287.266" readyin="201.34" attempt="2"/>
  <testcase split="split-5:2.541.x" name="ansible-plugin" classname="pct-report.ansible-plugin" time="72.917" readyin="184.375" attempt="1"/>
  <testcase split="split-5:2.541.x" name="azure-vm-agents-plugin" classname="pct-report.azure-vm-agents-plugin" time="66.712" readyin="184.375" attempt="1"/>
  <testcase split="split-5:2.541.x" name="cloud-stats-plugin" classname="pct-report.cloud-stats-plugin" time="97.526" readyin="184.375" attempt="1"/>
  <testcase split="split-5:2.541.x" name="customizable-header-plugin" classname="pct-report.customizable-header-plugin" time="67.771" readyin="184.375" attempt="1"/>
  <testcase split="split-5:2.541.x" name="durable-task-plugin" classname="pct-report.durable-task-plugin" time="206.222" readyin="201.37" attempt="2"/>
  <testcase split="split-5:2.541.x" name="flatpickr-api-plugin" classname="pct-report.flatpickr-api-plugin" time="43.253" readyin="201.37" attempt="2"/>
  <testcase split="split-5:2.541.x" name="gitlab-branch-source-plugin" classname="pct-report.gitlab-branch-source-plugin" time="132.427" readyin="201.37" attempt="2"/>
  <testcase split="split-5:2.541.x" name="ionicons-api-plugin" classname="pct-report.ionicons-api-plugin" time="50.101" readyin="201.37" attempt="2"/>
  <testcase split="split-5:2.541.x" name="jobcacher-plugin" classname="pct-report.jobcacher-plugin" time="132.037" readyin="201.37" attempt="2"/>
  <testcase split="split-5:2.541.x" name="mariadb-api-plugin" classname="pct-report.mariadb-api-plugin" time="48.636" readyin="201.37" attempt="2"/>
  <testcase split="split-5:2.541.x" name="nodejs-plugin" classname="pct-report.nodejs-plugin" time="128.06" readyin="201.37" attempt="2"/>
  <testcase split="split-5:2.541.x" name="pipeline-graph-analysis-plugin" classname="pct-report.pipeline-graph-analysis-plugin" time="196.568" readyin="201.37" attempt="2"/>
  <testcase split="split-5:2.541.x" name="reverse-proxy-auth-plugin" classname="pct-report.reverse-proxy-auth-plugin" time="50.696" readyin="201.37" attempt="2"/>
  <testcase split="split-5:2.541.x" name="ssh-agents-plugin" classname="pct-report.ssh-agents-plugin" time="157.843" readyin="201.37" attempt="2"/>
  <testcase split="split-5:2.541.x" name="warnings-ng-plugin" classname="pct-report.warnings-ng-plugin" time="769.605" readyin="201.37" attempt="2"/>
  <testcase split="split-6:2.541.x" name="ansicolor-plugin" classname="pct-report.ansicolor-plugin" time="116.442" readyin="203.779" attempt="1"/>
  <testcase split="split-6:2.541.x" name="badge-plugin" classname="pct-report.badge-plugin" time="110.105" readyin="203.779" attempt="1"/>
  <testcase split="split-6:2.541.x" name="cloudbees-disk-usage-simple-plugin" classname="pct-report.cloudbees-disk-usage-simple-plugin" time="42.035" readyin="203.779" attempt="1"/>
  <testcase split="split-6:2.541.x" name="dark-theme-plugin" classname="pct-report.dark-theme-plugin" time="45.066" readyin="320.658" attempt="2"/>
  <testcase split="split-6:2.541.x" name="ec2-plugin" classname="pct-report.ec2-plugin" time="236.51" readyin="320.658" attempt="2"/>
  <testcase split="split-6:2.541.x" name="flyway-api-plugin" classname="pct-report.flyway-api-plugin" time="48.469" readyin="320.658" attempt="2"/>
  <testcase split="split-6:2.541.x" name="gitlab-kubernetes-credentials-plugin" classname="pct-report.gitlab-kubernetes-credentials-plugin" time="50.16" readyin="320.658" attempt="2"/>
  <testcase split="split-6:2.541.x" name="jackson-annotations2-api-plugin" classname="pct-report.jackson-annotations2-api-plugin" time="36.664" readyin="320.658" attempt="2"/>
  <testcase split="split-6:2.541.x" name="joda-time-api-plugin" classname="pct-report.joda-time-api-plugin" time="32.412" readyin="320.658" attempt="2"/>
  <testcase split="split-6:2.541.x" name="markdown-formatter-plugin" classname="pct-report.markdown-formatter-plugin" time="46.659" readyin="320.658" attempt="2"/>
  <testcase split="split-6:2.541.x" name="nodelabelparameter-plugin" classname="pct-report.nodelabelparameter-plugin" time="137.126" readyin="320.658" attempt="2"/>
  <testcase split="split-6:2.541.x" name="pipeline-graph-view-plugin" classname="pct-report.pipeline-graph-view-plugin" time="379.262" readyin="320.658" attempt="2"/>
  <testcase split="split-6:2.541.x" name="role-strategy-plugin" classname="pct-report.role-strategy-plugin" time="305.251" readyin="320.658" attempt="2"/>
  <testcase split="split-6:2.541.x" name="ssh-credentials-plugin" classname="pct-report.ssh-credentials-plugin" time="75.395" readyin="320.658" attempt="2"/>
  <testcase split="split-6:2.541.x" name="woodstox-core-api-plugin" classname="pct-report.woodstox-core-api-plugin" time="27.562" readyin="320.658" attempt="2"/>
  <testcase split="split-7:2.541.x" name="ant-plugin" classname="pct-report.ant-plugin" time="121.711" readyin="203.788" attempt="1"/>
  <testcase split="split-7:2.541.x" name="basic-branch-build-strategies-plugin" classname="pct-report.basic-branch-build-strategies-plugin" time="79.106" readyin="203.788" attempt="1"/>
  <testcase split="split-7:2.541.x" name="cloudbees-folder-plugin" classname="pct-report.cloudbees-folder-plugin" time="146.79" readyin="318.439" attempt="2"/>
  <testcase split="split-7:2.541.x" name="dashboard-view-plugin" classname="pct-report.dashboard-view-plugin" time="104.058" readyin="318.439" attempt="2"/>
  <testcase split="split-7:2.541.x" name="echarts-api-plugin" classname="pct-report.echarts-api-plugin" time="53.892" readyin="318.439" attempt="2"/>
  <testcase split="split-7:2.541.x" name="font-awesome-api-plugin" classname="pct-report.font-awesome-api-plugin" time="53.216" readyin="318.439" attempt="2"/>
  <testcase split="split-7:2.541.x" name="gitlab-logo-plugin" classname="pct-report.gitlab-logo-plugin" time="43.45" readyin="318.439" attempt="2"/>
  <testcase split="split-7:2.541.x" name="jackson2-api-plugin" classname="pct-report.jackson2-api-plugin" time="46.465" readyin="318.439" attempt="2"/>
  <testcase split="split-7:2.541.x" name="jquery3-api-plugin" classname="pct-report.jquery3-api-plugin" time="56.001" readyin="318.439" attempt="2"/>
  <testcase split="split-7:2.541.x" name="mask-passwords-plugin" classname="pct-report.mask-passwords-plugin" time="93.366" readyin="318.439" attempt="2"/>
  <testcase split="split-7:2.541.x" name="oauth-credentials-plugin" classname="pct-report.oauth-credentials-plugin" time="38.917" readyin="318.439" attempt="2"/>
  <testcase split="split-7:2.541.x" name="pipeline-groovy-lib-plugin" classname="pct-report.pipeline-groovy-lib-plugin" time="244.852" readyin="318.439" attempt="2"/>
  <testcase split="split-7:2.541.x" name="run-condition-plugin" classname="pct-report.run-condition-plugin" time="157.615" readyin="318.439" attempt="2"/>
  <testcase split="split-7:2.541.x" name="ssh-steps-plugin" classname="pct-report.ssh-steps-plugin" time="76.796" readyin="318.439" attempt="2"/>
  <testcase split="split-7:2.541.x" name="workflow-api-plugin" classname="pct-report.workflow-api-plugin" time="143.319" readyin="318.439" attempt="2"/>
  <testcase split="split-8:2.541.x" name="antisamy-markup-formatter-plugin" classname="pct-report.antisamy-markup-formatter-plugin" time="54.255" readyin="203.78" attempt="1"/>
  <testcase split="split-8:2.541.x" name="bitbucket-branch-source-plugin" classname="pct-report.bitbucket-branch-source-plugin" time="309.186" readyin="320.656" attempt="2"/>
  <testcase split="split-8:2.541.x" name="cloudbees-jenkins-advisor-plugin" classname="pct-report.cloudbees-jenkins-advisor-plugin" time="88.434" readyin="320.656" attempt="2"/>
  <testcase split="split-8:2.541.x" name="data-tables-api-plugin" classname="pct-report.data-tables-api-plugin" time="61.12" readyin="320.656" attempt="2"/>
  <testcase split="split-8:2.541.x" name="eddsa-api-plugin" classname="pct-report.eddsa-api-plugin" time="62.15" readyin="320.656" attempt="2"/>
  <testcase split="split-8:2.541.x" name="forensics-api-plugin" classname="pct-report.forensics-api-plugin" time="101.446" readyin="320.656" attempt="2"/>
  <testcase split="split-8:2.541.x" name="gitlab-oauth-plugin" classname="pct-report.gitlab-oauth-plugin" time="46.2" readyin="320.656" attempt="2"/>
  <testcase split="split-8:2.541.x" name="jackson3-api-plugin" classname="pct-report.jackson3-api-plugin" time="55.661" readyin="320.656" attempt="2"/>
  <testcase split="split-8:2.541.x" name="jsch-plugin" classname="pct-report.jsch-plugin" time="82.938" readyin="320.656" attempt="2"/>
  <testcase split="split-8:2.541.x" name="matrix-auth-plugin" classname="pct-report.matrix-auth-plugin" time="213.598" readyin="320.656" attempt="2"/>
  <testcase split="split-8:2.541.x" name="office-365-connector-plugin" classname="pct-report.office-365-connector-plugin" time="86.179" readyin="320.656" attempt="2"/>
  <testcase split="split-8:2.541.x" name="pipeline-input-step-plugin" classname="pct-report.pipeline-input-step-plugin" time="159.758" readyin="320.656" attempt="2"/>
  <testcase split="split-8:2.541.x" name="s3-jobcacher-storage-plugin" classname="pct-report.s3-jobcacher-storage-plugin" time="60.005" readyin="320.656" attempt="2"/>
  <testcase split="split-8:2.541.x" name="sshd-plugin" classname="pct-report.sshd-plugin" time="173.278" readyin="320.656" attempt="2"/>
  <testcase split="split-8:2.541.x" name="workflow-basic-steps-plugin" classname="pct-report.workflow-basic-steps-plugin" time="285.301" readyin="320.656" attempt="2"/>
  <testcase split="split-9:2.541.x" name="apache-httpcomponents-client-4-api-plugin" classname="pct-report.apache-httpcomponents-client-4-api-plugin" time="68.897" readyin="300.36" attempt="1"/>
  <testcase split="split-9:2.541.x" name="bootstrap5-api-plugin" classname="pct-report.bootstrap5-api-plugin" time="101.374" readyin="300.36" attempt="1"/>
  <testcase split="split-9:2.541.x" name="command-launcher-plugin" classname="pct-report.command-launcher-plugin" time="132.42" readyin="300.36" attempt="1"/>
  <testcase split="split-9:2.541.x" name="database-h2-plugin" classname="pct-report.database-h2-plugin" time="59.936" readyin="300.36" attempt="1"/>
  <testcase split="split-9:2.541.x" name="electricflow-plugin" classname="pct-report.electricflow-plugin" time="177.035" readyin="300.36" attempt="1"/>
  <testcase split="split-9:2.541.x" name="gcp-java-sdk-plugin" classname="pct-report.gcp-java-sdk-plugin" time="140.987" readyin="300.36" attempt="1"/>
  <testcase split="split-9:2.541.x" name="gitlab-plugin" classname="pct-report.gitlab-plugin" time="494.814" readyin="300.36" attempt="1"/>
  <testcase split="split-9:2.541.x" name="jakarta-activation-api-plugin" classname="pct-report.jakarta-activation-api-plugin" time="68.785" readyin="300.36" attempt="1"/>
  <testcase split="split-9:2.541.x" name="json-api-plugin" classname="pct-report.json-api-plugin" time="67.3" readyin="300.36" attempt="1"/>
  <testcase split="split-9:2.541.x" name="matrix-project-plugin" classname="pct-report.matrix-project-plugin" time="210.07" readyin="300.36" attempt="1"/>
  <testcase split="split-9:2.541.x" name="oic-auth-plugin" classname="pct-report.oic-auth-plugin" time="426.026" readyin="300.36" attempt="1"/>
  <testcase split="split-9:2.541.x" name="pipeline-maven-plugin" classname="pct-report.pipeline-maven-plugin" time="422.775" readyin="300.36" attempt="1"/>
  <testcase split="split-9:2.541.x" name="s3-plugin" classname="pct-report.s3-plugin" time="115.425" readyin="300.36" attempt="1"/>
  <testcase split="split-9:2.541.x" name="structs-plugin" classname="pct-report.structs-plugin" time="80.941" readyin="300.36" attempt="1"/>
  <testcase split="split-9:2.541.x" name="workflow-cps-plugin" classname="pct-report.workflow-cps-plugin" time="718.24" readyin="300.36" attempt="1"/>
</testsuite>
```

</details>

</details>

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
