### PR TITLE
fix: exclude stale golden-file assertion for coverage plugin test

### DIFF
--- a/excludes.txt
+++ b/excludes.txt
@@ -14,3 +14,6 @@ org.jenkinsci.plugins.pipeline.modeldefinition.TriggersTest
 
 # TODO https://issues.jenkins.io/browse/JENKINS-71793
 com.cloudbees.workflow.ui.view.WorkflowStageViewActionTest#testTimezoneRespectedInStageStartTime
+
+# TODO coverage plugin chart.json predates echarts-api zeroBasedYAxis (https://github.com/jenkinsci/echarts-api-plugin/issues/465)
+io.jenkins.plugins.coverage.metrics.charts.CoverageSeriesBuilderTest#shouldHaveTwoValuesForTwoBuilds


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Excluded stale golden-file assertion for coverage plugin test `shouldHaveTwoValuesForTwoBuilds`

### Testing done
Ran `LINE=weekly PLUGINS=coverage bash local-test.sh` locally

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
