### PR TITLE
chore(pipeline): cleaner bom reports

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -244,21 +244,27 @@ if (BRANCH_NAME == 'master' || fullTest || weeklyTest) {
         // While we want one line per split (agent)
         stage(testSuiteName) {
           def testCases = []
+          def testSuiteAttributes = [
+            name: testSuiteName, line: line, time: pctDuration, commit: commit, build: env.BUILD_URL
+          ].collect { key, value -> "${key}=\"${value}\"" }.join(' ')
           results.each { combination, result ->
             def repository = combination.split(':')[0]
             def resultLine = combination.split(':')[1]
             if (line == resultLine) {
-              testCases << '<testcase split="' + result['split'] + '" name="' + repository + '" classname="pct-report.' + repository + '" time="' + result['elapsed'] + '" readyin="' + result['readyIn'] + '" attempt="' + result['attempt'] + '"/>\n'
+              def testCaseAttributes = [
+                split: result['split'],
+                name: repository,
+                classname: "pct-report.${repository}",
+                time: result['elapsed'],
+                readyin: result['readyIn'],
+                attempt: result['attempt'],
+              ].collect { key, value -> "${key}=\"${value}\"" }.join(' ')
+              testCases << '  <testcase ' + testCaseAttributes + '/>'
             }
           }
-          def content = """<?xml version="1.0" encoding="UTF-8"?>
-            <testsuite name="${testSuiteName}" line="${line}" pctduration="${pctDuration}" commit="${commit}" build="${env.BUILD_URL}">
-            ${testCases.sort().join('\n')}
-            </testsuite>
-          """
+          def content = '<?xml version="1.0" encoding="UTF-8"?>\n<testsuite ' + testSuiteAttributes + '>\n' + testCases.sort().join('\n') + '\n</testsuite>\n'
           writeFile file: "${testSuiteName}.xml", text: content
           junit testResults: "${testSuiteName}.xml"
-          archiveArtifacts artifacts: "${testSuiteName}.xml"
         }
       }
     }


### PR DESCRIPTION
This change uses lists to define test suite and test cases attributes for easier code readability.

It also removes the `archiveArtifacts` of those bom reports, initially introduced in #7033 for #7273 but not needed in the end. (This removal is required to allow #7319 without additional complication)

Follow-up of:
- #7273

### Testing done

CI, bom report properly recorded by `junit`: https://ci.jenkins.io/job/Tools/job/bom/job/PR-7316/1/testReport/pct-report/
> <img width="2210" height="670" alt="image" src="https://github.com/user-attachments/assets/39343d83-3f18-4b94-9976-f995b6212b4f" />

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
