### PR TITLE
chore(pipeline): skip prep.sh in subsequent builds on the same revision

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -244,21 +244,27 @@ if (BRANCH_NAME == 'master' || fullTest || weeklyTest) {
         // While we want one line per split (agent)
         stage(testSuiteName) {
           def testCases = []
+          def testSuiteAttributes = [
+            name: testSuiteName, line: line, time: pctDuration, commit: commit, build: env.BUILD_URL
+          ].collect { key, value -> "${key}=\"${value}\"" }.join(' ')
           results.each { combination, result ->
             def repository = combination.split(':')[0]
             def resultLine = combination.split(':')[1]
             if (line == resultLine) {
-              testCases << '<testcase split="' + result['split'] + '" name="' + repository + '" classname="pct-report.' + repository + '" time="' + result['elapsed'] + '" readyin="' + result['readyIn'] + '" attempt="' + result['attempt'] + '"/>\n'
+              def testCaseAttributes = [
+                split: result['split'],
+                name: repository,
+                classname: "pct-report.${repository}",
+                time: result['elapsed'],
+                readyin: result['readyIn'],
+                attempt: result['attempt'],
+              ].collect { key, value -> "${key}=\"${value}\"" }.join(' ')
+              testCases << '  <testcase ' + testCaseAttributes + '/>'
             }
           }
-          def content = """<?xml version="1.0" encoding="UTF-8"?>
-            <testsuite name="${testSuiteName}" line="${line}" pctduration="${pctDuration}" commit="${commit}" build="${env.BUILD_URL}">
-            ${testCases.sort().join('\n')}
-            </testsuite>
-          """
+          def content = '<?xml version="1.0" encoding="UTF-8"?>\n<testsuite ' + testSuiteAttributes + '>\n' + testCases.sort().join('\n') + '\n</testsuite>\n'
           writeFile file: "${testSuiteName}.xml", text: content
           junit testResults: "${testSuiteName}.xml"
-          archiveArtifacts artifacts: "${testSuiteName}.xml"
         }
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -73,6 +73,8 @@ def results = [:]
 def commit
 def pctDuration
 def reportNamePrefix = 'bom-report_'
+def incrementalDoneInPreviousBuild = false
+def stashGlob = 'pct.sh,incrementals.sh,consume-incrementals,excludes.txt,bom-*/excludes.txt,target/pct.jar,target/megawar-REPLACEME_LINE.war'
 
 mavenEnv(jdk: 21) {
   stage('prep') {
@@ -82,18 +84,35 @@ mavenEnv(jdk: 21) {
     if (!consumeIncrementals) {
       echo 'Forbidding use of incremental dependencies. If you need to consume incrementals, add the `consume-incrementals` label, or add a file named `consume-incrementals` to the repository root if you lack triage permission. Then keep this PR in draft until the dependencies have been switched to release versions.'
     }
-    withChecks(name: 'Tests', includeStage: true) {
-      withEnv(['SAMPLE_PLUGIN_OPTS=-Dset.changelist', "CONSUME_INCREMENTALS=${consumeIncrementals}"]) {
-        sh '''
-        mvn -v
-        bash prep.sh
-        '''
-      }
-      if (junit(testResults: '**/target/surefire-reports/TEST-*.xml,**/target/failsafe-reports/TEST-*.xml').failCount> 0) {
-        error 'Some test failures during prep.sh, not going to continue'
+    def prepArchive = "prep-${commit}.tar.gz"
+    withEnv["PREP_ARCHIVE=${prepArchive}"] {
+      // Try to retrieve prep archive from a previous build on the same revision
+      try {
+        copyArtifacts(projectName: env.JOB_NAME, selector: lastWithArtifacts(), filter: prepArchive, fingerprintArtifacts: true)
+        publishChecks(name: 'Tests / prep')
+        sh 'tar -xzvf "${PREP_ARCHIVE}" && rm -v "${PREP_ARCHIVE}"'
+        incrementalDoneInPreviousBuild = true
+      } catch(e) {
+        // If no corresponding prep archive found (first build or new commit), run prep.sh and prepare incrementals
+        withChecks(name: 'Tests', includeStage: true) {
+          withEnv(['SAMPLE_PLUGIN_OPTS=-Dset.changelist', "CONSUME_INCREMENTALS=${consumeIncrementals}"]) {
+            sh '''
+            mvn -v
+            bash prep.sh
+            '''
+          }
+          if (junit(testResults: '**/target/surefire-reports/TEST-*.xml,**/target/failsafe-reports/TEST-*.xml').failCount > 0) {
+            error 'Some test failures during prep.sh, not going to continue'
+          }
+        }
+        infra.prepareToPublishIncrementals()
+
+        // Archive prep.sh generated files used for all lines after the "prep" stage
+        sh 'tar -czvf "${PREP_ARCHIVE}" ' + stashGlob.replace('REPLACEME_LINE', '*') + (consumeIncrementalsMarkerFile ? ' consume-incrementals' : '')
+        archiveArtifacts artifacts: prepArchive, fingerprint: true
+        sh 'rm -v "${PREP_ARCHIVE}"'
       }
     }
-    infra.prepareToPublishIncrementals()
 
     fullTestMarkerFile = fileExists 'full-test'
     weeklyTestMarkerFile = fileExists 'weekly-test'
@@ -158,7 +177,7 @@ mavenEnv(jdk: 21) {
   }
   stage('stash line(s)') {
     lines.each { line ->
-      stash name: line, includes: "pct.sh,incrementals.sh,consume-incrementals,excludes.txt,bom-*/excludes.txt,target/pct.jar,target/megawar-${line}.war"
+      stash name: line, includes: stashGlob.replace('REPLACEME_LINE', line)
     }
   }
 }
@@ -287,5 +306,9 @@ stage('checks') {
 }
 
 stage('publish incrementals') {
-  infra.maybePublishIncrementals()
+  if (incrementalDoneInPreviousBuild) {
+    echo 'INFO: incrementals have been taken care of in a previous build'
+  } else {
+    infra.maybePublishIncrementals()
+  }
 }


### PR DESCRIPTION
In draft until #7316 which remove unused bom reports `archiveArtifact` step preventing this change to work without complication (dealing with multiple archives) is merged.

Ref:
- #7317

### Testing done

CI

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
